### PR TITLE
Fix: return user identities in user json obj

### DIFF
--- a/models/user.go
+++ b/models/user.go
@@ -55,7 +55,8 @@ type User struct {
 	AppMetaData  JSONMap `json:"app_metadata" db:"raw_app_meta_data"`
 	UserMetaData JSONMap `json:"user_metadata" db:"raw_user_meta_data"`
 
-	IsSuperAdmin bool `json:"-" db:"is_super_admin"`
+	IsSuperAdmin bool       `json:"-" db:"is_super_admin"`
+	Identities   []Identity `json:"identities" has_many:"identities"`
 
 	CreatedAt time.Time `json:"created_at" db:"created_at"`
 	UpdatedAt time.Time `json:"updated_at" db:"updated_at"`
@@ -330,7 +331,7 @@ func CountOtherUsers(tx *storage.Connection, instanceID, id uuid.UUID) (int, err
 
 func findUser(tx *storage.Connection, query string, args ...interface{}) (*User, error) {
 	obj := &User{}
-	if err := tx.Q().Where(query, args...).First(obj); err != nil {
+	if err := tx.Eager().Q().Where(query, args...).First(obj); err != nil {
 		if errors.Cause(err) == sql.ErrNoRows {
 			return nil, UserNotFoundError{}
 		}


### PR DESCRIPTION
## What kind of change does this PR introduce?
Returns the identities of a user in the user json object
```
{
   "id":"221a76c3-2e71-4c2c-acc6-2861299eb23e",
   "aud":"authenticated",
   "role":"authenticated",
   "email":"test@test.com",
   "email_confirmed_at":"2021-10-26T18:02:37.840634+08:00",
   "phone":"",
   "confirmed_at":"2021-10-26T18:02:37.840634+08:00",
   "last_sign_in_at":"2021-10-26T18:47:13.192456+08:00",
   "app_metadata":{
      "provider":"github",
      "providers":[
         "github"
      ]
   },
   "user_metadata":{
      "avatar_url":"avatar_url",
      "email":"test@test.com",
      "email_verified":true,
      "full_name":"full_name",
      "iss":"https://api.github.com",
      "name":"name",
      "preferred_username":"preferred_username",
      "provider_id":"12345",
      "sub":"12345",
      "user_name":"user_name"
   },
   "identities":[
      {
         "id":"12345",
         "user_id":"221a76c3-2e71-4c2c-acc6-2861299eb23e",
         "identity_data":{
            "avatar_url":"avatar_url",
            "email":"test@test.com",
            "email_verified":true,
            "full_name":"full_name",
            "iss":"https://api.github.com",
            "name":"name",
            "preferred_username":"preferred_username",
            "provider_id":"12345",
            "sub":"12345",
            "user_name":"user_name"
         },
         "provider":"github",
         "last_sign_in_at":"2021-10-26T18:02:37.825225+08:00",
         "created_at":"2021-10-26T18:02:37.825258+08:00",
         "updated_at":"2021-10-26T18:02:37.825262+08:00"
      }
   ],
   "created_at":"2021-10-26T18:02:37.818245+08:00",
   "updated_at":"2021-10-26T18:02:37.81825+08:00"
}
```
