### PR TITLE
feat: add hashed refresh tokens

### DIFF
--- a/crypto/crypto.go
+++ b/crypto/crypto.go
@@ -2,7 +2,9 @@ package crypto
 
 import (
 	"crypto/rand"
+	"crypto/sha256"
 	"encoding/base64"
+	"encoding/hex"
 	"fmt"
 	"io"
 	"math"
@@ -12,13 +14,44 @@ import (
 	"github.com/pkg/errors"
 )
 
+// SecureToken is an object that represents a unique randomly generated string
+// that can be sent to a client and/or stored in a database for lookup only.
+type SecureToken struct {
+	Original string `json:"-"`
+	Hashed   string `json:"-"`
+}
+
 // SecureToken creates a new random token
-func SecureToken() string {
-	b := make([]byte, 16)
-	if _, err := io.ReadFull(rand.Reader, b); err != nil {
+func GenerateSecureToken() SecureToken {
+	bytes := make([]byte, 16)
+	if _, err := io.ReadFull(rand.Reader, bytes); err != nil {
 		panic(err.Error()) // rand should never fail
 	}
-	return base64.RawURLEncoding.EncodeToString(b)
+
+	original := base64.RawURLEncoding.EncodeToString(bytes)
+
+	return SecureToken{
+		Original: original,
+		Hashed:   HashSHA224Base64(original),
+	}
+}
+
+// HashSHA224 hashes the provided string with SHA256/224 and returns it as
+// Base64 URL encoded. SHA256/224 is a good hashing function as it's shorter
+// than SHA256 but also is not succeptible to a length extension attack.
+func HashSHA224Base64(str string) string {
+	bytes := sha256.Sum224([]byte(str))
+
+	return base64.RawURLEncoding.EncodeToString(bytes[:])
+}
+
+// HashSHA224 hashes the provided string with SHA256/224 and returns it as
+// hex encoded. SHA256/224 is a good hashing function as it's shorter
+// than SHA256 but also is not succeptible to a length extension attack.
+func HashSHA224Hex(str string) string {
+	bytes := sha256.Sum224([]byte(str))
+
+	return hex.EncodeToString(bytes[:])
 }
 
 // GenerateOtp generates a random n digit otp

--- a/models/refresh_token_test.go
+++ b/models/refresh_token_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/netlify/gotrue/conf"
+	"github.com/netlify/gotrue/crypto"
 	"github.com/netlify/gotrue/storage"
 	"github.com/netlify/gotrue/storage/test"
 	"github.com/stretchr/testify/require"
@@ -41,6 +42,9 @@ func (ts *RefreshTokenTestSuite) TestGrantAuthenticatedUser() {
 	require.NoError(ts.T(), err)
 
 	require.NotEmpty(ts.T(), r.Token)
+	require.NotEmpty(ts.T(), r.HashedToken)
+	require.NotEqual(ts.T(), r.Token, r.HashedToken)
+	require.Equal(ts.T(), r.HashedToken, "H:"+crypto.HashSHA224Base64(r.Token))
 	require.Equal(ts.T(), u.ID, r.UserID)
 }
 
@@ -48,12 +52,23 @@ func (ts *RefreshTokenTestSuite) TestGrantRefreshTokenSwap() {
 	u := ts.createUser()
 	r, err := GrantAuthenticatedUser(ts.db, u, GrantParams{})
 	require.NoError(ts.T(), err)
+	require.NotEmpty(ts.T(), r.Token)
+	require.NotEmpty(ts.T(), r.HashedToken)
 
 	s, err := GrantRefreshTokenSwap(&http.Request{}, ts.db, u, r)
 	require.NoError(ts.T(), err)
+	require.NotEmpty(ts.T(), s.Token)
+	require.NotEmpty(ts.T(), s.HashedToken)
+	require.NotEqual(ts.T(), s.Token, s.HashedToken)
+	require.Equal(ts.T(), s.Parent, storage.NullString(r.HashedToken))
 
-	_, nr, err := FindUserWithRefreshToken(ts.db, r.Token)
+	_, nr, err := FindUserWithRefreshToken(ts.db, r.Token) // using the original not hashed token
 	require.NoError(ts.T(), err)
+
+	require.Equal(ts.T(), nr.Token, r.Token)
+	require.NotEmpty(ts.T(), nr.HashedToken)
+	require.NotEqual(ts.T(), nr.Token, nr.HashedToken)
+	require.Equal(ts.T(), nr.HashedToken, "H:"+crypto.HashSHA224Base64(r.Token))
 
 	require.Equal(ts.T(), r.ID, nr.ID)
 	require.True(ts.T(), nr.Revoked, "expected old token to be revoked")
@@ -68,7 +83,7 @@ func (ts *RefreshTokenTestSuite) TestLogout() {
 	require.NoError(ts.T(), err)
 
 	require.NoError(ts.T(), Logout(ts.db, u.ID))
-	u, r, err = FindUserWithRefreshToken(ts.db, r.Token)
+	u, r, err = FindUserWithRefreshToken(ts.db, r.Token) // using the original not hashed token
 	require.Errorf(ts.T(), err, "expected error when there are no refresh tokens to authenticate. user: %v token: %v", u, r)
 
 	require.True(ts.T(), IsNotFoundError(err), "expected NotFoundError")

--- a/models/user.go
+++ b/models/user.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/gobuffalo/pop/v5"
 	"github.com/gofrs/uuid"
+	"github.com/netlify/gotrue/crypto"
 	"github.com/netlify/gotrue/storage"
 	"github.com/pkg/errors"
 	"golang.org/x/crypto/bcrypt"
@@ -371,13 +372,25 @@ func FindUserByTokenAndTokenType(tx *storage.Connection, token string, tokenType
 
 // FindUserWithRefreshToken finds a user from the provided refresh token.
 func FindUserWithRefreshToken(tx *storage.Connection, token string) (*User, *RefreshToken, error) {
+	// it may just be that an attacker has stolen a hashed token value from the database
+	// (which is identified by the H: prefix). this attacker would be able to look up the
+	// exact token unless we remove the `H:` prefix.
+	// technically this input value should have been rejected
+	// before arriving in this function, but it is now too late to
+	// reject and is best if the data is sanitized.
+	token = strings.TrimPrefix(token, "H:")
+
+	hashedToken := "H:" + crypto.HashSHA224Base64(token)
+
 	refreshToken := &RefreshToken{}
-	if err := tx.Where("token = ?", token).First(refreshToken); err != nil {
+	if err := tx.Where("token = ? OR token = ?", hashedToken, token).First(refreshToken); err != nil {
 		if errors.Cause(err) == sql.ErrNoRows {
 			return nil, nil, RefreshTokenNotFoundError{}
 		}
 		return nil, nil, errors.Wrap(err, "error finding refresh token")
 	}
+
+	refreshToken.Token = token // database only holds the hashed token, so adding the original here
 
 	user, err := findUser(tx, "id = ?", refreshToken.UserID)
 	if err != nil {


### PR DESCRIPTION
Today refresh tokens are stored _raw_ in the database. Should the database be stolen, leaked or misused by an external or internal party, it would be nearly trivial to issue a valid access token for any user.

This PR stores the refresh tokens (the `token` column in `refresh_tokens`) as a SHA256/224 hash. It is thus impossible to impersonate a user using this value, but it is possible to verify that the user has a valid token.

For backward compatibility purposes, a token lookup occurs using both the hashed and raw value of the token; but all new tokens will be using the hashed and secure form. To prevent hashed tokens being used instead of real tokens, they are stored with a `H:` prefix in the database, and backward-compatible lookups are done only after stripping the same prefix before hashing.

Furthermore, the old behavior with the reuse window of refresh tokens is now cleaned up. A new refresh token is generated if a revoked refresh token is issued within the revocation period. (This only happens if the browser / client has not synced up the refresh tokens they use for requests -- in a multi-tab or concurrent request environment.)