### PR TITLE
feat: Support for OAuth callback proxy.

### DIFF
--- a/api/context.go
+++ b/api/context.go
@@ -22,6 +22,7 @@ const (
 	userKey                 = contextKey("user")
 	sessionKey              = contextKey("session")
 	externalReferrerKey     = contextKey("external_referrer")
+	externalProxyKey        = contextKey("external_proxy")
 	functionHooksKey        = contextKey("function_hooks")
 	adminUserKey            = contextKey("admin_user")
 	oauthTokenKey           = contextKey("oauth_token") // for OAuth1.0, also known as request token
@@ -139,6 +140,19 @@ func withExternalReferrer(ctx context.Context, token string) context.Context {
 
 func getExternalReferrer(ctx context.Context) string {
 	obj := ctx.Value(externalReferrerKey)
+	if obj == nil {
+		return ""
+	}
+
+	return obj.(string)
+}
+
+func withExternalProxy(ctx context.Context, proxy string) context.Context {
+	return context.WithValue(ctx, externalProxyKey, proxy)
+}
+
+func getExternalProxy(ctx context.Context) string {
+	obj := ctx.Value(externalProxyKey)
 	if obj == nil {
 		return ""
 	}

--- a/api/provider/apple.go
+++ b/api/provider/apple.go
@@ -55,12 +55,17 @@ type idTokenClaims struct {
 }
 
 // NewAppleProvider creates a Apple account provider.
-func NewAppleProvider(ext conf.OAuthProviderConfiguration) (OAuthProvider, error) {
+func NewAppleProvider(ext conf.OAuthProviderConfiguration, proxyURL string) (OAuthProvider, error) {
 	if err := ext.Validate(); err != nil {
 		return nil, err
 	}
 
 	authHost := chooseHost(ext.URL, defaultAppleAPIBase)
+	redirectURL := proxyURL
+
+	if redirectURL == "" {
+		redirectURL = ext.RedirectURI
+	}
 
 	return &AppleProvider{
 		Config: &oauth2.Config{
@@ -74,7 +79,7 @@ func NewAppleProvider(ext conf.OAuthProviderConfiguration) (OAuthProvider, error
 				scopeEmail,
 				scopeName,
 			},
-			RedirectURL: ext.RedirectURI,
+			RedirectURL: redirectURL,
 		},
 		UserInfoURL: authHost + idTokenVerificationKeyEndpoint,
 	}, nil

--- a/api/provider/azure.go
+++ b/api/provider/azure.go
@@ -26,7 +26,7 @@ type azureUser struct {
 }
 
 // NewAzureProvider creates a Azure account provider.
-func NewAzureProvider(ext conf.OAuthProviderConfiguration, scopes string) (OAuthProvider, error) {
+func NewAzureProvider(ext conf.OAuthProviderConfiguration, proxyURL string, scopes string) (OAuthProvider, error) {
 	if err := ext.Validate(); err != nil {
 		return nil, err
 	}
@@ -40,6 +40,12 @@ func NewAzureProvider(ext conf.OAuthProviderConfiguration, scopes string) (OAuth
 		oauthScopes = append(oauthScopes, strings.Split(scopes, ",")...)
 	}
 
+	redirectURL := proxyURL
+
+	if redirectURL == "" {
+		redirectURL = ext.RedirectURI
+	}
+
 	return &azureProvider{
 		Config: &oauth2.Config{
 			ClientID:     ext.ClientID,
@@ -48,7 +54,7 @@ func NewAzureProvider(ext conf.OAuthProviderConfiguration, scopes string) (OAuth
 				AuthURL:  authHost + "/oauth2/v2.0/authorize",
 				TokenURL: authHost + "/oauth2/v2.0/token",
 			},
-			RedirectURL: ext.RedirectURI,
+			RedirectURL: redirectURL,
 			Scopes:      oauthScopes,
 		},
 		APIPath: apiPath,

--- a/api/provider/bitbucket.go
+++ b/api/provider/bitbucket.go
@@ -37,13 +37,18 @@ type bitbucketEmails struct {
 }
 
 // NewBitbucketProvider creates a Bitbucket account provider.
-func NewBitbucketProvider(ext conf.OAuthProviderConfiguration) (OAuthProvider, error) {
+func NewBitbucketProvider(ext conf.OAuthProviderConfiguration, proxyURL string) (OAuthProvider, error) {
 	if err := ext.Validate(); err != nil {
 		return nil, err
 	}
 
 	authHost := chooseHost(ext.URL, defaultBitbucketAuthBase)
 	apiPath := chooseHost(ext.URL, defaultBitbucketAPIBase) + "/2.0"
+	redirectURL := proxyURL
+
+	if redirectURL == "" {
+		redirectURL = ext.RedirectURI
+	}
 
 	return &bitbucketProvider{
 		Config: &oauth2.Config{
@@ -53,7 +58,7 @@ func NewBitbucketProvider(ext conf.OAuthProviderConfiguration) (OAuthProvider, e
 				AuthURL:  authHost + "/site/oauth2/authorize",
 				TokenURL: authHost + "/site/oauth2/access_token",
 			},
-			RedirectURL: ext.RedirectURI,
+			RedirectURL: redirectURL,
 			Scopes:      []string{"account", "email"},
 		},
 		APIPath: apiPath,

--- a/api/provider/discord.go
+++ b/api/provider/discord.go
@@ -30,7 +30,7 @@ type discordUser struct {
 }
 
 // NewDiscordProvider creates a Discord account provider.
-func NewDiscordProvider(ext conf.OAuthProviderConfiguration, scopes string) (OAuthProvider, error) {
+func NewDiscordProvider(ext conf.OAuthProviderConfiguration, proxyURL string, scopes string) (OAuthProvider, error) {
 	if err := ext.Validate(); err != nil {
 		return nil, err
 	}
@@ -46,6 +46,12 @@ func NewDiscordProvider(ext conf.OAuthProviderConfiguration, scopes string) (OAu
 		oauthScopes = append(oauthScopes, strings.Split(scopes, ",")...)
 	}
 
+	redirectURL := proxyURL
+
+	if redirectURL == "" {
+		redirectURL = ext.RedirectURI
+	}
+
 	return &discordProvider{
 		Config: &oauth2.Config{
 			ClientID:     ext.ClientID,
@@ -55,7 +61,7 @@ func NewDiscordProvider(ext conf.OAuthProviderConfiguration, scopes string) (OAu
 				TokenURL: apiPath + "/oauth2/token",
 			},
 			Scopes:      oauthScopes,
-			RedirectURL: ext.RedirectURI,
+			RedirectURL: redirectURL,
 		},
 		APIPath: apiPath,
 	}, nil

--- a/api/provider/facebook.go
+++ b/api/provider/facebook.go
@@ -37,7 +37,7 @@ type facebookUser struct {
 }
 
 // NewFacebookProvider creates a Facebook account provider.
-func NewFacebookProvider(ext conf.OAuthProviderConfiguration, scopes string) (OAuthProvider, error) {
+func NewFacebookProvider(ext conf.OAuthProviderConfiguration, proxyURL string, scopes string) (OAuthProvider, error) {
 	if err := ext.Validate(); err != nil {
 		return nil, err
 	}
@@ -54,11 +54,17 @@ func NewFacebookProvider(ext conf.OAuthProviderConfiguration, scopes string) (OA
 		oauthScopes = append(oauthScopes, strings.Split(scopes, ",")...)
 	}
 
+	redirectURL := proxyURL
+
+	if redirectURL == "" {
+		redirectURL = ext.RedirectURI
+	}
+
 	return &facebookProvider{
 		Config: &oauth2.Config{
 			ClientID:     ext.ClientID,
 			ClientSecret: ext.Secret,
-			RedirectURL:  ext.RedirectURI,
+			RedirectURL:  redirectURL,
 			Endpoint: oauth2.Endpoint{
 				AuthURL:  authHost + "/dialog/oauth",
 				TokenURL: tokenHost + "/oauth/access_token",

--- a/api/provider/github.go
+++ b/api/provider/github.go
@@ -37,7 +37,7 @@ type githubUserEmail struct {
 }
 
 // NewGithubProvider creates a Github account provider.
-func NewGithubProvider(ext conf.OAuthProviderConfiguration, scopes string) (OAuthProvider, error) {
+func NewGithubProvider(ext conf.OAuthProviderConfiguration, proxyURL string, scopes string) (OAuthProvider, error) {
 	if err := ext.Validate(); err != nil {
 		return nil, err
 	}
@@ -56,6 +56,12 @@ func NewGithubProvider(ext conf.OAuthProviderConfiguration, scopes string) (OAut
 		oauthScopes = append(oauthScopes, strings.Split(scopes, ",")...)
 	}
 
+	redirectURL := proxyURL
+
+	if redirectURL == "" {
+		redirectURL = ext.RedirectURI
+	}
+
 	return &githubProvider{
 		Config: &oauth2.Config{
 			ClientID:     ext.ClientID,
@@ -64,7 +70,7 @@ func NewGithubProvider(ext conf.OAuthProviderConfiguration, scopes string) (OAut
 				AuthURL:  authHost + "/login/oauth/authorize",
 				TokenURL: authHost + "/login/oauth/access_token",
 			},
-			RedirectURL: ext.RedirectURI,
+			RedirectURL: redirectURL,
 			Scopes:      oauthScopes,
 		},
 		APIHost: apiHost,

--- a/api/provider/gitlab.go
+++ b/api/provider/gitlab.go
@@ -33,7 +33,7 @@ type gitlabUserEmail struct {
 }
 
 // NewGitlabProvider creates a Gitlab account provider.
-func NewGitlabProvider(ext conf.OAuthProviderConfiguration, scopes string) (OAuthProvider, error) {
+func NewGitlabProvider(ext conf.OAuthProviderConfiguration, proxyURL string, scopes string) (OAuthProvider, error) {
 	if err := ext.Validate(); err != nil {
 		return nil, err
 	}
@@ -47,6 +47,12 @@ func NewGitlabProvider(ext conf.OAuthProviderConfiguration, scopes string) (OAut
 	}
 
 	host := chooseHost(ext.URL, defaultGitLabAuthBase)
+	redirectURL := proxyURL
+
+	if redirectURL == "" {
+		redirectURL = ext.RedirectURI
+	}
+
 	return &gitlabProvider{
 		Config: &oauth2.Config{
 			ClientID:     ext.ClientID,
@@ -55,7 +61,7 @@ func NewGitlabProvider(ext conf.OAuthProviderConfiguration, scopes string) (OAut
 				AuthURL:  host + "/oauth/authorize",
 				TokenURL: host + "/oauth/token",
 			},
-			RedirectURL: ext.RedirectURI,
+			RedirectURL: redirectURL,
 			Scopes:      oauthScopes,
 		},
 		Host: host,

--- a/api/provider/google.go
+++ b/api/provider/google.go
@@ -28,7 +28,7 @@ type googleUser struct {
 }
 
 // NewGoogleProvider creates a Google account provider.
-func NewGoogleProvider(ext conf.OAuthProviderConfiguration, scopes string) (OAuthProvider, error) {
+func NewGoogleProvider(ext conf.OAuthProviderConfiguration, proxyURL string, scopes string) (OAuthProvider, error) {
 	if err := ext.Validate(); err != nil {
 		return nil, err
 	}
@@ -45,6 +45,12 @@ func NewGoogleProvider(ext conf.OAuthProviderConfiguration, scopes string) (OAut
 		oauthScopes = append(oauthScopes, strings.Split(scopes, ",")...)
 	}
 
+	redirectURL := proxyURL
+
+	if redirectURL == "" {
+		redirectURL = ext.RedirectURI
+	}
+
 	return &googleProvider{
 		Config: &oauth2.Config{
 			ClientID:     ext.ClientID,
@@ -54,7 +60,7 @@ func NewGoogleProvider(ext conf.OAuthProviderConfiguration, scopes string) (OAut
 				TokenURL: authHost + "/o/oauth2/token",
 			},
 			Scopes:      oauthScopes,
-			RedirectURL: ext.RedirectURI,
+			RedirectURL: redirectURL,
 		},
 		APIPath: apiPath,
 	}, nil

--- a/api/provider/keycloak.go
+++ b/api/provider/keycloak.go
@@ -23,7 +23,7 @@ type keycloakUser struct {
 }
 
 // NewKeycloakProvider creates a Keycloak account provider.
-func NewKeycloakProvider(ext conf.OAuthProviderConfiguration, scopes string) (OAuthProvider, error) {
+func NewKeycloakProvider(ext conf.OAuthProviderConfiguration, proxyURL string, scopes string) (OAuthProvider, error) {
 	if err := ext.Validate(); err != nil {
 		return nil, err
 	}
@@ -46,6 +46,12 @@ func NewKeycloakProvider(ext conf.OAuthProviderConfiguration, scopes string) (OA
 		ext.URL = ext.URL[:extURLlen-1]
 	}
 
+	redirectURL := proxyURL
+
+	if redirectURL == "" {
+		redirectURL = ext.RedirectURI
+	}
+
 	return &keycloakProvider{
 		Config: &oauth2.Config{
 			ClientID:     ext.ClientID,
@@ -54,7 +60,7 @@ func NewKeycloakProvider(ext conf.OAuthProviderConfiguration, scopes string) (OA
 				AuthURL:  ext.URL + "/protocol/openid-connect/auth",
 				TokenURL: ext.URL + "/protocol/openid-connect/token",
 			},
-			RedirectURL: ext.RedirectURI,
+			RedirectURL: redirectURL,
 			Scopes:      oauthScopes,
 		},
 		Host: ext.URL,

--- a/api/provider/linkedin.go
+++ b/api/provider/linkedin.go
@@ -59,7 +59,7 @@ type linkedinElements struct {
 }
 
 // NewLinkedinProvider creates a Linkedin account provider.
-func NewLinkedinProvider(ext conf.OAuthProviderConfiguration, scopes string) (OAuthProvider, error) {
+func NewLinkedinProvider(ext conf.OAuthProviderConfiguration, proxyURL string, scopes string) (OAuthProvider, error) {
 	if err := ext.Validate(); err != nil {
 		return nil, err
 	}
@@ -75,6 +75,12 @@ func NewLinkedinProvider(ext conf.OAuthProviderConfiguration, scopes string) (OA
 		oauthScopes = append(oauthScopes, strings.Split(scopes, ",")...)
 	}
 
+	redirectURL := proxyURL
+
+	if redirectURL == "" {
+		redirectURL = ext.RedirectURI
+	}
+
 	return &linkedinProvider{
 		Config: &oauth2.Config{
 			ClientID:     ext.ClientID,
@@ -84,7 +90,7 @@ func NewLinkedinProvider(ext conf.OAuthProviderConfiguration, scopes string) (OA
 				TokenURL: apiPath + "/oauth/v2/accessToken",
 			},
 			Scopes:      oauthScopes,
-			RedirectURL: ext.RedirectURI,
+			RedirectURL: redirectURL,
 		},
 		APIPath: apiPath,
 	}, nil

--- a/api/provider/notion.go
+++ b/api/provider/notion.go
@@ -38,12 +38,17 @@ type notionUser struct {
 }
 
 // NewNotionProvider creates a Notion account provider.
-func NewNotionProvider(ext conf.OAuthProviderConfiguration) (OAuthProvider, error) {
+func NewNotionProvider(ext conf.OAuthProviderConfiguration, proxyURL string) (OAuthProvider, error) {
 	if err := ext.Validate(); err != nil {
 		return nil, err
 	}
 
 	authHost := chooseHost(ext.URL, defaultNotionApiBase)
+	redirectURL := proxyURL
+
+	if redirectURL == "" {
+		redirectURL = ext.RedirectURI
+	}
 
 	return &notionProvider{
 		Config: &oauth2.Config{
@@ -53,7 +58,7 @@ func NewNotionProvider(ext conf.OAuthProviderConfiguration) (OAuthProvider, erro
 				AuthURL:  authHost + "/v1/oauth/authorize",
 				TokenURL: authHost + "/v1/oauth/token",
 			},
-			RedirectURL: ext.RedirectURI,
+			RedirectURL: redirectURL,
 		},
 		APIPath: authHost,
 	}, nil

--- a/api/provider/slack.go
+++ b/api/provider/slack.go
@@ -25,7 +25,7 @@ type slackUser struct {
 }
 
 // NewSlackProvider creates a Slack account provider.
-func NewSlackProvider(ext conf.OAuthProviderConfiguration, scopes string) (OAuthProvider, error) {
+func NewSlackProvider(ext conf.OAuthProviderConfiguration, proxyURL string, scopes string) (OAuthProvider, error) {
 	if err := ext.Validate(); err != nil {
 		return nil, err
 	}
@@ -43,6 +43,12 @@ func NewSlackProvider(ext conf.OAuthProviderConfiguration, scopes string) (OAuth
 		oauthScopes = append(oauthScopes, strings.Split(scopes, ",")...)
 	}
 
+	redirectURL := proxyURL
+
+	if redirectURL == "" {
+		redirectURL = ext.RedirectURI
+	}
+
 	return &slackProvider{
 		Config: &oauth2.Config{
 			ClientID:     ext.ClientID,
@@ -52,7 +58,7 @@ func NewSlackProvider(ext conf.OAuthProviderConfiguration, scopes string) (OAuth
 				TokenURL: apiPath + "/oauth.access",
 			},
 			Scopes:      oauthScopes,
-			RedirectURL: ext.RedirectURI,
+			RedirectURL: redirectURL,
 		},
 		APIPath: apiPath,
 	}, nil

--- a/api/provider/spotify.go
+++ b/api/provider/spotify.go
@@ -33,7 +33,7 @@ type spotifyUserImage struct {
 }
 
 // NewSpotifyProvider creates a Spotify account provider.
-func NewSpotifyProvider(ext conf.OAuthProviderConfiguration, scopes string) (OAuthProvider, error) {
+func NewSpotifyProvider(ext conf.OAuthProviderConfiguration, proxyURL string, scopes string) (OAuthProvider, error) {
 	if err := ext.Validate(); err != nil {
 		return nil, err
 	}
@@ -49,6 +49,12 @@ func NewSpotifyProvider(ext conf.OAuthProviderConfiguration, scopes string) (OAu
 		oauthScopes = append(oauthScopes, strings.Split(scopes, ",")...)
 	}
 
+	redirectURL := proxyURL
+
+	if redirectURL == "" {
+		redirectURL = ext.RedirectURI
+	}
+
 	return &spotifyProvider{
 		Config: &oauth2.Config{
 			ClientID:     ext.ClientID,
@@ -58,7 +64,7 @@ func NewSpotifyProvider(ext conf.OAuthProviderConfiguration, scopes string) (OAu
 				TokenURL: authPath + "/api/token",
 			},
 			Scopes:      oauthScopes,
-			RedirectURL: ext.RedirectURI,
+			RedirectURL: redirectURL,
 		},
 		APIPath: apiPath,
 	}, nil

--- a/api/provider/twitch.go
+++ b/api/provider/twitch.go
@@ -43,7 +43,7 @@ type twitchUsers struct {
 }
 
 // NewTwitchProvider creates a Twitch account provider.
-func NewTwitchProvider(ext conf.OAuthProviderConfiguration, scopes string) (OAuthProvider, error) {
+func NewTwitchProvider(ext conf.OAuthProviderConfiguration, proxyURL string, scopes string) (OAuthProvider, error) {
 	if err := ext.Validate(); err != nil {
 		return nil, err
 	}
@@ -59,6 +59,12 @@ func NewTwitchProvider(ext conf.OAuthProviderConfiguration, scopes string) (OAut
 		oauthScopes = append(oauthScopes, strings.Split(scopes, ",")...)
 	}
 
+	redirectURL := proxyURL
+
+	if redirectURL == "" {
+		redirectURL = ext.RedirectURI
+	}
+
 	return &twitchProvider{
 		Config: &oauth2.Config{
 			ClientID:     ext.ClientID,
@@ -67,7 +73,7 @@ func NewTwitchProvider(ext conf.OAuthProviderConfiguration, scopes string) (OAut
 				AuthURL:  authHost + "/oauth2/authorize",
 				TokenURL: authHost + "/oauth2/token",
 			},
-			RedirectURL: ext.RedirectURI,
+			RedirectURL: redirectURL,
 			Scopes:      oauthScopes,
 		},
 		APIHost: apiHost,

--- a/api/provider/twitter.go
+++ b/api/provider/twitter.go
@@ -44,15 +44,21 @@ type twitterUser struct {
 }
 
 // NewTwitterProvider creates a Twitter account provider.
-func NewTwitterProvider(ext conf.OAuthProviderConfiguration, scopes string) (OAuthProvider, error) {
+func NewTwitterProvider(ext conf.OAuthProviderConfiguration, proxyURL string, scopes string) (OAuthProvider, error) {
 	if err := ext.Validate(); err != nil {
 		return nil, err
 	}
 	authHost := chooseHost(ext.URL, defaultTwitterAPIBase)
+	redirectURL := proxyURL
+
+	if redirectURL == "" {
+		redirectURL = ext.RedirectURI
+	}
+
 	p := &TwitterProvider{
 		ClientKey:   ext.ClientID,
 		Secret:      ext.Secret,
-		CallbackURL: ext.RedirectURI,
+		CallbackURL: redirectURL,
 		UserInfoURL: authHost + endpointProfile,
 	}
 	p.Consumer = newConsumer(p, authHost)

--- a/api/provider/workos.go
+++ b/api/provider/workos.go
@@ -36,7 +36,7 @@ type workosUser struct {
 }
 
 // NewWorkOSProvider creates a WorkOS account provider.
-func NewWorkOSProvider(ext conf.OAuthProviderConfiguration, query *url.Values) (OAuthProvider, error) {
+func NewWorkOSProvider(ext conf.OAuthProviderConfiguration, proxyURL string, query *url.Values) (OAuthProvider, error) {
 	if err := ext.Validate(); err != nil {
 		return nil, err
 	}
@@ -59,6 +59,12 @@ func NewWorkOSProvider(ext conf.OAuthProviderConfiguration, query *url.Values) (
 		}
 	}
 
+	redirectURL := proxyURL
+
+	if redirectURL == "" {
+		redirectURL = ext.RedirectURI
+	}
+
 	return &workosProvider{
 		Config: &oauth2.Config{
 			ClientID:     ext.ClientID,
@@ -67,7 +73,7 @@ func NewWorkOSProvider(ext conf.OAuthProviderConfiguration, query *url.Values) (
 				AuthURL:  apiPath + "/sso/authorize",
 				TokenURL: apiPath + "/sso/token",
 			},
-			RedirectURL: ext.RedirectURI,
+			RedirectURL: redirectURL,
 		},
 		APIPath:         apiPath,
 		AuthCodeOptions: authCodeOptions,

--- a/api/provider/zoom.go
+++ b/api/provider/zoom.go
@@ -30,13 +30,18 @@ type zoomUser struct {
 }
 
 // NewZoomProvider creates a Zoom account provider.
-func NewZoomProvider(ext conf.OAuthProviderConfiguration) (OAuthProvider, error) {
+func NewZoomProvider(ext conf.OAuthProviderConfiguration, proxyURL string) (OAuthProvider, error) {
 	if err := ext.Validate(); err != nil {
 		return nil, err
 	}
 
 	apiPath := chooseHost(ext.URL, defaultZoomAPIBase) + "/v2"
 	authPath := chooseHost(ext.URL, defaultZoomAuthBase) + "/oauth"
+	redirectURL := proxyURL
+
+	if redirectURL == "" {
+		redirectURL = ext.RedirectURI
+	}
 
 	return &zoomProvider{
 		Config: &oauth2.Config{
@@ -46,7 +51,7 @@ func NewZoomProvider(ext conf.OAuthProviderConfiguration) (OAuthProvider, error)
 				AuthURL:  authPath + "/authorize",
 				TokenURL: authPath + "/token",
 			},
-			RedirectURL: ext.RedirectURI,
+			RedirectURL: redirectURL,
 		},
 		APIPath: apiPath,
 	}, nil


### PR DESCRIPTION
## What kind of change does this PR introduce?

This addresses a major pain point for hosted Supabase consumers whereby Google et al. OAuth consent screens indicate you're logging into `<gibberish>.supabase.co`, rather than your app.

GoTrue clients may now optionally supply a "proxy" param that is provided to external providers as the callback, rather than the `GOTRUE_EXTERNAL_<PROVIDER>_REDIRECT_URI` (which is not configurable unless you're self hosting). 

The proxy end-point is something Supabase consumers implement and lives at their app's domain, and simply redirects back to GoTrue (or rather Kong). It'd make sense to implement this end-point in https://github.com/supabase/auth-helpers so any consumers of those libraries obtain this functionality for free.

## What is the current behavior?

Addresses the auth component of https://github.com/supabase/supabase/issues/12429

![image](https://user-images.githubusercontent.com/482276/193637818-2a625142-2f35-4c83-b862-aeda0ba34ab1.png)

## What is the new behavior?

![image](https://user-images.githubusercontent.com/482276/193637796-2ff78961-41d3-4340-a1fd-dc268edf66d6.png)

For this to work we do two (related) things.

1. We accept a `proxy` query param at `/authorize`. We give this to providers as the callback URL, instead of `<id>.supabase.co/auth/v1/callback`.
2. We store `proxy` in our `state` JWT. This is done so that when GoTrue's `/callback` is called (post proxy redirect) we're able to retrieve this URL and include it as the `redirect_uri` when exchanging the auth code.

## Additional context

JS PR: https://github.com/supabase/gotrue-js/pull/466

Closes supabase/supabase#142 
