### PR TITLE
fix: remove duplicated index on refresh_tokens table

### DIFF
--- a/migrations/20230411005111_remove_duplicate_idx.up.sql
+++ b/migrations/20230411005111_remove_duplicate_idx.up.sql
@@ -1,0 +1,1 @@
+drop index {{index .Options "Namespace" }}.refresh_tokens_token_idx;


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Remove `auth.refresh_tokens_token_idx` because we already have a unique index `auth.refresh_tokens_token_unique` on the `auth.refresh_tokens` table