### PR TITLE
feat: use `otherMails` with Azure

### DIFF
--- a/internal/api/provider/azure.go
+++ b/internal/api/provider/azure.go
@@ -22,9 +22,10 @@ type azureProvider struct {
 }
 
 type azureUser struct {
-	Name  string `json:"name"`
-	Email string `json:"email"`
-	Sub   string `json:"sub"`
+	Name       string   `json:"name"`
+	Email      string   `json:"email"`
+	Sub        string   `json:"sub"`
+	OtherMails []string `json:"otherMails"`
 }
 
 // NewAzureProvider creates a Azure account provider.
@@ -67,26 +68,44 @@ func (g azureProvider) GetUserData(ctx context.Context, tok *oauth2.Token) (*Use
 		return nil, err
 	}
 
-	if u.Email == "" {
+	var data UserProvidedData
+
+	data.Metadata = &Claims{
+		Issuer:  g.APIPath,
+		Subject: u.Sub,
+		Name:    u.Name,
+
+		// To be deprecated
+		FullName:   u.Name,
+		ProviderId: u.Sub,
+	}
+
+	if u.Email != "" {
+		data.Emails = append(data.Emails, Email{
+			Email:    u.Email,
+			Verified: true,
+		})
+	}
+
+	if u.OtherMails != nil {
+		for _, mail := range u.OtherMails {
+			if mail != "" {
+				data.Emails = append(data.Emails, Email{
+					Email:    mail,
+					Verified: false,
+				})
+			}
+		}
+	}
+
+	if len(data.Emails) == 0 {
 		return nil, errors.New("unable to find email with Azure provider")
 	}
 
-	return &UserProvidedData{
-		Metadata: &Claims{
-			Issuer:        g.APIPath,
-			Subject:       u.Sub,
-			Name:          u.Name,
-			Email:         u.Email,
-			EmailVerified: true,
+	data.Emails[0].Primary = true
 
-			// To be deprecated
-			FullName:   u.Name,
-			ProviderId: u.Sub,
-		},
-		Emails: []Email{{
-			Email:    u.Email,
-			Verified: true,
-			Primary:  true,
-		}},
-	}, nil
+	data.Metadata.Email = data.Emails[0].Email
+	data.Metadata.EmailVerified = data.Emails[0].Verified
+
+	return &data, nil
 }


### PR DESCRIPTION
It appears that some Azure accounts may not have an `email` claim but do have [`otherMails`](https://learn.microsoft.com/en-us/azure/active-directory-b2c/user-profile-attributes). GoTrue will also extract those emails and use the first one of those as the primary if no email is defined.