### PR TITLE
feat: make the email client explicity set the format to be HTML

### DIFF
--- a/internal/mailer/mailer.go
+++ b/internal/mailer/mailer.go
@@ -28,8 +28,13 @@ type Mailer interface {
 // NewMailer returns a new gotrue mailer
 func NewMailer(globalConfig *conf.GlobalConfiguration) Mailer {
 	mail := gomail.NewMessage()
-
-	// so that messages are not grouped under each other
+	
+	mail.SetHeaders(map[string][]string{
+		// Make the emails explicitly set to be HTML formatted (to cover older email clients)
+        	"Content-Type": {"text/html; charset=utf-8"},
+		// so that messages are not grouped under each other
+        	"Message-ID":   {fmt.Sprintf("<%s@gotrue-mailer>", uuid.Must(uuid.NewV4()).String())},
+    	})
 	mail.SetHeader("Message-ID", fmt.Sprintf("<%s@gotrue-mailer>", uuid.Must(uuid.NewV4()).String()))
 
 	from := mail.FormatAddress(globalConfig.SMTP.AdminEmail, globalConfig.SMTP.SenderName)

--- a/internal/mailer/mailer.go
+++ b/internal/mailer/mailer.go
@@ -35,7 +35,6 @@ func NewMailer(globalConfig *conf.GlobalConfiguration) Mailer {
 		// so that messages are not grouped under each other
 		"Message-ID": {fmt.Sprintf("<%s@gotrue-mailer>", uuid.Must(uuid.NewV4()).String())},
 	})
-	mail.SetHeader("Message-ID", fmt.Sprintf("<%s@gotrue-mailer>", uuid.Must(uuid.NewV4()).String()))
 
 	from := mail.FormatAddress(globalConfig.SMTP.AdminEmail, globalConfig.SMTP.SenderName)
 

--- a/internal/mailer/mailer.go
+++ b/internal/mailer/mailer.go
@@ -28,13 +28,13 @@ type Mailer interface {
 // NewMailer returns a new gotrue mailer
 func NewMailer(globalConfig *conf.GlobalConfiguration) Mailer {
 	mail := gomail.NewMessage()
-	
+
 	mail.SetHeaders(map[string][]string{
 		// Make the emails explicitly set to be HTML formatted (to cover older email clients)
-        	"Content-Type": {"text/html; charset=utf-8"},
+		"Content-Type": {"text/html; charset=utf-8"},
 		// so that messages are not grouped under each other
-        	"Message-ID":   {fmt.Sprintf("<%s@gotrue-mailer>", uuid.Must(uuid.NewV4()).String())},
-    	})
+		"Message-ID": {fmt.Sprintf("<%s@gotrue-mailer>", uuid.Must(uuid.NewV4()).String())},
+	})
 	mail.SetHeader("Message-ID", fmt.Sprintf("<%s@gotrue-mailer>", uuid.Must(uuid.NewV4()).String()))
 
 	from := mail.FormatAddress(globalConfig.SMTP.AdminEmail, globalConfig.SMTP.SenderName)


### PR DESCRIPTION
## What kind of change does this PR introduce?
This makes the emails to be explicitly set to be HTML formatted instead of plain text which helper older clients that cannot figure this out themselves. 

## What is the current behavior?

Email messages are sent as plain/text. 

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
