### PR TITLE
docs: add comparison of test functions and oauth provider table to contributing.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -535,6 +535,28 @@ An end-to-end test includes:
 
 Since implementing an additional OAuth provider consists of making api calls to an external api, we set up a mock server to attempt to mock the responses expected from the OAuth provider.
 
+|Function/Provider|Apple|Azure|Bitbucket|Discord|Facebook|Figma|Fly|Github|Gitlab|Google|Kakao|Keycloak|Linkedin|Notion|Twitch|Twitter|WorkOS|Zoom
+|---|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
+|TestSignupExternal*|O|O|O|O|O|O|O|O|O|O|O|O|O|O|O|O||O
+|TestSignupExternal*WithConnection|||||||||||||||||O|
+|TestSignupExternal*WithOrganization|||||||||||||||||O|
+|TestSignupExternal*WithProvider|||||||||||||||||O|
+|TestSignupExternal*WithoutURLSetup||||||||||||O||||||
+|TestSignupExternal*(_)AuthorizationCode||O|O|O|O|O|O|O|O|O|O|O|O|O|O||O|O
+|TestSignupExternal*_PKCE||||||O|O|O||||||||||
+|TestSignupExternal*DisableSignupErrorWhenNoUser||O|O|O|O|O|O|O|O|O|O|O|O|O|O||O|O
+|TestSignupExternal*DisableSignupErrorWhen(Empty\|No)Email||O|O|O|O|O|O|O|O|O|O|O||O|O||O|O
+|TestSignupExternal*DisableSignupSuccessWithPrimaryEmail||O|O|O|O|O|O|O|O|O|O|O|O|O|O||O|O
+|TestSignupExternal*DisableSignupSuccessWithSecondaryEmail|||O||||||O|||||||||
+|TestSignupExternal*DisableSignupSuccessWithNonPrimaryEmail||||||||O||||||||||
+|TestInviteTokenExternal*SuccessWhenMatchingToken||O|O|O|O|O||O|O|O|O|O|O|O|O||O|O
+|TestInviteTokenExternal*ErrorWhenNoMatchingToken||O|O|O|O|O||O|O|O|O|O|O|O|O||O|O
+|TestInviteTokenExternal*ErrorWhenWrongToken||O|O|O|O|O||O|O|O|O|O|O|O|O||O|O
+|TestInviteTokenExternal*ErrorWhenEmailDoesntMatch||O|O|O|O|O||O|O|O|O|O|O|O|O||O|O
+|TestSignupExternal*ErrorWhenUserBanned||||||O|O|O|||O|||||||
+|TestSignupExternal*ErrorWhenVerifiedFalse||||||||O|||O|||||||
+|TestSignupExternal*_MissingProfilePic|||||||||||||O|||||
+
 ## License
 
 By contributing to GoTrue, you agree that your contributions will be licensed


### PR DESCRIPTION
## What kind of change does this PR introduce?

Docs update

## What is the new behavior?

The comparison table is added to contributing.md

![image](https://github.com/supabase/gotrue/assets/51817199/5cb427a0-5ae1-4df2-82b6-e69cf9851c85)

## Additional context

There is a function (DisableSignupErrorWhen(Empty\|No)Email) in the mix that tests for no(or empty) email.
It would be nice to have a choice between Empty and No.
