### PR TITLE
feat: add auth code flow

### DIFF
--- a/internal/api/external.go
+++ b/internal/api/external.go
@@ -76,7 +76,8 @@ func (a *API) GetExternalProviderRedirectURL(w http.ResponseWriter, r *http.Requ
 	if err := validatePKCEParams(codeChallengeMethod, codeChallenge); err != nil {
 		return "", err
 	}
-	flowType := getFlowFromChallenge(codeChallenge)
+	// TODO: Adjust this, currently default to PKCE
+	flowType := getFlow(codeChallenge, "")
 
 	flowStateID := ""
 	if isPKCEFlow(flowType) {

--- a/internal/api/external.go
+++ b/internal/api/external.go
@@ -80,7 +80,7 @@ func (a *API) GetExternalProviderRedirectURL(w http.ResponseWriter, r *http.Requ
 	flowType := getFlow(codeChallenge, "")
 
 	flowStateID := ""
-	if isPKCEFlow(flowType) {
+	if isCodeFlow(flowType) {
 		flowState, err := generateFlowState(a.db, providerType, models.OAuth, codeChallengeMethod, codeChallenge, nil)
 		if err != nil {
 			return "", err
@@ -243,7 +243,7 @@ func (a *API) internalExternalProviderCallback(w http.ResponseWriter, r *http.Re
 	if flowState != nil {
 		// This means that the callback is using PKCE
 		// Set the flowState.AuthCode to the query param here
-		rurl, err = a.prepPKCERedirectURL(rurl, flowState.AuthCode)
+		rurl, err = a.prepCodeRedirectURL(rurl, flowState.AuthCode)
 		if err != nil {
 			return err
 		}

--- a/internal/api/external.go
+++ b/internal/api/external.go
@@ -53,6 +53,7 @@ func (a *API) GetExternalProviderRedirectURL(w http.ResponseWriter, r *http.Requ
 	scopes := query.Get("scopes")
 	codeChallenge := query.Get("code_challenge")
 	codeChallengeMethod := query.Get("code_challenge_method")
+	responseType := query.Get("response_type")
 
 	p, err := a.Provider(ctx, providerType, scopes)
 	if err != nil {
@@ -73,7 +74,7 @@ func (a *API) GetExternalProviderRedirectURL(w http.ResponseWriter, r *http.Requ
 	redirectURL := utilities.GetReferrer(r, config)
 	log := observability.GetLogEntry(r)
 	log.WithField("provider", providerType).Info("Redirecting to external provider")
-	if err := validatePKCEParams(codeChallengeMethod, codeChallenge); err != nil {
+	if err := validateCodeFlowParams(codeChallengeMethod, codeChallenge, responseType); err != nil {
 		return "", err
 	}
 	// TODO: Adjust this, currently default to PKCE
@@ -118,6 +119,7 @@ func (a *API) GetExternalProviderRedirectURL(w http.ResponseWriter, r *http.Requ
 	query.Del("provider")
 	query.Del("code_challenge")
 	query.Del("code_challenge_method")
+	query.Del("response_type")
 	for key := range query {
 		if key == "workos_provider" {
 			// See https://workos.com/docs/reference/sso/authorize/get

--- a/internal/api/external.go
+++ b/internal/api/external.go
@@ -81,7 +81,7 @@ func (a *API) GetExternalProviderRedirectURL(w http.ResponseWriter, r *http.Requ
 
 	flowStateID := ""
 	if isCodeFlow(flowType) {
-		flowState, err := generateFlowState(a.db, providerType, models.OAuth, codeChallengeMethod, codeChallenge, nil)
+		flowState, err := generateFlowState(a.db, providerType, models.OAuth, codeChallengeMethod, codeChallenge, nil, flowType)
 		if err != nil {
 			return "", err
 		}

--- a/internal/api/external.go
+++ b/internal/api/external.go
@@ -78,7 +78,7 @@ func (a *API) GetExternalProviderRedirectURL(w http.ResponseWriter, r *http.Requ
 		return "", err
 	}
 	// TODO: Adjust this, currently default to PKCE
-	flowType := getFlow(codeChallenge, "")
+	flowType := getFlow(codeChallenge, responseType)
 
 	flowStateID := ""
 	if isCodeFlow(flowType) {

--- a/internal/api/helpers.go
+++ b/internal/api/helpers.go
@@ -84,6 +84,7 @@ type RequestParams interface {
 		IdTokenGrantParams |
 		InviteParams |
 		OtpParams |
+		AuthCodeGrantParams |
 		PKCEGrantParams |
 		PasswordGrantParams |
 		RecoverParams |

--- a/internal/api/helpers_test.go
+++ b/internal/api/helpers_test.go
@@ -41,33 +41,38 @@ func TestIsValidPKCEParmas(t *testing.T) {
 	cases := []struct {
 		challengeMethod string
 		challenge       string
+		responseType    string
 		expected        error
 	}{
 		{
 			challengeMethod: "",
 			challenge:       "",
+			responseType:    "code",
 			expected:        nil,
 		},
 		{
 			challengeMethod: "test",
 			challenge:       "testtesttesttesttesttesttesttesttesttesttesttesttesttesttesttest",
+			responseType:    "code",
 			expected:        nil,
 		},
 		{
 			challengeMethod: "test",
 			challenge:       "",
+			responseType:    "code",
 			expected:        badRequestError(InvalidPKCEParamsErrorMessage),
 		},
 		{
 			challengeMethod: "",
 			challenge:       "test",
+			responseType:    "code",
 			expected:        badRequestError(InvalidPKCEParamsErrorMessage),
 		},
 	}
 
 	for i, c := range cases {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
-			err := validatePKCEParams(c.challengeMethod, c.challenge)
+			err := validateCodeFlowParams(c.challengeMethod, c.challenge, c.responseType)
 			require.Equal(t, c.expected, err)
 		})
 	}

--- a/internal/api/magic_link.go
+++ b/internal/api/magic_link.go
@@ -32,7 +32,7 @@ func (p *MagicLinkParams) Validate() error {
 	if err != nil {
 		return err
 	}
-	if err := validatePKCEParams(p.CodeChallengeMethod, p.CodeChallenge); err != nil {
+	if err := validateCodeFlowParams(p.CodeChallengeMethod, p.CodeChallenge, p.ResponseType); err != nil {
 		return err
 	}
 	return nil

--- a/internal/api/magic_link.go
+++ b/internal/api/magic_link.go
@@ -130,7 +130,7 @@ func (a *API) MagicLink(w http.ResponseWriter, r *http.Request) error {
 	}
 
 	if isCodeFlow(flowType) {
-		if _, err = generateFlowState(a.db, models.MagicLink.String(), models.MagicLink, params.CodeChallengeMethod, params.CodeChallenge, &user.ID); err != nil {
+		if _, err = generateFlowState(a.db, models.MagicLink.String(), models.MagicLink, params.CodeChallengeMethod, params.CodeChallenge, &user.ID, flowType); err != nil {
 			return err
 		}
 	}

--- a/internal/api/magic_link.go
+++ b/internal/api/magic_link.go
@@ -20,6 +20,7 @@ type MagicLinkParams struct {
 	Data                map[string]interface{} `json:"data"`
 	CodeChallengeMethod string                 `json:"code_challenge_method"`
 	CodeChallenge       string                 `json:"code_challenge"`
+	ResponseType        string                 `json:"response_type"`
 }
 
 func (p *MagicLinkParams) Validate() error {
@@ -62,7 +63,7 @@ func (a *API) MagicLink(w http.ResponseWriter, r *http.Request) error {
 		params.Data = make(map[string]interface{})
 	}
 
-	flowType := getFlowFromChallenge(params.CodeChallenge)
+	flowType := getFlow(params.CodeChallenge, params.ResponseType)
 
 	var isNewUser bool
 	aud := a.requestAud(ctx, r)
@@ -91,6 +92,7 @@ func (a *API) MagicLink(w http.ResponseWriter, r *http.Request) error {
 			Data:                params.Data,
 			CodeChallengeMethod: params.CodeChallengeMethod,
 			CodeChallenge:       params.CodeChallenge,
+			ResponseType:        params.ResponseType,
 		}
 		newBodyContent, err := json.Marshal(signUpParams)
 		if err != nil {
@@ -110,6 +112,7 @@ func (a *API) MagicLink(w http.ResponseWriter, r *http.Request) error {
 				Data:                params.Data,
 				CodeChallengeMethod: params.CodeChallengeMethod,
 				CodeChallenge:       params.CodeChallenge,
+				ResponseType:        params.ResponseType,
 			}
 			metadata, err := json.Marshal(newBodyContent)
 			if err != nil {

--- a/internal/api/magic_link.go
+++ b/internal/api/magic_link.go
@@ -129,7 +129,7 @@ func (a *API) MagicLink(w http.ResponseWriter, r *http.Request) error {
 		return sendJSON(w, http.StatusOK, make(map[string]string))
 	}
 
-	if isPKCEFlow(flowType) {
+	if isCodeFlow(flowType) {
 		if _, err = generateFlowState(a.db, models.MagicLink.String(), models.MagicLink, params.CodeChallengeMethod, params.CodeChallenge, &user.ID); err != nil {
 			return err
 		}

--- a/internal/api/otp.go
+++ b/internal/api/otp.go
@@ -21,6 +21,7 @@ type OtpParams struct {
 	Channel             string                 `json:"channel"`
 	CodeChallengeMethod string                 `json:"code_challenge_method"`
 	CodeChallenge       string                 `json:"code_challenge"`
+	ResponseType        string                 `json:"response_type"`
 }
 
 // SmsParams contains the request body params for sms otp
@@ -30,6 +31,7 @@ type SmsParams struct {
 	Data                map[string]interface{} `json:"data"`
 	CodeChallengeMethod string                 `json:"code_challenge_method"`
 	CodeChallenge       string                 `json:"code_challenge"`
+	ResponseType        string                 `json:"response_type"`
 }
 
 func (p *OtpParams) Validate() error {
@@ -39,7 +41,7 @@ func (p *OtpParams) Validate() error {
 	if p.Email != "" && p.Channel != "" {
 		return badRequestError("Channel should only be specified with Phone OTP")
 	}
-	if err := validatePKCEParams(p.CodeChallengeMethod, p.CodeChallenge); err != nil {
+	if err := validateCodeFlowParams(p.CodeChallengeMethod, p.CodeChallenge, p.ResponseType); err != nil {
 		return err
 	}
 	return nil

--- a/internal/api/otp_test.go
+++ b/internal/api/otp_test.go
@@ -58,6 +58,7 @@ func (ts *OtpTestSuite) TestOtpPKCE() {
 				CreateUser:          true,
 				CodeChallengeMethod: "s256",
 				CodeChallenge:       testCodeChallenge,
+				ResponseType:        "code",
 			},
 			expected: struct {
 				code     int
@@ -110,6 +111,7 @@ func (ts *OtpTestSuite) TestOtpPKCE() {
 				CreateUser:          true,
 				CodeChallengeMethod: "s256",
 				CodeChallenge:       testCodeChallenge,
+				ResponseType:        "code",
 			},
 			expected: struct {
 				code     int

--- a/internal/api/pkce.go
+++ b/internal/api/pkce.go
@@ -10,6 +10,7 @@ import (
 
 const (
 	PKCEPrefix                    = "pkce_"
+	AuthCodePrefix = "code_"
 	MinCodeChallengeLength        = 43
 	MaxCodeChallengeLength        = 128
 	InvalidPKCEParamsErrorMessage = "PKCE flow requires code_challenge_method and code_challenge"
@@ -49,7 +50,7 @@ func issueAuthCode(tx *storage.Connection, user *models.User, authenticationMeth
 }
 
 func isCodeFlow(flowType models.FlowType) bool {
-	return flowType == models.PKCEFlow || flowType == models.AuthCode
+	return flowType == models.PKCEFlow || flowType == models.AuthCodeFlow
 }
 
 func isImplicitFlow(flowType models.FlowType) bool {
@@ -90,7 +91,7 @@ func getFlow(codeChallenge string, responseType string) models.FlowType {
 	if codeChallenge != "" {
 		return models.PKCEFlow
 	} else if responseType == "code" {
-		return models.AuthCode
+		return models.AuthCodeFlow
 	} else {
 		return models.ImplicitFlow
 	}
@@ -105,7 +106,7 @@ func generateFlowState(tx *storage.Connection, providerType string, authenticati
 			return nil, err
 		}
 		flowState = models.NewPKCEFlowState(providerType, codeChallenge, codeChallengeMethod, authenticationMethod, userID)
-	} else if flowType == models.AuthCode {
+	} else if flowType == models.AuthCodeFlow {
 		flowState = models.NewAuthCodeFlowState(providerType, authenticationMethod, userID)
 	}
 	if err := tx.Create(flowState); err != nil {

--- a/internal/api/pkce.go
+++ b/internal/api/pkce.go
@@ -82,15 +82,21 @@ func getFlow(codeChallenge string, responseType string) models.FlowType {
 }
 
 // Should only be used with Auth Code of PKCE Flows
-func generateFlowState(tx *storage.Connection, providerType string, authenticationMethod models.AuthenticationMethod, codeChallengeMethodParam string, codeChallenge string, userID *uuid.UUID) (*models.FlowState, error) {
+func generateFlowState(tx *storage.Connection, providerType string, authenticationMethod models.AuthenticationMethod, codeChallengeMethodParam string, codeChallenge string, userID *uuid.UUID, flowType models.FlowType) (*models.FlowState, error) {
 	codeChallengeMethod, err := models.ParseCodeChallengeMethod(codeChallengeMethodParam)
 	if err != nil {
 		return nil, err
 	}
-	flowState := models.NewFlowState(providerType, codeChallenge, codeChallengeMethod, authenticationMethod, userID)
+	var flowState *models.FlowState
+	if flowType == models.PKCEFlow {
+		flowState = models.NewPKCEFlowState(providerType, codeChallenge, codeChallengeMethod, authenticationMethod, userID)
+	} else if flowType == models.AuthCode {
+		flowState = models.NewAuthCodeFlowState(providerType, authenticationMethod, userID)
+	}
 	if err := tx.Create(flowState); err != nil {
 		return nil, err
 	}
+
 	return flowState, nil
 
 }

--- a/internal/api/pkce.go
+++ b/internal/api/pkce.go
@@ -30,7 +30,7 @@ func isValidCodeChallenge(codeChallenge string) (bool, error) {
 }
 
 func addFlowPrefixToToken(token string, flowType models.FlowType) string {
-	if isPKCEFlow(flowType) {
+	if isCodeFlow(flowType) {
 		return flowType.String() + "_" + token
 	} else if isImplicitFlow(flowType) {
 		return token
@@ -48,8 +48,8 @@ func issueAuthCode(tx *storage.Connection, user *models.User, authenticationMeth
 	return flowState.AuthCode, nil
 }
 
-func isPKCEFlow(flowType models.FlowType) bool {
-	return flowType == models.PKCEFlow
+func isCodeFlow(flowType models.FlowType) bool {
+	return flowType == models.PKCEFlow || flowType == models.AuthCode
 }
 
 func isImplicitFlow(flowType models.FlowType) bool {

--- a/internal/api/pkce.go
+++ b/internal/api/pkce.go
@@ -71,9 +71,11 @@ func validatePKCEParams(codeChallengeMethod, codeChallenge string) error {
 	return nil
 }
 
-func getFlowFromChallenge(codeChallenge string) models.FlowType {
+func getFlow(codeChallenge string, responseType string) models.FlowType {
 	if codeChallenge != "" {
 		return models.PKCEFlow
+	} else if responseType == "code" {
+		return models.AuthCode
 	} else {
 		return models.ImplicitFlow
 	}

--- a/internal/api/recover.go
+++ b/internal/api/recover.go
@@ -57,7 +57,7 @@ func (a *API) Recover(w http.ResponseWriter, r *http.Request) error {
 		}
 		return internalServerError("Unable to process request").WithInternalError(err)
 	}
-	if isPKCEFlow(flowType) {
+	if isCodeFlow(flowType) {
 		if _, err := generateFlowState(a.db, models.Recovery.String(), models.Recovery, params.CodeChallengeMethod, params.CodeChallenge, &(user.ID)); err != nil {
 			return err
 		}

--- a/internal/api/recover.go
+++ b/internal/api/recover.go
@@ -25,7 +25,7 @@ func (p *RecoverParams) Validate() error {
 	if p.Email, err = validateEmail(p.Email); err != nil {
 		return err
 	}
-	if err := validatePKCEParams(p.CodeChallengeMethod, p.CodeChallenge); err != nil {
+	if err := validateCodeFlowParams(p.CodeChallengeMethod, p.CodeChallenge, p.ResponseType); err != nil {
 		return err
 	}
 	return nil

--- a/internal/api/recover.go
+++ b/internal/api/recover.go
@@ -14,6 +14,7 @@ type RecoverParams struct {
 	Email               string `json:"email"`
 	CodeChallenge       string `json:"code_challenge"`
 	CodeChallengeMethod string `json:"code_challenge_method"`
+	ResponseType        string `json:"response_type"`
 }
 
 func (p *RecoverParams) Validate() error {
@@ -40,7 +41,7 @@ func (a *API) Recover(w http.ResponseWriter, r *http.Request) error {
 		return err
 	}
 
-	flowType := getFlowFromChallenge(params.CodeChallenge)
+	flowType := getFlow(params.CodeChallenge, params.ResponseType)
 	if err := params.Validate(); err != nil {
 		return err
 	}
@@ -57,7 +58,7 @@ func (a *API) Recover(w http.ResponseWriter, r *http.Request) error {
 		return internalServerError("Unable to process request").WithInternalError(err)
 	}
 	if isPKCEFlow(flowType) {
-		if _, err := generateFlowState(db, models.Recovery.String(), models.Recovery, params.CodeChallengeMethod, params.CodeChallenge, &(user.ID)); err != nil {
+		if _, err := generateFlowState(a.db, models.Recovery.String(), models.Recovery, params.CodeChallengeMethod, params.CodeChallenge, &(user.ID)); err != nil {
 			return err
 		}
 	}

--- a/internal/api/recover.go
+++ b/internal/api/recover.go
@@ -58,7 +58,7 @@ func (a *API) Recover(w http.ResponseWriter, r *http.Request) error {
 		return internalServerError("Unable to process request").WithInternalError(err)
 	}
 	if isCodeFlow(flowType) {
-		if _, err := generateFlowState(a.db, models.Recovery.String(), models.Recovery, params.CodeChallengeMethod, params.CodeChallenge, &(user.ID)); err != nil {
+		if _, err := generateFlowState(a.db, models.Recovery.String(), models.Recovery, params.CodeChallengeMethod, params.CodeChallenge, &(user.ID), flowType); err != nil {
 			return err
 		}
 	}

--- a/internal/api/samlacs.go
+++ b/internal/api/samlacs.go
@@ -304,7 +304,7 @@ func (a *API) SAMLACS(w http.ResponseWriter, r *http.Request) error {
 	if flowState != nil {
 		// This means that the callback is using PKCE
 		// Set the flowState.AuthCode to the query param here
-		redirectTo, err = a.prepPKCERedirectURL(redirectTo, flowState.AuthCode)
+		redirectTo, err = a.prepCodeRedirectURL(redirectTo, flowState.AuthCode)
 		if err != nil {
 			return err
 		}

--- a/internal/api/signup.go
+++ b/internal/api/signup.go
@@ -232,7 +232,7 @@ func (a *API) Signup(w http.ResponseWriter, r *http.Request) error {
 					return terr
 				}
 				if isCodeFlow(flowType) {
-					_, terr := generateFlowState(tx, params.Provider, models.EmailSignup, params.CodeChallengeMethod, params.CodeChallenge, &user.ID)
+					_, terr := generateFlowState(tx, params.Provider, models.EmailSignup, params.CodeChallengeMethod, params.CodeChallenge, &user.ID, flowType)
 					if terr != nil {
 						return terr
 					}

--- a/internal/api/signup.go
+++ b/internal/api/signup.go
@@ -51,7 +51,7 @@ func (a *API) validateSignupParams(ctx context.Context, p *SignupParams) error {
 	if p.Phone != "" && p.CodeChallenge != "" {
 		return badRequestError("PKCE not supported for phone signups")
 	}
-	if err := validatePKCEParams(p.CodeChallengeMethod, p.CodeChallenge); err != nil {
+	if err := validateCodeFlowParams(p.CodeChallengeMethod, p.CodeChallenge, p.ResponseType); err != nil {
 		return err
 	}
 

--- a/internal/api/signup.go
+++ b/internal/api/signup.go
@@ -231,7 +231,7 @@ func (a *API) Signup(w http.ResponseWriter, r *http.Request) error {
 				}); terr != nil {
 					return terr
 				}
-				if isPKCEFlow(flowType) {
+				if isCodeFlow(flowType) {
 					_, terr := generateFlowState(tx, params.Provider, models.EmailSignup, params.CodeChallengeMethod, params.CodeChallenge, &user.ID)
 					if terr != nil {
 						return terr

--- a/internal/api/signup.go
+++ b/internal/api/signup.go
@@ -28,6 +28,7 @@ type SignupParams struct {
 	Channel             string                 `json:"channel"`
 	CodeChallengeMethod string                 `json:"code_challenge_method"`
 	CodeChallenge       string                 `json:"code_challenge"`
+	ResponseType        string                 `json:"response_type"`
 }
 
 func (a *API) validateSignupParams(ctx context.Context, p *SignupParams) error {
@@ -129,7 +130,7 @@ func (a *API) Signup(w http.ResponseWriter, r *http.Request) error {
 	}
 
 	var err error
-	flowType := getFlowFromChallenge(params.CodeChallenge)
+	flowType := getFlow(params.CodeChallenge, params.ResponseType)
 
 	var user *models.User
 	var grantParams models.GrantParams

--- a/internal/api/sso.go
+++ b/internal/api/sso.go
@@ -62,7 +62,7 @@ func (a *API) SingleSignOn(w http.ResponseWriter, r *http.Request) error {
 	var flowStateID *uuid.UUID
 	flowStateID = nil
 	if isCodeFlow(flowType) {
-		flowState, err := generateFlowState(db, models.SSOSAML.String(), models.SSOSAML, codeChallengeMethod, codeChallenge, nil)
+		flowState, err := generateFlowState(db, models.SSOSAML.String(), models.SSOSAML, codeChallengeMethod, codeChallenge, nil, flowType)
 		if err != nil {
 			return err
 		}

--- a/internal/api/sso.go
+++ b/internal/api/sso.go
@@ -61,7 +61,7 @@ func (a *API) SingleSignOn(w http.ResponseWriter, r *http.Request) error {
 	flowType := getFlow(params.CodeChallenge, params.ResponseType)
 	var flowStateID *uuid.UUID
 	flowStateID = nil
-	if isPKCEFlow(flowType) {
+	if isCodeFlow(flowType) {
 		flowState, err := generateFlowState(db, models.SSOSAML.String(), models.SSOSAML, codeChallengeMethod, codeChallenge, nil)
 		if err != nil {
 			return err

--- a/internal/api/sso.go
+++ b/internal/api/sso.go
@@ -54,8 +54,9 @@ func (a *API) SingleSignOn(w http.ResponseWriter, r *http.Request) error {
 	}
 	codeChallengeMethod := params.CodeChallengeMethod
 	codeChallenge := params.CodeChallenge
+	responseType := params.ResponseType
 
-	if err := validatePKCEParams(codeChallengeMethod, codeChallenge); err != nil {
+	if err := validateCodeFlowParams(codeChallengeMethod, codeChallenge, responseType); err != nil {
 		return err
 	}
 	flowType := getFlow(params.CodeChallenge, params.ResponseType)

--- a/internal/api/sso.go
+++ b/internal/api/sso.go
@@ -16,6 +16,7 @@ type SingleSignOnParams struct {
 	SkipHTTPRedirect    *bool     `json:"skip_http_redirect"`
 	CodeChallenge       string    `json:"code_challenge"`
 	CodeChallengeMethod string    `json:"code_challenge_method"`
+	ResponseType        string    `json:"response_type"`
 }
 
 type SingleSignOnResponse struct {
@@ -57,7 +58,7 @@ func (a *API) SingleSignOn(w http.ResponseWriter, r *http.Request) error {
 	if err := validatePKCEParams(codeChallengeMethod, codeChallenge); err != nil {
 		return err
 	}
-	flowType := getFlowFromChallenge(params.CodeChallenge)
+	flowType := getFlow(params.CodeChallenge, params.ResponseType)
 	var flowStateID *uuid.UUID
 	flowStateID = nil
 	if isPKCEFlow(flowType) {

--- a/internal/api/sso_test.go
+++ b/internal/api/sso_test.go
@@ -648,6 +648,7 @@ func (ts *SSOTestSuite) TestSingleSignOn() {
 				"provider_id":           providers[0].ID,
 				"code_challenge":        "vby3iMQ4XUuycKkEyNsYHXshPql1Dod7Ebey2iXTXm4",
 				"code_challenge_method": "s256",
+				"response_type":         "code",
 			},
 			Code: http.StatusSeeOther,
 			URL:  "https://accounts.google.com/o/saml2?idpid=EXAMPLE-A",

--- a/internal/api/token.go
+++ b/internal/api/token.go
@@ -123,7 +123,7 @@ func (a *API) AuthCode(ctx context.Context, w http.ResponseWriter, r *http.Reque
 
 	flowState, err := models.FindFlowStateByAuthCode(db, params.AuthCode)
 	// Sanity check in case user ID was not set properly
-	if models.IsNotFoundError(err) || flowState.UserID == nil || flowState.FlowType != models.AuthCode.String() {
+	if models.IsNotFoundError(err) || flowState.UserID == nil || flowState.FlowType != models.AuthCodeFlow.String() {
 		return forbiddenError("invalid flow state, no valid flow state found")
 	} else if err != nil {
 		return err

--- a/internal/api/token_test.go
+++ b/internal/api/token_test.go
@@ -306,7 +306,7 @@ func (ts *TokenTestSuite) TestTokenPKCEGrantFailure() {
 	invalidVerifier := codeVerifier + "123"
 	codeChallenge := sha256.Sum256([]byte(codeVerifier))
 	challenge := base64.RawURLEncoding.EncodeToString(codeChallenge[:])
-	flowState := models.NewFlowState("github", challenge, models.SHA256, models.OAuth, nil)
+	flowState := models.NewPKCEFlowState("github", challenge, models.SHA256, models.OAuth, nil)
 	flowState.AuthCode = authCode
 	require.NoError(ts.T(), ts.API.db.Create(flowState))
 	cases := []struct {

--- a/internal/api/token_test.go
+++ b/internal/api/token_test.go
@@ -546,6 +546,7 @@ func (ts *TokenTestSuite) TestMagicLinkPKCESignIn() {
 		CreateUser:          true,
 		CodeChallengeMethod: "s256",
 		CodeChallenge:       challenge,
+		ResponseType:        "code",
 	}))
 	req = httptest.NewRequest(http.MethodPost, "/otp", &buffer)
 	req.Header.Set("Content-Type", "application/json")

--- a/internal/api/user.go
+++ b/internal/api/user.go
@@ -197,7 +197,7 @@ func (a *API) UserUpdate(w http.ResponseWriter, r *http.Request) error {
 			mailer := a.Mailer(ctx)
 			referrer := utilities.GetReferrer(r, config)
 			flowType := getFlow(params.CodeChallenge, params.ResponseType)
-			if isPKCEFlow(flowType) {
+			if isCodeFlow(flowType) {
 				_, terr := generateFlowState(tx, models.EmailChange.String(), models.EmailChange, params.CodeChallengeMethod, params.CodeChallenge, &user.ID)
 				if terr != nil {
 					return terr

--- a/internal/api/user.go
+++ b/internal/api/user.go
@@ -198,7 +198,7 @@ func (a *API) UserUpdate(w http.ResponseWriter, r *http.Request) error {
 			referrer := utilities.GetReferrer(r, config)
 			flowType := getFlow(params.CodeChallenge, params.ResponseType)
 			if isCodeFlow(flowType) {
-				_, terr := generateFlowState(tx, models.EmailChange.String(), models.EmailChange, params.CodeChallengeMethod, params.CodeChallenge, &user.ID)
+				_, terr := generateFlowState(tx, models.EmailChange.String(), models.EmailChange, params.CodeChallengeMethod, params.CodeChallenge, &user.ID, flowType)
 				if terr != nil {
 					return terr
 				}

--- a/internal/api/user.go
+++ b/internal/api/user.go
@@ -22,6 +22,7 @@ type UserUpdateParams struct {
 	AppData             map[string]interface{} `json:"app_metadata,omitempty"`
 	Phone               string                 `json:"phone"`
 	Channel             string                 `json:"channel"`
+	ResponseType        string                 `json:"response_type"`
 	CodeChallenge       string                 `json:"code_challenge"`
 	CodeChallengeMethod string                 `json:"code_challenge_method"`
 }
@@ -195,7 +196,7 @@ func (a *API) UserUpdate(w http.ResponseWriter, r *http.Request) error {
 		if params.Email != "" && params.Email != user.GetEmail() {
 			mailer := a.Mailer(ctx)
 			referrer := utilities.GetReferrer(r, config)
-			flowType := getFlowFromChallenge(params.CodeChallenge)
+			flowType := getFlow(params.CodeChallenge, params.ResponseType)
 			if isPKCEFlow(flowType) {
 				_, terr := generateFlowState(tx, models.EmailChange.String(), models.EmailChange, params.CodeChallengeMethod, params.CodeChallenge, &user.ID)
 				if terr != nil {

--- a/internal/api/verify.go
+++ b/internal/api/verify.go
@@ -191,7 +191,7 @@ func (a *API) verifyGet(w http.ResponseWriter, r *http.Request, params *VerifyPa
 			if terr = a.setCookieTokens(config, token, false, w); terr != nil {
 				return internalServerError("Failed to set JWT cookie. %s", terr)
 			}
-		} else if isPKCEFlow(flowType) {
+		} else if isCodeFlow(flowType) {
 			if authCode, terr = issueAuthCode(tx, user, authenticationMethod); terr != nil {
 				return badRequestError("No associated flow state found. %s", terr)
 			}
@@ -215,8 +215,8 @@ func (a *API) verifyGet(w http.ResponseWriter, r *http.Request, params *VerifyPa
 		q := url.Values{}
 		q.Set("type", params.Type)
 		rurl = token.AsRedirectURL(rurl, q)
-	} else if isPKCEFlow(flowType) {
-		rurl, err = a.prepPKCERedirectURL(rurl, authCode)
+	} else if isCodeFlow(flowType) {
+		rurl, err = a.prepCodeRedirectURL(rurl, authCode)
 		if err != nil {
 			return err
 		}
@@ -467,7 +467,7 @@ func (a *API) prepRedirectURL(message string, rurl string, flowType models.FlowT
 	return u.String(), nil
 }
 
-func (a *API) prepPKCERedirectURL(rurl, code string) (string, error) {
+func (a *API) prepCodeRedirectURL(rurl, code string) (string, error) {
 	u, err := url.Parse(rurl)
 	if err != nil {
 		return "", err

--- a/internal/api/verify.go
+++ b/internal/api/verify.go
@@ -135,8 +135,15 @@ func (a *API) verifyGet(w http.ResponseWriter, r *http.Request, params *VerifyPa
 
 	flowType := models.ImplicitFlow
 	var authenticationMethod models.AuthenticationMethod
+	// TODO: simplify this
 	if strings.HasPrefix(params.Token, PKCEPrefix) {
 		flowType = models.PKCEFlow
+		authenticationMethod, err = models.ParseAuthenticationMethod(params.Type)
+		if err != nil {
+			return err
+		}
+	} else if strings.HasPrefix(params.Token, AuthCodePrefix) {
+		flowType = models.AuthCodeFlow
 		authenticationMethod, err = models.ParseAuthenticationMethod(params.Type)
 		if err != nil {
 			return err
@@ -459,7 +466,7 @@ func (a *API) prepRedirectURL(message string, rurl string, flowType models.FlowT
 	hq := url.Values{}
 	q := u.Query()
 	hq.Set("message", message)
-	if flowType == models.PKCEFlow {
+	if flowType == models.PKCEFlow || flowType == models.AuthCodeFlow {
 		q.Set("message", message)
 	}
 	u.RawQuery = q.Encode()

--- a/internal/api/verify_test.go
+++ b/internal/api/verify_test.go
@@ -76,6 +76,7 @@ func (ts *VerifyTestSuite) TestVerifyPasswordRecovery() {
 				// Code Challenge needs to be at least 43 characters long
 				"code_challenge":        "6b151854-cc15-4e29-8db7-3d3a9f15b3066b151854-cc15-4e29-8db7-3d3a9f15b306",
 				"code_challenge_method": models.SHA256.String(),
+				"response_type":         "code",
 			},
 			isPKCE: true,
 		},
@@ -155,6 +156,7 @@ func (ts *VerifyTestSuite) TestVerifySecureEmailChange() {
 				// Code Challenge needs to be at least 43 characters long
 				"code_challenge":        "6b151854-cc15-4e29-8db7-3d3a9f15b3066b151854-cc15-4e29-8db7-3d3a9f15b306",
 				"code_challenge_method": models.SHA256.String(),
+				"reseponse_type":        "code",
 			},
 			isPKCE:       true,
 			currentEmail: newEmail,

--- a/internal/api/verify_test.go
+++ b/internal/api/verify_test.go
@@ -661,7 +661,7 @@ func (ts *VerifyTestSuite) TestVerifyPKCEOTP() {
 			var buffer bytes.Buffer
 			require.NoError(ts.T(), json.NewEncoder(&buffer).Encode(c.payload))
 			codeChallenge := "codechallengecodechallengcodechallengcodechallengcodechallenge" + c.payload.Type
-			flowState := models.NewFlowState(c.authenticationMethod.String(), codeChallenge, models.SHA256, c.authenticationMethod, &u.ID)
+			flowState := models.NewPKCEFlowState(c.authenticationMethod.String(), codeChallenge, models.SHA256, c.authenticationMethod, &u.ID)
 			require.NoError(ts.T(), ts.API.db.Create(flowState))
 
 			requestUrl := fmt.Sprintf("http://localhost/verify?type=%v&token=%v", c.payload.Type, c.payload.Token)

--- a/internal/mailer/template.go
+++ b/internal/mailer/template.go
@@ -278,6 +278,7 @@ func (m *TemplateMailer) MagicLinkMail(user *models.User, otp, referrerURL strin
 		"RedirectTo":      referrerURL,
 	}
 
+
 	return m.Mailer.Mail(
 		user.GetEmail(),
 		withDefault(m.Config.Mailer.Subjects.MagicLink, "Your Magic Link"),

--- a/internal/models/flow_state.go
+++ b/internal/models/flow_state.go
@@ -85,17 +85,34 @@ func (FlowState) TableName() string {
 	return tableName
 }
 
-func NewFlowState(providerType, codeChallenge string, codeChallengeMethod CodeChallengeMethod, authenticationMethod AuthenticationMethod, userID *uuid.UUID) *FlowState {
+func NewPKCEFlowState(providerType, codeChallenge string, codeChallengeMethod CodeChallengeMethod, authenticationMethod AuthenticationMethod, userID *uuid.UUID) *FlowState {
 	id := uuid.Must(uuid.NewV4())
 	authCode := uuid.Must(uuid.NewV4())
 	flowState := &FlowState{
-		ID:                  id,
-		ProviderType:        providerType,
-		CodeChallenge:       codeChallenge,
-		CodeChallengeMethod: codeChallengeMethod.String(),
-		AuthCode:            authCode.String(),
-		// TODO: Populate this properly
-		FlowType:             "pkce",
+		ID:                   id,
+		ProviderType:         providerType,
+		CodeChallenge:        codeChallenge,
+		CodeChallengeMethod:  codeChallengeMethod.String(),
+		AuthCode:             authCode.String(),
+		FlowType:             PKCEFlow.String(),
+		AuthenticationMethod: authenticationMethod.String(),
+		UserID:               userID,
+	}
+	return flowState
+}
+
+func NewAuthCodeFlowState(providerType string, authenticationMethod AuthenticationMethod, userID *uuid.UUID) *FlowState {
+	id := uuid.Must(uuid.NewV4())
+	authCode := uuid.Must(uuid.NewV4())
+	// TODO: decide whether to swap out placeholder values
+	codeChallenge := AuthCode.String() + "_" + uuid.Must(uuid.NewV4()).String()
+	flowState := &FlowState{
+		ID:                   id,
+		ProviderType:         providerType,
+		CodeChallenge:        codeChallenge,
+		CodeChallengeMethod:  Plain.String(),
+		AuthCode:             authCode.String(),
+		FlowType:             PKCEFlow.String(),
 		AuthenticationMethod: authenticationMethod.String(),
 		UserID:               userID,
 	}

--- a/internal/models/flow_state.go
+++ b/internal/models/flow_state.go
@@ -21,6 +21,7 @@ const InvalidCodeMethodError = "code challenge method not supported"
 type FlowState struct {
 	ID                   uuid.UUID  `json:"id" db:"id"`
 	UserID               *uuid.UUID `json:"user_id,omitempty" db:"user_id"`
+	FlowType             string     `json:"flow_type" db:"flow_type"`
 	AuthCode             string     `json:"auth_code" db:"auth_code"`
 	AuthenticationMethod string     `json:"authentication_method" db:"authentication_method"`
 	CodeChallenge        string     `json:"code_challenge" db:"code_challenge"`
@@ -63,6 +64,7 @@ type FlowType int
 
 const (
 	PKCEFlow FlowType = iota
+	AuthCode
 	ImplicitFlow
 )
 
@@ -70,6 +72,8 @@ func (flowType FlowType) String() string {
 	switch flowType {
 	case PKCEFlow:
 		return "pkce"
+	case AuthCode:
+		return "code"
 	case ImplicitFlow:
 		return "implicit"
 	}
@@ -85,11 +89,13 @@ func NewFlowState(providerType, codeChallenge string, codeChallengeMethod CodeCh
 	id := uuid.Must(uuid.NewV4())
 	authCode := uuid.Must(uuid.NewV4())
 	flowState := &FlowState{
-		ID:                   id,
-		ProviderType:         providerType,
-		CodeChallenge:        codeChallenge,
-		CodeChallengeMethod:  codeChallengeMethod.String(),
-		AuthCode:             authCode.String(),
+		ID:                  id,
+		ProviderType:        providerType,
+		CodeChallenge:       codeChallenge,
+		CodeChallengeMethod: codeChallengeMethod.String(),
+		AuthCode:            authCode.String(),
+		// TODO: Populate this
+		FlowType:             "code",
 		AuthenticationMethod: authenticationMethod.String(),
 		UserID:               userID,
 	}

--- a/internal/models/flow_state.go
+++ b/internal/models/flow_state.go
@@ -94,8 +94,8 @@ func NewFlowState(providerType, codeChallenge string, codeChallengeMethod CodeCh
 		CodeChallenge:       codeChallenge,
 		CodeChallengeMethod: codeChallengeMethod.String(),
 		AuthCode:            authCode.String(),
-		// TODO: Populate this
-		FlowType:             "code",
+		// TODO: Populate this properly
+		FlowType:             "pkce",
 		AuthenticationMethod: authenticationMethod.String(),
 		UserID:               userID,
 	}

--- a/internal/models/flow_state.go
+++ b/internal/models/flow_state.go
@@ -64,7 +64,7 @@ type FlowType int
 
 const (
 	PKCEFlow FlowType = iota
-	AuthCode
+	AuthCodeFlow
 	ImplicitFlow
 )
 
@@ -72,7 +72,7 @@ func (flowType FlowType) String() string {
 	switch flowType {
 	case PKCEFlow:
 		return "pkce"
-	case AuthCode:
+	case AuthCodeFlow:
 		return "code"
 	case ImplicitFlow:
 		return "implicit"
@@ -105,14 +105,14 @@ func NewAuthCodeFlowState(providerType string, authenticationMethod Authenticati
 	id := uuid.Must(uuid.NewV4())
 	authCode := uuid.Must(uuid.NewV4())
 	// TODO: decide whether to swap out placeholder values
-	codeChallenge := AuthCode.String() + "_" + uuid.Must(uuid.NewV4()).String()
+	codeChallenge := AuthCodeFlow.String() + "_" + uuid.Must(uuid.NewV4()).String()
 	flowState := &FlowState{
 		ID:                   id,
 		ProviderType:         providerType,
 		CodeChallenge:        codeChallenge,
 		CodeChallengeMethod:  Plain.String(),
 		AuthCode:             authCode.String(),
-		FlowType:             PKCEFlow.String(),
+		FlowType:             AuthCodeFlow.String(),
 		AuthenticationMethod: authenticationMethod.String(),
 		UserID:               userID,
 	}

--- a/migrations/20240310120130_add_flow_type_column.up.sql
+++ b/migrations/20240310120130_add_flow_type_column.up.sql
@@ -4,10 +4,10 @@ exception
     when duplicate_object then null;
 end $$;
 
+-- TODO: Maybe merge this into a single block. Also check if we need indexes
 do $$
 begin
    alter table {{ index .Options "Namespace" }}.flow_state
    add column if not exists flow_type flow_type not null default 'code';
-
 end
 $$;

--- a/migrations/20240310120130_add_flow_type_column.up.sql
+++ b/migrations/20240310120130_add_flow_type_column.up.sql
@@ -1,0 +1,13 @@
+do $$ begin
+   create type flow_type as enum('code', 'pkce');
+exception
+    when duplicate_object then null;
+end $$;
+
+do $$
+begin
+   alter table {{ index .Options "Namespace" }}.flow_state
+   add column if not exists flow_type flow_type not null default 'code';
+
+end
+$$;


### PR DESCRIPTION
## What kind of change does this PR introduce?

Here's an overview of what an Auth Code implementation would look like. Further details in internal RFC. 

Key points are:
- PKCE and Auth Code flows are indicated by the parameter `response_type: "code"`. The PKCE Flow is an extension of the Auth Code flow and is activated when a `code_challenge` and `code_challenge_method` are passed in. 
- Allows for use cases where there is need for a token returned as a query param `?` but not the strict security guarantees of the `PKCE` flow
- This will also allow us to implement an interface on the client libraries which has a consistent interface in that one can use with the expectation that one will always receive an access token as a query param.


The Implicit Flow remains as the default though hopefully we can eliminate that soon. 

Please use with corresponding [gotrue-js PR](https://github.com/supabase/gotrue-js/pull/861) to play around

Would need to update the OpenAPI spec if this moves forward
