### PR TITLE
fix: Fix broken link to netlify original

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Auth is a user management and authentication server written in Go that powers
 - Sign in with external providers (Google, Apple, Facebook, Discord, ...)
 
 It is originally based on the excellent
-[Auth codebase by Netlify](https://github.com/netlify/auth), however both have diverged significantly in features and capabilities.
+[GoTrue codebase by Netlify](https://github.com/netlify/gotrue), however both have diverged significantly in features and capabilities.
 
 If you wish to contribute to the project, please refer to the [contributing guide](/CONTRIBUTING.md).
 


### PR DESCRIPTION
sed replace is great, but obviously requires someone to be super attentive when they do it on an entire repo!

## What kind of change does this PR introduce?

docs update

## What is the current behavior?

Links to never-existed `netlify` github repo

## What is the new behavior?

Points to the actually existing `netlify` repo

Fixes https://github.com/supabase/gotrue/issues/1492