### PR TITLE
fix: refactor mfa and aal update methods

### DIFF
--- a/internal/api/admin.go
+++ b/internal/api/admin.go
@@ -545,11 +545,7 @@ func (a *API) adminUserDeleteFactor(w http.ResponseWriter, r *http.Request) erro
 func (a *API) adminUserGetFactors(w http.ResponseWriter, r *http.Request) error {
 	ctx := r.Context()
 	user := getUser(ctx)
-	factors, terr := models.FindFactorsByUser(a.db, user)
-	if terr != nil {
-		return terr
-	}
-	return sendJSON(w, http.StatusOK, factors)
+	return sendJSON(w, http.StatusOK, user.Factors)
 }
 
 // adminUserUpdate updates a single factor object

--- a/internal/api/mfa_test.go
+++ b/internal/api/mfa_test.go
@@ -663,7 +663,7 @@ func cleanupHook(ts *MFATestSuite, hookName string) {
 	require.NoError(ts.T(), err)
 }
 
-// FindFactorsByUser returns all factors belonging to a user ordered by timestamp
+// FindFactorsByUser returns all factors belonging to a user ordered by timestamp. Don't use this outside of tests.
 func FindFactorsByUser(tx *storage.Connection, user *models.User) ([]*models.Factor, error) {
 	factors := []*models.Factor{}
 	if err := tx.Q().Where("user_id = ?", user.ID).Order("created_at asc").All(&factors); err != nil {

--- a/internal/api/token.go
+++ b/internal/api/token.go
@@ -293,7 +293,7 @@ func (a *API) PKCE(ctx context.Context, w http.ResponseWriter, r *http.Request) 
 
 func (a *API) generateAccessToken(ctx context.Context, tx *storage.Connection, user *models.User, sessionId *uuid.UUID, authenticationMethod models.AuthenticationMethod) (string, int64, error) {
 	config := a.config
-	aal, amr := models.AAL1.String(), []models.AMREntry{}
+	aal, amr := models.AAL1, []models.AMREntry{}
 	sid := ""
 	if sessionId != nil {
 		sid = sessionId.String()
@@ -324,7 +324,7 @@ func (a *API) generateAccessToken(ctx context.Context, tx *storage.Connection, u
 		UserMetaData:                  user.UserMetaData,
 		Role:                          user.Role,
 		SessionId:                     sid,
-		AuthenticatorAssuranceLevel:   aal,
+		AuthenticatorAssuranceLevel:   aal.String(),
 		AuthenticationMethodReference: amr,
 		IsAnonymous:                   user.IsAnonymous,
 	}
@@ -452,10 +452,7 @@ func (a *API) updateMFASessionAndClaims(r *http.Request, tx *storage.Connection,
 			return terr
 		}
 
-		if err := session.UpdateAssociatedFactor(tx, grantParams.FactorID); err != nil {
-			return err
-		}
-		if err := session.UpdateAssociatedAAL(tx, aal); err != nil {
+		if err := session.UpdateAALAndAssociatedFactor(tx, aal, grantParams.FactorID); err != nil {
 			return err
 		}
 

--- a/internal/models/factor.go
+++ b/internal/models/factor.go
@@ -141,18 +141,6 @@ func NewFactor(user *User, friendlyName string, factorType string, state FactorS
 	return factor
 }
 
-// FindFactorsByUser returns all factors belonging to a user ordered by timestamp
-func FindFactorsByUser(tx *storage.Connection, user *User) ([]*Factor, error) {
-	factors := []*Factor{}
-	if err := tx.Q().Where("user_id = ?", user.ID).Order("created_at asc").All(&factors); err != nil {
-		if errors.Cause(err) == sql.ErrNoRows {
-			return factors, nil
-		}
-		return nil, errors.Wrap(err, "Database error when finding MFA factors associated to user")
-	}
-	return factors, nil
-}
-
 func FindFactorByFactorID(conn *storage.Connection, factorID uuid.UUID) (*Factor, error) {
 	var factor Factor
 	err := conn.Find(&factor, factorID)

--- a/internal/models/sessions_test.go
+++ b/internal/models/sessions_test.go
@@ -84,7 +84,7 @@ func (ts *SessionsTestSuite) TestCalculateAALAndAMR() {
 	aal, amr, err := session.CalculateAALAndAMR(u)
 	require.NoError(ts.T(), err)
 
-	require.Equal(ts.T(), AAL2.String(), aal)
+	require.Equal(ts.T(), AAL2, aal)
 	require.Equal(ts.T(), totalDistinctClaims, len(amr))
 
 	found := false


### PR DESCRIPTION
## What kind of change does this PR introduce?

Regular cleanup.

-  Merge the AAL and AMR update methods. Think this was suggested a while back but only getting to it now. 
-  Move `FindUserByFactors` to tests - a user should never need to find a user by factors. They can fetch it from the models. 


Ideally I'd remove it entirely but it's used in a few tests which will take significant time to refactor.

