### PR TITLE
feat: forbid generating an access token without a session

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Auth is a user management and authentication server written in Go that powers
 - Sign in with external providers (Google, Apple, Facebook, Discord, ...)
 
 It is originally based on the excellent
-[Auth codebase by Netlify](https://github.com/netlify/auth), however both have diverged significantly in features and capabilities.
+[GoTrue codebase by Netlify](https://github.com/netlify/gotrue), however both have diverged significantly in features and capabilities.
 
 If you wish to contribute to the project, please refer to the [contributing guide](/CONTRIBUTING.md).
 

--- a/internal/api/audit_test.go
+++ b/internal/api/audit_test.go
@@ -54,7 +54,6 @@ func (ts *AuditTestSuite) makeSuperAdmin(email string) string {
 	require.NoError(ts.T(), ts.API.db.Create(session))
 
 	var token string
-
 	token, _, err = ts.API.generateAccessToken(context.Background(), ts.API.db, u, &session.ID, models.PasswordGrant)
 	require.NoError(ts.T(), err, "Error generating access token")
 

--- a/internal/api/audit_test.go
+++ b/internal/api/audit_test.go
@@ -47,9 +47,15 @@ func (ts *AuditTestSuite) makeSuperAdmin(email string) string {
 	require.NoError(ts.T(), err, "Error making new user")
 
 	u.Role = "supabase_admin"
+	require.NoError(ts.T(), ts.API.db.Create(u))
+
+	session, err := models.NewSession(u.ID, nil)
+	require.NoError(ts.T(), err)
+	require.NoError(ts.T(), ts.API.db.Create(session))
 
 	var token string
-	token, _, err = ts.API.generateAccessToken(context.Background(), ts.API.db, u, nil, models.PasswordGrant)
+
+	token, _, err = ts.API.generateAccessToken(context.Background(), ts.API.db, u, &session.ID, models.PasswordGrant)
 	require.NoError(ts.T(), err, "Error generating access token")
 
 	p := jwt.Parser{ValidMethods: []string{jwt.SigningMethodHS256.Name}}

--- a/internal/api/invite_test.go
+++ b/internal/api/invite_test.go
@@ -56,11 +56,16 @@ func (ts *InviteTestSuite) makeSuperAdmin(email string) string {
 
 	u, err := models.NewUser("123456789", email, "test", ts.Config.JWT.Aud, map[string]interface{}{"full_name": "Test User"})
 	require.NoError(ts.T(), err, "Error making new user")
+	require.NoError(ts.T(), ts.API.db.Create(u))
 
 	u.Role = "supabase_admin"
 
 	var token string
-	token, _, err = ts.API.generateAccessToken(context.Background(), ts.API.db, u, nil, models.Invite)
+
+	session, err := models.NewSession(u.ID, nil)
+	require.NoError(ts.T(), err)
+	require.NoError(ts.T(), ts.API.db.Create(session))
+	token, _, err = ts.API.generateAccessToken(context.Background(), ts.API.db, u, &session.ID, models.Invite)
 
 	require.NoError(ts.T(), err, "Error generating access token")
 

--- a/internal/api/logout_test.go
+++ b/internal/api/logout_test.go
@@ -43,7 +43,10 @@ func (ts *LogoutTestSuite) SetupTest() {
 
 	// generate access token to use for logout
 	var t string
-	t, _, err = ts.API.generateAccessToken(context.Background(), ts.API.db, u, nil, models.PasswordGrant)
+	s, err := models.NewSession(u.ID, nil)
+	require.NoError(ts.T(), err)
+	require.NoError(ts.T(), ts.API.db.Create(s))
+	t, _, err = ts.API.generateAccessToken(context.Background(), ts.API.db, u, &s.ID, models.PasswordGrant)
 	require.NoError(ts.T(), err)
 	ts.token = t
 }

--- a/internal/api/phone_test.go
+++ b/internal/api/phone_test.go
@@ -159,7 +159,11 @@ func (ts *PhoneTestSuite) TestMissingSmsProviderConfig() {
 	u.PhoneConfirmedAt = &now
 	require.NoError(ts.T(), ts.API.db.Update(u), "Error updating new test user")
 
-	token := ts.generateAccessTokenAndSession(context.Background(), u, models.OTP)
+	s, err := models.NewSession(u.ID, nil)
+	require.NoError(ts.T(), err)
+	require.NoError(ts.T(), ts.API.db.Create(s))
+
+	token, _, err := ts.API.generateAccessToken(context.Background(), ts.API.db, u, &s.ID, models.PasswordGrant)
 	require.NoError(ts.T(), err)
 
 	cases := []struct {
@@ -256,15 +260,4 @@ func (ts *PhoneTestSuite) TestMissingSmsProviderConfig() {
 			})
 		}
 	}
-}
-
-func (ts *PhoneTestSuite) generateAccessTokenAndSession(ctx context.Context, u *models.User, authenticationMethod models.AuthenticationMethod) string {
-	s, err := models.NewSession(u.ID, nil)
-	require.NoError(ts.T(), err)
-	require.NoError(ts.T(), ts.API.db.Create(s))
-
-	token, _, err := ts.API.generateAccessToken(context.Background(), ts.API.db, u, &s.ID, models.PasswordGrant)
-	require.NoError(ts.T(), err)
-	return token
-
 }

--- a/internal/api/phone_test.go
+++ b/internal/api/phone_test.go
@@ -160,7 +160,9 @@ func (ts *PhoneTestSuite) TestMissingSmsProviderConfig() {
 	require.NoError(ts.T(), ts.API.db.Update(u), "Error updating new test user")
 
 	var token string
-	token, _, err = ts.API.generateAccessToken(context.Background(), ts.API.db, u, nil, models.OTP)
+	session, err := models.FindSessionByUserID(ts.API.db, u.ID)
+	require.NoError(ts.T(), err)
+	token, _, err = ts.API.generateAccessToken(context.Background(), ts.API.db, u, &session.ID, models.OTP)
 	require.NoError(ts.T(), err)
 
 	cases := []struct {

--- a/internal/api/phone_test.go
+++ b/internal/api/phone_test.go
@@ -159,10 +159,7 @@ func (ts *PhoneTestSuite) TestMissingSmsProviderConfig() {
 	u.PhoneConfirmedAt = &now
 	require.NoError(ts.T(), ts.API.db.Update(u), "Error updating new test user")
 
-	var token string
-	session, err := models.FindSessionByUserID(ts.API.db, u.ID)
-	require.NoError(ts.T(), err)
-	token, _, err = ts.API.generateAccessToken(context.Background(), ts.API.db, u, &session.ID, models.OTP)
+	token := ts.generateAccessTokenAndSession(context.Background(), u, models.OTP)
 	require.NoError(ts.T(), err)
 
 	cases := []struct {
@@ -259,4 +256,15 @@ func (ts *PhoneTestSuite) TestMissingSmsProviderConfig() {
 			})
 		}
 	}
+}
+
+func (ts *PhoneTestSuite) generateAccessTokenAndSession(ctx context.Context, u *models.User, authenticationMethod models.AuthenticationMethod) string {
+	s, err := models.NewSession(u.ID, nil)
+	require.NoError(ts.T(), err)
+	require.NoError(ts.T(), ts.API.db.Create(s))
+
+	token, _, err := ts.API.generateAccessToken(context.Background(), ts.API.db, u, &s.ID, models.PasswordGrant)
+	require.NoError(ts.T(), err)
+	return token
+
 }

--- a/internal/api/token.go
+++ b/internal/api/token.go
@@ -293,16 +293,15 @@ func (a *API) PKCE(ctx context.Context, w http.ResponseWriter, r *http.Request) 
 
 func (a *API) generateAccessToken(ctx context.Context, tx *storage.Connection, user *models.User, sessionId *uuid.UUID, authenticationMethod models.AuthenticationMethod) (string, int64, error) {
 	config := a.config
-	aal, amr := models.AAL1.String(), []models.AMREntry{}
 	if sessionId == nil {
-		return "", "", internalServerError("Session is required to issue access token")
+		return "", 0, internalServerError("Session is required to issue access token")
 	}
 	sid := sessionId.String()
 	session, terr := models.FindSessionByID(tx, *sessionId, false)
 	if terr != nil {
 		return "", 0, terr
 	}
-	aal, amr, terr = session.CalculateAALAndAMR(user)
+	aal, amr, terr := session.CalculateAALAndAMR(user)
 	if terr != nil {
 		return "", 0, terr
 	}

--- a/internal/api/token.go
+++ b/internal/api/token.go
@@ -294,17 +294,17 @@ func (a *API) PKCE(ctx context.Context, w http.ResponseWriter, r *http.Request) 
 func (a *API) generateAccessToken(ctx context.Context, tx *storage.Connection, user *models.User, sessionId *uuid.UUID, authenticationMethod models.AuthenticationMethod) (string, int64, error) {
 	config := a.config
 	aal, amr := models.AAL1.String(), []models.AMREntry{}
-	sid := ""
-	if sessionId != nil {
-		sid = sessionId.String()
-		session, terr := models.FindSessionByID(tx, *sessionId, false)
-		if terr != nil {
-			return "", 0, terr
-		}
-		aal, amr, terr = session.CalculateAALAndAMR(user)
-		if terr != nil {
-			return "", 0, terr
-		}
+	if sessionId == nil {
+		return "", "", internalServerError("Session is required to issue access token")
+	}
+	sid := sessionId.String()
+	session, terr := models.FindSessionByID(tx, *sessionId, false)
+	if terr != nil {
+		return "", 0, terr
+	}
+	aal, amr, terr = session.CalculateAALAndAMR(user)
+	if terr != nil {
+		return "", 0, terr
 	}
 
 	issuedAt := time.Now().UTC()

--- a/internal/api/verify_test.go
+++ b/internal/api/verify_test.go
@@ -177,9 +177,13 @@ func (ts *VerifyTestSuite) TestVerifySecureEmailChange() {
 		req := httptest.NewRequest(http.MethodPut, "http://localhost/user", &buffer)
 		req.Header.Set("Content-Type", "application/json")
 
-		// Generate access token for request
+		// Generate access token for request and a mock session
 		var token string
-		token, _, err = ts.API.generateAccessToken(context.Background(), ts.API.db, u, nil, models.MagicLink)
+		session, err := models.NewSession(u.ID, nil)
+		require.NoError(ts.T(), err)
+		require.NoError(ts.T(), ts.API.db.Create(session))
+
+		token, _, err = ts.API.generateAccessToken(context.Background(), ts.API.db, u, &session.ID, models.MagicLink)
 		require.NoError(ts.T(), err)
 		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Enforces the precondition of a valid session before one can create an access token.  This supports refactors around `generateAccessToken` and  `updateMFASessionAndClaims`. Also allows for stronger guarantees within the function since one can always assume there is a valid session.

There were a few test changes:
- To mirror real world use, Access Tokens should now only exist where there is a valid session. We wrap  `generateAccessToken` into a helper `generateAccessTokenAndSession` to replace previous occurrences where session was set to nil.
- We split TestUpdatePassword into cases where reauthentication is required and reauthentication is not required. We also attach a session to two of the test cases as they were previously nil