### PR TITLE
feat: add max length check for email

### DIFF
--- a/internal/api/mail.go
+++ b/internal/api/mail.go
@@ -489,6 +489,9 @@ func validateEmail(email string) (string, error) {
 	if email == "" {
 		return "", badRequestError(ErrorCodeValidationFailed, "An email address is required")
 	}
+	if len(email) > 255 {
+		return "", badRequestError(ErrorCodeValidationFailed, "An email address is too long")
+	}
 	if err := checkmail.ValidateFormat(email); err != nil {
 		return "", badRequestError(ErrorCodeValidationFailed, "Unable to validate email address: "+err.Error())
 	}


### PR DESCRIPTION
## What kind of change does this PR introduce?

feature: add max length check for email.

## What is the current behavior?

Currently, email length is only checked on db side. Email has max length 255 characters, when user sends (>255 characters) large email to `/admin/users` endpoint, db is doing unnecessary queries.

![Screenshot from 2024-03-30 02-40-54](https://github.com/supabase/auth/assets/72510037/10a36b08-5112-4737-9c3a-b9e01c7ccc10)


## What is the new behavior?

Code returns early if user enters large email. There will be no db queries.

![Screenshot from 2024-03-30 02-44-31](https://github.com/supabase/auth/assets/72510037/735a4e79-561f-412a-b536-6dac3aa6f339)
