### PR TITLE
fix: move all EmailActionTypes to mailer package

### DIFF
--- a/internal/api/resend_test.go
+++ b/internal/api/resend_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"github.com/supabase/auth/internal/conf"
+	mail "github.com/supabase/auth/internal/mailer"
 	"github.com/supabase/auth/internal/models"
 )
 
@@ -194,15 +195,15 @@ func (ts *ResendTestSuite) TestResendSuccess() {
 			require.Equal(ts.T(), http.StatusOK, w.Code)
 
 			switch c.params["type"] {
-			case signupVerification, emailChangeVerification:
+			case mail.SignupVerification, mail.EmailChangeVerification:
 				dbUser, err := models.FindUserByID(ts.API.db, c.user.ID)
 				require.NoError(ts.T(), err)
 				require.NotEmpty(ts.T(), dbUser)
 
-				if c.params["type"] == signupVerification {
+				if c.params["type"] == mail.SignupVerification {
 					require.NotEqual(ts.T(), dbUser.ConfirmationToken, c.user.ConfirmationToken)
 					require.NotEqual(ts.T(), dbUser.ConfirmationSentAt, c.user.ConfirmationSentAt)
-				} else if c.params["type"] == emailChangeVerification {
+				} else if c.params["type"] == mail.EmailChangeVerification {
 					require.NotEqual(ts.T(), dbUser.EmailChangeTokenNew, c.user.EmailChangeTokenNew)
 					require.NotEqual(ts.T(), dbUser.EmailChangeSentAt, c.user.EmailChangeSentAt)
 				}

--- a/internal/api/signup_test.go
+++ b/internal/api/signup_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	mail "github.com/supabase/auth/internal/mailer"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -132,7 +133,7 @@ func (ts *SignupTestSuite) TestVerifySignup() {
 	require.NoError(ts.T(), err)
 
 	// Setup request
-	reqUrl := fmt.Sprintf("http://localhost/verify?type=%s&token=%s", signupVerification, u.ConfirmationToken)
+	reqUrl := fmt.Sprintf("http://localhost/verify?type=%s&token=%s", mail.SignupVerification, u.ConfirmationToken)
 	req := httptest.NewRequest(http.MethodGet, reqUrl, nil)
 
 	// Setup response recorder

--- a/internal/mailer/mailer.go
+++ b/internal/mailer/mailer.go
@@ -32,14 +32,6 @@ type EmailParams struct {
 	RedirectTo string
 }
 
-type EmailData struct {
-	OTP             string `json:"otp"`
-	TokenHash       string `json:"token_hash"`
-	RedirectTo      string `json:"redirect_to"`
-	EmailActionType string `json:"email_action_type"`
-	SiteURL         string `json:"site_url"`
-}
-
 // NewMailer returns a new gotrue mailer
 func NewMailer(globalConfig *conf.GlobalConfiguration) Mailer {
 	mail := gomail.NewMessage()

--- a/internal/mailer/mailer.go
+++ b/internal/mailer/mailer.go
@@ -32,6 +32,14 @@ type EmailParams struct {
 	RedirectTo string
 }
 
+type EmailData struct {
+	OTP             string `json:"otp"`
+	TokenHash       string `json:"token_hash"`
+	RedirectTo      string `json:"redirect_to"`
+	EmailActionType string `json:"email_action_type"`
+	SiteURL         string `json:"site_url"`
+}
+
 // NewMailer returns a new gotrue mailer
 func NewMailer(globalConfig *conf.GlobalConfiguration) Mailer {
 	mail := gomail.NewMessage()

--- a/internal/mailer/template.go
+++ b/internal/mailer/template.go
@@ -34,6 +34,18 @@ func encodeRedirectURL(referrerURL string) string {
 	return referrerURL
 }
 
+const (
+	SignupVerification             = "signup"
+	RecoveryVerification           = "recovery"
+	InviteVerification             = "invite"
+	MagicLinkVerification          = "magiclink"
+	EmailChangeVerification        = "email_change"
+	EmailOTPVerification           = "email"
+	EmailChangeCurrentVerification = "email_change_current"
+	EmailChangeNewVerification     = "email_change_new"
+	ReauthenticationVerification   = "reauthentication"
+)
+
 const defaultInviteMail = `<h2>You have been invited</h2>
 
 <p>You have been invited to create a user on {{ .SiteURL }}. Follow this link to accept the invite:</p>


### PR DESCRIPTION
## What kind of change does this PR introduce?

Moves the mail related refactors from #1496  into a new PR so the hook related PR is easier to review. This PR moves all EmailActionTypes to mailer package to establish an explicit link between mailer and the packages it is used in.

The changes are cosmetic and should not affect underlying functionality.
