### PR TITLE
feat: add send email Hook

### DIFF
--- a/internal/api/hooks.go
+++ b/internal/api/hooks.go
@@ -183,11 +183,11 @@ func (a *API) invokeHTTPHook(ctx context.Context, r *http.Request, input, output
 		var err error
 
 		if response, err = a.runHTTPHook(ctx, r, a.config.Hook.SendSMS, input, output); err != nil {
-			return internalServerError("Error invoking custom SMS provider hook.").WithInternalError(err)
+			return internalServerError("Error invoking Send SMS hook.").WithInternalError(err)
 		}
 
 		if err := json.Unmarshal(response, hookOutput); err != nil {
-			return internalServerError("Error unmarshaling custom SMS provider hook output.").WithInternalError(err)
+			return internalServerError("Error unmarshaling Send SMS output.").WithInternalError(err)
 		}
 	case *hooks.SendEmailInput:
 		hookOutput, ok := output.(*hooks.SendEmailOutput)
@@ -199,14 +199,14 @@ func (a *API) invokeHTTPHook(ctx context.Context, r *http.Request, input, output
 		var err error
 
 		if response, err = a.runHTTPHook(ctx, r, a.config.Hook.SendEmail, input, output); err != nil {
-			return internalServerError("Error invoking custom email provider hook.").WithInternalError(err)
+			return internalServerError("Error invoking Send Email hook.").WithInternalError(err)
 		}
 		if err != nil {
 			return err
 		}
 
 		if err := json.Unmarshal(response, hookOutput); err != nil {
-			return internalServerError("Error unmarshaling custom SMS provider hook output.").WithInternalError(err)
+			return internalServerError("Error unmarshaling Send Email hook output.").WithInternalError(err)
 		}
 
 	default:

--- a/internal/api/hooks.go
+++ b/internal/api/hooks.go
@@ -189,6 +189,25 @@ func (a *API) invokeHTTPHook(ctx context.Context, r *http.Request, input, output
 		if err := json.Unmarshal(response, hookOutput); err != nil {
 			return internalServerError("Error unmarshaling custom SMS provider hook output.").WithInternalError(err)
 		}
+	case *hooks.SendEmailInput:
+		hookOutput, ok := output.(*hooks.SendEmailOutput)
+		if !ok {
+			panic("output should be *hooks.SendEmailOutput")
+		}
+
+		var response []byte
+		var err error
+
+		if response, err = a.runHTTPHook(ctx, r, a.config.Hook.SendEmail, input, output); err != nil {
+			return internalServerError("Error invoking custom email provider hook.").WithInternalError(err)
+		}
+		if err != nil {
+			return err
+		}
+
+		if err := json.Unmarshal(response, hookOutput); err != nil {
+			return internalServerError("Error unmarshaling custom SMS provider hook output.").WithInternalError(err)
+		}
 
 	default:
 		panic("unknown HTTP hook type")

--- a/internal/api/mail.go
+++ b/internal/api/mail.go
@@ -279,7 +279,7 @@ func (a *API) sendConfirmation(r *http.Request, tx *storage.Connection, u *model
 	token := crypto.GenerateTokenHash(u.GetEmail(), otp)
 	u.ConfirmationToken = addFlowPrefixToToken(token, flowType)
 	now := time.Now()
-	err = a.sendEmail(r, u, otp, mail.SignupVerification)
+	err = a.sendEmail(r, u, otp, mail.SignupVerification, "")
 	if err != nil {
 		u.ConfirmationToken = oldToken
 		return errors.Wrap(err, "Error sending confirmation email")
@@ -305,7 +305,7 @@ func (a *API) sendInvite(r *http.Request, tx *storage.Connection, u *models.User
 	}
 	u.ConfirmationToken = crypto.GenerateTokenHash(u.GetEmail(), otp)
 	now := time.Now()
-	err = a.sendEmail(r, u, otp, mail.InviteVerification)
+	err = a.sendEmail(r, u, otp, mail.InviteVerification, "")
 	if err != nil {
 		u.ConfirmationToken = oldToken
 		return errors.Wrap(err, "Error sending invite email")
@@ -338,7 +338,7 @@ func (a *API) sendPasswordRecovery(r *http.Request, tx *storage.Connection, u *m
 	token := crypto.GenerateTokenHash(u.GetEmail(), otp)
 	u.RecoveryToken = addFlowPrefixToToken(token, flowType)
 	now := time.Now()
-	err = a.sendEmail(r, u, otp, mail.RecoveryVerification)
+	err = a.sendEmail(r, u, otp, mail.RecoveryVerification, "")
 	if err != nil {
 		u.RecoveryToken = oldToken
 		return errors.Wrap(err, "Error sending recovery email")
@@ -370,7 +370,7 @@ func (a *API) sendReauthenticationOtp(r *http.Request, tx *storage.Connection, u
 	}
 	u.ReauthenticationToken = crypto.GenerateTokenHash(u.GetEmail(), otp)
 	now := time.Now()
-	err = a.sendEmail(r, u, otp, mail.ReauthenticationVerification)
+	err = a.sendEmail(r, u, otp, mail.ReauthenticationVerification, "")
 	if err != nil {
 		u.ReauthenticationToken = oldToken
 		return errors.Wrap(err, "Error sending reauthentication email")
@@ -405,7 +405,7 @@ func (a *API) sendMagicLink(r *http.Request, tx *storage.Connection, u *models.U
 	u.RecoveryToken = addFlowPrefixToToken(token, flowType)
 
 	now := time.Now()
-	err = a.sendEmail(r, u, otp, mail.MagicLinkVerification)
+	err = a.sendEmail(r, u, otp, mail.MagicLinkVerification, "")
 	if err != nil {
 		u.RecoveryToken = oldToken
 		return errors.Wrap(err, "Error sending magic link email")
@@ -421,16 +421,12 @@ func (a *API) sendMagicLink(r *http.Request, tx *storage.Connection, u *models.U
 
 // sendEmailChange sends out an email change token to the new email.
 func (a *API) sendEmailChange(r *http.Request, tx *storage.Connection, u *models.User, email string, flowType models.FlowType) error {
-	ctx := r.Context()
 	config := a.config
 	otpLength := config.Mailer.OtpLength
 	var err error
-	mailer := a.Mailer()
 	if err := validateSentWithinFrequencyLimit(u.EmailChangeSentAt, config.SMTP.MaxFrequency); err != nil {
 		return err
 	}
-	referrerURL := utilities.GetReferrer(r, config)
-	externalURL := getExternalHost(ctx)
 
 	otpNew, err := crypto.GenerateOtp(otpLength)
 	if err != nil {
@@ -454,7 +450,8 @@ func (a *API) sendEmailChange(r *http.Request, tx *storage.Connection, u *models
 
 	u.EmailChangeConfirmStatus = zeroConfirmation
 	now := time.Now()
-	if err := mailer.EmailChangeMail(r, u, otpNew, otpCurrent, referrerURL, externalURL); err != nil {
+	err = a.sendEmail(r, u, mail.EmailChangeVerification, otpCurrent, otpNew)
+	if err != nil {
 		return err
 	}
 
@@ -492,7 +489,7 @@ func validateSentWithinFrequencyLimit(sentAt *time.Time, frequency time.Duration
 	return nil
 }
 
-func (a *API) sendEmail(r *http.Request, u *models.User, otp, emailVerificationType string) error {
+func (a *API) sendEmail(r *http.Request, u *models.User, emailVerificationType, otp, otpNew string) error {
 	mailer := a.Mailer()
 	ctx := r.Context()
 	config := a.config
@@ -510,6 +507,8 @@ func (a *API) sendEmail(r *http.Request, u *models.User, otp, emailVerificationT
 		return mailer.RecoveryMail(r, u, otp, referrerURL, externalURL)
 	case mail.InviteVerification:
 		return mailer.InviteMail(r, u, otp, referrerURL, externalURL)
+	case mail.EmailChangeVerification:
+		return mailer.EmailChangeMail(r, u, otpNew, otp, referrerURL, externalURL)
 
 	}
 	return nil

--- a/internal/api/mail.go
+++ b/internal/api/mail.go
@@ -406,7 +406,7 @@ func (a *API) sendMagicLink(r *http.Request, tx *storage.Connection, u *models.U
 	u.RecoveryToken = addFlowPrefixToToken(token, flowType)
 
 	now := time.Now()
-	err = a.sendEmail(r, u, otp, mail.MagicLinkVerification, "", u.RecoveryToken)
+	err = a.sendEmail(r, u, mail.MagicLinkVerification, otp, "", u.RecoveryToken)
 	if err != nil {
 		u.RecoveryToken = oldToken
 		return errors.Wrap(err, "Error sending magic link email")

--- a/internal/api/mail.go
+++ b/internal/api/mail.go
@@ -503,14 +503,13 @@ func (a *API) sendEmail(r *http.Request, u *models.User, emailActionType, otp, o
 			SiteURL:         externalURL.String(),
 			TokenHash:       tokenHashWithPrefix,
 		}
-		input := hooks.SendEmailInput{
-			User:      u,
-			EmailData: emailData,
-		}
-
 		if emailActionType == mail.EmailChangeVerification && config.Mailer.SecureEmailChangeEnabled && u.GetEmail() != "" {
 			emailData.OTPNew = otpNew
 			emailData.TokenHashNew = u.EmailChangeTokenCurrent
+		}
+		input := hooks.SendEmailInput{
+			User:      u,
+			EmailData: emailData,
 		}
 		output := hooks.SendEmailOutput{}
 		return a.invokeHTTPHook(ctx, r, &input, &output)

--- a/internal/api/mail.go
+++ b/internal/api/mail.go
@@ -497,14 +497,14 @@ func (a *API) sendEmail(r *http.Request, u *models.User, emailActionType, otp, o
 	externalURL := getExternalHost(ctx)
 	if config.Hook.SendEmail.Enabled {
 		emailData := mail.EmailData{
-			OTP:             otp,
+			Token:           otp,
 			EmailActionType: emailActionType,
 			RedirectTo:      referrerURL,
 			SiteURL:         externalURL.String(),
 			TokenHash:       tokenHashWithPrefix,
 		}
 		if emailActionType == mail.EmailChangeVerification && config.Mailer.SecureEmailChangeEnabled && u.GetEmail() != "" {
-			emailData.OTPNew = otpNew
+			emailData.TokenNew = otpNew
 			emailData.TokenHashNew = u.EmailChangeTokenCurrent
 		}
 		input := hooks.SendEmailInput{

--- a/internal/api/mail.go
+++ b/internal/api/mail.go
@@ -510,7 +510,6 @@ func (a *API) sendEmail(r *http.Request, u *models.User, emailActionType, otp, o
 
 		if emailActionType == mail.EmailChangeVerification && config.Mailer.SecureEmailChangeEnabled && u.GetEmail() != "" {
 			emailData.OTPNew = otpNew
-			//
 			emailData.TokenHashNew = u.EmailChangeTokenCurrent
 		}
 		output := hooks.SendEmailOutput{}

--- a/internal/conf/configuration.go
+++ b/internal/conf/configuration.go
@@ -452,7 +452,7 @@ type HookConfiguration struct {
 	PasswordVerificationAttempt ExtensibilityPointConfiguration `json:"password_verification_attempt" split_words:"true"`
 	CustomAccessToken           ExtensibilityPointConfiguration `json:"custom_access_token" split_words:"true"`
 	CustomSMSProvider           ExtensibilityPointConfiguration `json:"custom_sms_provider" split_words:"true"`
-	SendEmail                   ExtensibilityPointConfiguration `json:"custom_email_provider" split_words:"true"`
+	SendEmail                   ExtensibilityPointConfiguration `json:"send_email" split_words:"true"`
 }
 
 type HTTPHookSecrets []string

--- a/internal/conf/configuration.go
+++ b/internal/conf/configuration.go
@@ -452,6 +452,7 @@ type HookConfiguration struct {
 	PasswordVerificationAttempt ExtensibilityPointConfiguration `json:"password_verification_attempt" split_words:"true"`
 	CustomAccessToken           ExtensibilityPointConfiguration `json:"custom_access_token" split_words:"true"`
 	CustomSMSProvider           ExtensibilityPointConfiguration `json:"custom_sms_provider" split_words:"true"`
+	SendEmail                   ExtensibilityPointConfiguration `json:"custom_email_provider" split_words:"true"`
 }
 
 type HTTPHookSecrets []string

--- a/internal/hooks/auth_hooks.go
+++ b/internal/hooks/auth_hooks.go
@@ -3,6 +3,7 @@ package hooks
 import (
 	"github.com/gofrs/uuid"
 	"github.com/golang-jwt/jwt"
+	"github.com/supabase/auth/internal/mailer"
 	"github.com/supabase/auth/internal/models"
 )
 
@@ -146,6 +147,16 @@ type CustomSMSProviderInput struct {
 }
 
 type CustomSMSProviderOutput struct {
+	Success   bool          `json:"success"`
+	HookError AuthHookError `json:"error,omitempty"`
+}
+
+type SendEmailInput struct {
+	User      *models.User     `json:"user"`
+	EmailData mailer.EmailData `json:"email_data"`
+}
+
+type SendEmailOutput struct {
 	Success   bool          `json:"success"`
 	HookError AuthHookError `json:"error,omitempty"`
 }

--- a/internal/mailer/mailer.go
+++ b/internal/mailer/mailer.go
@@ -32,6 +32,16 @@ type EmailParams struct {
 	RedirectTo string
 }
 
+type EmailData struct {
+	OTP             string `json:"otp"`
+	TokenHash       string `json:"token_hash"`
+	RedirectTo      string `json:"redirect_to"`
+	EmailActionType string `json:"email_action_type"`
+	SiteURL         string `json:"site_url"`
+	OTPNew          string `json:"otp_new"`
+	TokenHashNew    string `json:"token_hash_new"`
+}
+
 // NewMailer returns a new gotrue mailer
 func NewMailer(globalConfig *conf.GlobalConfiguration) Mailer {
 	mail := gomail.NewMessage()

--- a/internal/mailer/mailer.go
+++ b/internal/mailer/mailer.go
@@ -33,12 +33,12 @@ type EmailParams struct {
 }
 
 type EmailData struct {
-	OTP             string `json:"otp"`
+	Token           string `json:"token"`
 	TokenHash       string `json:"token_hash"`
 	RedirectTo      string `json:"redirect_to"`
 	EmailActionType string `json:"email_action_type"`
 	SiteURL         string `json:"site_url"`
-	OTPNew          string `json:"otp_new"`
+	TokenNew        string `json:"token_new"`
 	TokenHashNew    string `json:"token_hash_new"`
 }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

The send email hook serves as a substitute for the default email client (e.g. GoMail) across all endpoints. 


Supercedes #1496  as it was simpler to visualize the PR when starting from scratch 