### PR TITLE
fix: rename from CustomSMSProvider to SendSMS

### DIFF
--- a/internal/api/hooks.go
+++ b/internal/api/hooks.go
@@ -174,15 +174,15 @@ func (a *API) runHTTPHook(ctx context.Context, r *http.Request, hookConfig conf.
 
 func (a *API) invokeHTTPHook(ctx context.Context, r *http.Request, input, output any) error {
 	switch input.(type) {
-	case *hooks.CustomSMSProviderInput:
-		hookOutput, ok := output.(*hooks.CustomSMSProviderOutput)
+	case *hooks.SendSMSInput:
+		hookOutput, ok := output.(*hooks.SendSMSOutput)
 		if !ok {
-			panic("output should be *hooks.CustomSMSProviderOutput")
+			panic("output should be *hooks.SendSMSOutput")
 		}
 		var response []byte
 		var err error
 
-		if response, err = a.runHTTPHook(ctx, r, a.config.Hook.CustomSMSProvider, input, output); err != nil {
+		if response, err = a.runHTTPHook(ctx, r, a.config.Hook.SendSMS, input, output); err != nil {
 			return internalServerError("Error invoking custom SMS provider hook.").WithInternalError(err)
 		}
 

--- a/internal/api/phone.go
+++ b/internal/api/phone.go
@@ -95,13 +95,13 @@ func (a *API) sendPhoneConfirmation(ctx context.Context, r *http.Request, tx *st
 		if err != nil {
 			return "", err
 		}
-		if config.Hook.CustomSMSProvider.Enabled {
-			input := hooks.CustomSMSProviderInput{
+		if config.Hook.SendSMS.Enabled {
+			input := hooks.SendSMSInput{
 				UserID: user.ID,
 				Phone:  user.Phone.String(),
 				OTP:    otp,
 			}
-			output := hooks.CustomSMSProviderOutput{}
+			output := hooks.SendSMSOutput{}
 			err := a.invokeHTTPHook(ctx, r, &input, &output)
 			if err != nil {
 				return "", err

--- a/internal/conf/configuration.go
+++ b/internal/conf/configuration.go
@@ -451,7 +451,7 @@ type HookConfiguration struct {
 	MFAVerificationAttempt      ExtensibilityPointConfiguration `json:"mfa_verification_attempt" split_words:"true"`
 	PasswordVerificationAttempt ExtensibilityPointConfiguration `json:"password_verification_attempt" split_words:"true"`
 	CustomAccessToken           ExtensibilityPointConfiguration `json:"custom_access_token" split_words:"true"`
-	CustomSMSProvider           ExtensibilityPointConfiguration `json:"custom_sms_provider" split_words:"true"`
+	SendSMS           ExtensibilityPointConfiguration `json:"custom_sms_provider" split_words:"true"`
 }
 
 type HTTPHookSecrets []string
@@ -480,7 +480,7 @@ func (h *HookConfiguration) Validate() error {
 		h.MFAVerificationAttempt,
 		h.PasswordVerificationAttempt,
 		h.CustomAccessToken,
-		h.CustomSMSProvider,
+		h.SendSMS,
 	}
 	for _, point := range points {
 		if err := point.ValidateExtensibilityPoint(); err != nil {
@@ -582,8 +582,8 @@ func LoadGlobal(filename string) (*GlobalConfiguration, error) {
 		}
 	}
 
-	if config.Hook.CustomSMSProvider.Enabled {
-		if err := config.Hook.CustomSMSProvider.PopulateExtensibilityPoint(); err != nil {
+	if config.Hook.SendSMS.Enabled {
+		if err := config.Hook.SendSMS.PopulateExtensibilityPoint(); err != nil {
 			return nil, err
 		}
 	}

--- a/internal/conf/configuration.go
+++ b/internal/conf/configuration.go
@@ -451,7 +451,7 @@ type HookConfiguration struct {
 	MFAVerificationAttempt      ExtensibilityPointConfiguration `json:"mfa_verification_attempt" split_words:"true"`
 	PasswordVerificationAttempt ExtensibilityPointConfiguration `json:"password_verification_attempt" split_words:"true"`
 	CustomAccessToken           ExtensibilityPointConfiguration `json:"custom_access_token" split_words:"true"`
-	SendSMS                     ExtensibilityPointConfiguration `json:"custom_sms_provider" split_words:"true"`
+	SendSMS                     ExtensibilityPointConfiguration `json:"send_sms" split_words:"true"`
 }
 
 type HTTPHookSecrets []string

--- a/internal/conf/configuration.go
+++ b/internal/conf/configuration.go
@@ -451,7 +451,7 @@ type HookConfiguration struct {
 	MFAVerificationAttempt      ExtensibilityPointConfiguration `json:"mfa_verification_attempt" split_words:"true"`
 	PasswordVerificationAttempt ExtensibilityPointConfiguration `json:"password_verification_attempt" split_words:"true"`
 	CustomAccessToken           ExtensibilityPointConfiguration `json:"custom_access_token" split_words:"true"`
-	SendSMS           ExtensibilityPointConfiguration `json:"custom_sms_provider" split_words:"true"`
+	SendSMS                     ExtensibilityPointConfiguration `json:"custom_sms_provider" split_words:"true"`
 }
 
 type HTTPHookSecrets []string

--- a/internal/hooks/auth_hooks.go
+++ b/internal/hooks/auth_hooks.go
@@ -139,13 +139,13 @@ type CustomAccessTokenOutput struct {
 	HookError AuthHookError          `json:"error,omitempty"`
 }
 
-type CustomSMSProviderInput struct {
+type SendSMSInput struct {
 	UserID uuid.UUID `json:"user_id"`
 	Phone  string    `json:"phone"`
 	OTP    string    `json:"otp"`
 }
 
-type CustomSMSProviderOutput struct {
+type SendSMSOutput struct {
 	Success   bool          `json:"success"`
 	HookError AuthHookError `json:"error,omitempty"`
 }
@@ -174,15 +174,15 @@ func (ca *CustomAccessTokenOutput) Error() string {
 	return ca.HookError.Message
 }
 
-func (cs *CustomSMSProviderOutput) IsError() bool {
+func (cs *SendSMSOutput) IsError() bool {
 	return cs.HookError.Message != ""
 }
 
-func (cs *CustomSMSProviderOutput) Error() string {
+func (cs *SendSMSOutput) Error() string {
 	return cs.HookError.Message
 }
 
-func (cs *CustomSMSProviderOutput) IsHTTPHook() bool {
+func (cs *SendSMSOutput) IsHTTPHook() bool {
 	return true
 }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

We are renaming `CustomEmailProvider` to `SendEmail`. For consistency, I guess we should rename `CustomSMSProvider` to `SendSMS`. More context in #1496 

This should be fine since [the PR to add env configs for this hook](https://github.com/supabase/infrastructure/pull/17604) has not landed in prod
