### PR TITLE
fix: generate signup link should not error

### DIFF
--- a/internal/api/mail.go
+++ b/internal/api/mail.go
@@ -1,10 +1,11 @@
 package api
 
 import (
-	mail "github.com/supabase/auth/internal/mailer"
 	"net/http"
 	"strings"
 	"time"
+
+	mail "github.com/supabase/auth/internal/mailer"
 
 	"github.com/badoux/checkmail"
 	"github.com/fatih/structs"
@@ -72,8 +73,7 @@ func (a *API) adminGenerateLink(w http.ResponseWriter, r *http.Request) error {
 					// password generation must always succeed
 					panic(err)
 				}
-
-			default:
+			case mail.RecoveryVerification, mail.EmailChangeCurrentVerification, mail.EmailChangeNewVerification:
 				return notFoundError(ErrorCodeUserNotFound, "User with this email not found")
 			}
 		} else {

--- a/internal/api/mail_test.go
+++ b/internal/api/mail_test.go
@@ -65,7 +65,19 @@ func (ts *MailTestSuite) TestGenerateLink() {
 		ExpectedResponse map[string]interface{}
 	}{
 		{
-			Desc: "Generate signup link",
+			Desc: "Generate signup link for new user",
+			Body: GenerateLinkParams{
+				Email:    "new_user@example.com",
+				Password: "secret123",
+				Type:     "signup",
+			},
+			ExpectedCode: http.StatusOK,
+			ExpectedResponse: map[string]interface{}{
+				"redirect_to": ts.Config.SiteURL,
+			},
+		},
+		{
+			Desc: "Generate signup link for existing user",
 			Body: GenerateLinkParams{
 				Email:    "test@example.com",
 				Password: "secret123",


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Fixes an error introduced in #1377 where generating a signup link for a new user results in a "User with this email not found" error
Bug fix, feature, docs update, ...

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
