### PR TITLE
fix: remove deprecated LogoutAllRefreshTokens

### DIFF
--- a/internal/api/admin.go
+++ b/internal/api/admin.go
@@ -500,10 +500,6 @@ func (a *API) adminUserDelete(w http.ResponseWriter, r *http.Request) error {
 			if terr := models.Logout(tx, user.ID); terr != nil {
 				return internalServerError("Error deleting user's sessions").WithInternalError(terr)
 			}
-			// for backward compatibility: hard delete all associated refresh tokens
-			if terr := models.LogoutAllRefreshTokens(tx, user.ID); terr != nil {
-				return internalServerError("Error deleting user's refresh tokens").WithInternalError(terr)
-			}
 		} else {
 			if terr := tx.Destroy(user); terr != nil {
 				return internalServerError("Database error deleting user").WithInternalError(terr)

--- a/internal/api/logout.go
+++ b/internal/api/logout.go
@@ -48,10 +48,6 @@ func (a *API) Logout(w http.ResponseWriter, r *http.Request) error {
 			return terr
 		}
 
-		if s == nil {
-			return models.LogoutAllRefreshTokens(tx, u.ID)
-		}
-
 		switch scope {
 		case LogoutLocal:
 			return models.LogoutSession(tx, s.ID)

--- a/internal/models/refresh_token.go
+++ b/internal/models/refresh_token.go
@@ -164,9 +164,3 @@ func createRefreshToken(tx *storage.Connection, user *User, oldToken *RefreshTok
 	}
 	return token, nil
 }
-
-// Deprecated. For backward compatibility, some access tokens may not have a sessionId. Use models.Logout instead.
-// LogoutAllRefreshTokens deletes all sessions for a user.
-func LogoutAllRefreshTokens(tx *storage.Connection, userId uuid.UUID) error {
-	return tx.RawQuery("DELETE FROM "+(&pop.Model{Value: RefreshToken{}}).TableName()+" WHERE instance_id = ? and user_id = ?", uuid.Nil, userId).Exec()
-}


### PR DESCRIPTION
## What kind of change does this PR introduce?
As all access tokens should have an associated ID, we should now be able to delete the deprecated code.
