### PR TITLE
feat: allow aliases on local development

### DIFF
--- a/internal/conf/configuration.go
+++ b/internal/conf/configuration.go
@@ -637,6 +637,9 @@ func (e *ExtensibilityPointConfiguration) ValidateExtensibilityPoint(allowedHTTP
 		return validatePostgresPath(u)
 	case "http":
 		hostname := u.Hostname()
+		if len(allowedHTTPHostNames) == 0 {
+			allowedHTTPHostNames = []string{"localhost", "127.0.0.1", "::1", "host.docker.internal"}
+		}
 		if isStringInSlice(hostname, allowedHTTPHostNames) {
 			return validateHTTPHookSecrets(e.HTTPHookSecrets)
 		}

--- a/internal/conf/configuration.go
+++ b/internal/conf/configuration.go
@@ -627,7 +627,7 @@ func (e *ExtensibilityPointConfiguration) ValidateExtensibilityPoint() error {
 		return validatePostgresPath(u)
 	case "http":
 		hostname := u.Hostname()
-		if hostname == "localhost" || hostname == "127.0.0.1" || hostname == "::1" || hostname == "host.docker.internal" {
+		if hostname == "localhost" || hostname == "127.0.0.1" || hostname == "::1" || hostname == "host.docker.internal" || hostname == "kong" || hostname == "edge_runtime" {
 			return validateHTTPHookSecrets(e.HTTPHookSecrets)
 		}
 		return fmt.Errorf("only localhost, 127.0.0.1, and ::1 are supported with http")

--- a/internal/conf/configuration_test.go
+++ b/internal/conf/configuration_test.go
@@ -155,6 +155,14 @@ func TestHTTPHookSecretsDecode(t *testing.T) {
 }
 
 func TestValidateExtensibilityPointURI(t *testing.T) {
+	allowedLocalHostNames := []string{
+		"localhost",
+		"127.0.0.1",
+		"::1",
+		"host.docker.internal",
+		"kong",
+		"edge_runtime",
+	}
 	cases := []struct {
 		desc        string
 		uri         string
@@ -168,7 +176,7 @@ func TestValidateExtensibilityPointURI(t *testing.T) {
 		{desc: "Another Valid URI", uri: "pg-functions://postgres/MySpeCial/FUNCTION_THAT_YELLS_AT_YOU", expectError: false},
 		{desc: "Valid HTTP URI", uri: "http://localhost/functions/v1/custom-sms-sender", expectError: false},
 		{desc: "Valid localhost URI with kong alias", uri: "http://kong:8000/functions/v1/custom-sms-sender", expectError: false},
-		{desc: "Valid localhost URI with edge_runtime", uri: "http://edge_runtime:8000/functions/v1/custom-sms-sender", expectError: false},
+		{desc: "Valid localhost URI with edge_runtime", uri: "http://edge_runtime:54321/functions/v1/custom-sms-sender", expectError: false},
 
 		// Negative test cases
 		{desc: "Invalid HTTP URI", uri: "http://asdfgggg.website.co/functions/v1/custom-sms-sender", expectError: true},
@@ -180,7 +188,7 @@ func TestValidateExtensibilityPointURI(t *testing.T) {
 
 	for _, tc := range cases {
 		ep := ExtensibilityPointConfiguration{URI: tc.uri}
-		err := ep.ValidateExtensibilityPoint()
+		err := ep.ValidateExtensibilityPoint(allowedLocalHostNames)
 		if tc.expectError {
 			require.Error(t, err)
 		} else {
@@ -206,8 +214,9 @@ func TestValidateExtensibilityPointSecrets(t *testing.T) {
 		{desc: "Invalid Symmetric Secret", secret: []string{"tommy"}, expectError: true},
 	}
 	for _, tc := range cases {
+		allowedLocalHostNames := []string{}
 		ep := ExtensibilityPointConfiguration{URI: validHTTPSURI, HTTPHookSecrets: tc.secret}
-		err := ep.ValidateExtensibilityPoint()
+		err := ep.ValidateExtensibilityPoint(allowedLocalHostNames)
 		if tc.expectError {
 			require.Error(t, err)
 		} else {

--- a/internal/conf/configuration_test.go
+++ b/internal/conf/configuration_test.go
@@ -167,6 +167,8 @@ func TestValidateExtensibilityPointURI(t *testing.T) {
 		{desc: "Another Valid URI", uri: "pg-functions://postgres/user_management/add_user", expectError: false},
 		{desc: "Another Valid URI", uri: "pg-functions://postgres/MySpeCial/FUNCTION_THAT_YELLS_AT_YOU", expectError: false},
 		{desc: "Valid HTTP URI", uri: "http://localhost/functions/v1/custom-sms-sender", expectError: false},
+		{desc: "Valid localhost URI with kong alias", uri: "http://kong:8000/functions/v1/custom-sms-sender", expectError: false},
+		{desc: "Valid localhost URI with edge_runtime", uri: "http://edge_runtime:8000/functions/v1/custom-sms-sender", expectError: false},
 
 		// Negative test cases
 		{desc: "Invalid HTTP URI", uri: "http://asdfgggg.website.co/functions/v1/custom-sms-sender", expectError: true},


### PR DESCRIPTION
## What kind of change does this PR introduce?

Allow developers to use aliases such as kong and edge_functions for local development as `host.docker.internal` might not be compatible on all platforms

Link: https://github.com/supabase/cli/pull/2129#discussion_r1557894821

By default, we allow the following HTTP HostNames: localhost, 127.0.0.1, ::1, host.docker.internal.