### PR TITLE
feat: add array attribute mapping for SAML

### DIFF
--- a/internal/api/samlassertion.go
+++ b/internal/api/samlassertion.go
@@ -128,9 +128,18 @@ func (a *SAMLAssertion) Process(mapping models.SAMLAttributeMapping) map[string]
 		for _, name := range names {
 			for _, attr := range a.Attribute(name) {
 				if attr.Value != "" {
-					ret[key] = attr.Value
 					setKey = true
-					break
+
+					if mapper.Array {
+						if ret[key] == nil {
+							ret[key] = []string{}
+						}
+
+						ret[key] = append(ret[key].([]string), attr.Value)
+					} else {
+						ret[key] = attr.Value
+						break
+					}
 				}
 			}
 

--- a/internal/api/samlassertion_test.go
+++ b/internal/api/samlassertion_test.go
@@ -204,6 +204,42 @@ func TestSAMLAssertionProcessing(t *tst.T) {
 				"email": "soap@example.com",
 			},
 		},
+		{
+			xml: `<?xml version="1.0" encoding="UTF-8"?>
+<saml2:Assertion xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion" xmlns:xsd="http://www.w3.org/2001/XMLSchema" ID="_72591c79da230cac1457d0ea0f2771ab" IssueInstant="2022-08-11T14:53:38.260Z" Version="2.0">
+	<saml2:AttributeStatement>
+		<saml2:Attribute Name="http://whatever.com/groups" FriendlyName="groups" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:string">
+			<saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xsd:string">group1</saml2:AttributeValue>
+			<saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xsd:string">group2</saml2:AttributeValue>
+		</saml2:Attribute>
+		<saml2:Attribute Name="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress" FriendlyName="mail" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
+			<saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xsd:string">soap@example.com</saml2:AttributeValue>
+		</saml2:Attribute>
+	</saml2:AttributeStatement>
+</saml2:Assertion>
+`,
+			mapping: models.SAMLAttributeMapping{
+				Keys: map[string]models.SAMLAttribute{
+					"email": {
+						Names: []string{
+							"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress",
+							"http://schemas.xmlsoap.org/claims/EmailAddress",
+						},
+					},
+					"groups": {
+						Name:  "groups",
+						Array: true,
+					},
+				},
+			},
+			expected: map[string]interface{}{
+				"email": "soap@example.com",
+				"groups": []string{
+					"group1",
+					"group2",
+				},
+			},
+		},
 	}
 
 	for i, example := range examples {

--- a/internal/models/sso.go
+++ b/internal/models/sso.go
@@ -36,6 +36,7 @@ type SAMLAttribute struct {
 	Name    string      `json:"name,omitempty"`
 	Names   []string    `json:"names,omitempty"`
 	Default interface{} `json:"default,omitempty"`
+	Array   bool        `json:"array,omitempty"`
 }
 
 type SAMLAttributeMapping struct {
@@ -76,6 +77,10 @@ func (m *SAMLAttributeMapping) Equal(o *SAMLAttributeMapping) bool {
 		}
 
 		if mvalue.Default != value.Default {
+			return false
+		}
+
+		if mvalue.Array != value.Array {
 			return false
 		}
 	}


### PR DESCRIPTION
By adding the `"array": true` option in the JSON SAML attribute mapping document for a key, the SAML attribute(s) for that key will be represented as an array in the user identity claims.