### PR TITLE
feat: allow for postgres and http functions on each extensibility point

### DIFF
--- a/internal/api/hooks.go
+++ b/internal/api/hooks.go
@@ -145,7 +145,7 @@ func (a *API) runHTTPHook(r *http.Request, hookConfig conf.ExtensibilityPointCon
 			return nil, internalServerError("Invalid Content-Type header")
 		}
 		if mediaType != "application/json" {
-			return nil, internalServerError("Expected JSON response from hook, received: " + contentType)
+			return nil, internalServerError("Invalid JSON response. Received content-type: " + contentType)
 		}
 
 		switch rsp.StatusCode {

--- a/internal/api/hooks.go
+++ b/internal/api/hooks.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
@@ -31,7 +32,7 @@ const (
 	PayloadLimit            = 200 * 1024 // 200KB
 )
 
-func (a *API) runPostgresHook(ctx context.Context, tx *storage.Connection, name string, input, output any) ([]byte, error) {
+func (a *API) runPostgresHook(ctx context.Context, tx *storage.Connection, hookConfig conf.ExtensibilityPointConfiguration, input, output any) ([]byte, error) {
 	db := a.db.WithContext(ctx)
 
 	request, err := json.Marshal(input)
@@ -46,7 +47,7 @@ func (a *API) runPostgresHook(ctx context.Context, tx *storage.Connection, name 
 			return terr
 		}
 
-		if terr := tx.RawQuery(fmt.Sprintf("select %s(?);", name), request).First(&response); terr != nil {
+		if terr := tx.RawQuery(fmt.Sprintf("select %s(?);", hookConfig.HookName), request).First(&response); terr != nil {
 			return terr
 		}
 
@@ -75,7 +76,8 @@ func (a *API) runPostgresHook(ctx context.Context, tx *storage.Connection, name 
 	return response, nil
 }
 
-func (a *API) runHTTPHook(ctx context.Context, r *http.Request, hookConfig conf.ExtensibilityPointConfiguration, input, output any) ([]byte, error) {
+func (a *API) runHTTPHook(r *http.Request, hookConfig conf.ExtensibilityPointConfiguration, input, output any) ([]byte, error) {
+	ctx := r.Context()
 	client := http.Client{
 		Timeout: DefaultHTTPHookTimeout,
 	}
@@ -172,67 +174,54 @@ func (a *API) runHTTPHook(ctx context.Context, r *http.Request, hookConfig conf.
 	return nil, nil
 }
 
-func (a *API) invokeHTTPHook(ctx context.Context, r *http.Request, input, output any) error {
+// invokePostgresHook invokes the hook code. conn can be nil, in which case a new
+// transaction is opened. If calling invokeHook within a transaction, always
+// pass the current transaction, as pool-exhaustion deadlocks are very easy to
+// trigger.
+func (a *API) invokeHook(conn *storage.Connection, r *http.Request, input, output any, uri string) error {
+	var err error
+	var response []byte
+	u, err := url.Parse(uri)
+	if err != nil {
+		return err
+	}
+
 	switch input.(type) {
 	case *hooks.SendSMSInput:
 		hookOutput, ok := output.(*hooks.SendSMSOutput)
 		if !ok {
 			panic("output should be *hooks.SendSMSOutput")
 		}
-		var response []byte
-		var err error
-
-		if response, err = a.runHTTPHook(ctx, r, a.config.Hook.SendSMS, input, output); err != nil {
-			return internalServerError("Error invoking Send SMS hook.").WithInternalError(err)
+		if response, err = a.runHook(r, conn, a.config.Hook.SendSMS, input, output, u.Scheme); err != nil {
+			return err
 		}
-
 		if err := json.Unmarshal(response, hookOutput); err != nil {
 			return internalServerError("Error unmarshaling Send SMS output.").WithInternalError(err)
 		}
+		if hookOutput.IsError() {
+			httpCode := hookOutput.HookError.HTTPCode
+
+			if httpCode == 0 {
+				httpCode = http.StatusInternalServerError
+			}
+			httpError := &HTTPError{
+				HTTPStatus: httpCode,
+				Message:    hookOutput.HookError.Message,
+			}
+			return httpError.WithInternalError(&hookOutput.HookError)
+		}
+		return nil
 	case *hooks.SendEmailInput:
 		hookOutput, ok := output.(*hooks.SendEmailOutput)
 		if !ok {
 			panic("output should be *hooks.SendEmailOutput")
 		}
-
-		var response []byte
-		var err error
-
-		if response, err = a.runHTTPHook(ctx, r, a.config.Hook.SendEmail, input, output); err != nil {
-			return internalServerError("Error invoking Send Email hook.").WithInternalError(err)
-		}
-		if err != nil {
+		if response, err = a.runHook(r, conn, a.config.Hook.SendEmail, input, output, u.Scheme); err != nil {
 			return err
 		}
-
 		if err := json.Unmarshal(response, hookOutput); err != nil {
-			return internalServerError("Error unmarshaling Send Email hook output.").WithInternalError(err)
+			return internalServerError("Error unmarshaling Send Email output.").WithInternalError(err)
 		}
-
-	default:
-		panic("unknown HTTP hook type")
-	}
-	return nil
-}
-
-// invokePostgresHook invokes the hook code. tx can be nil, in which case a new
-// transaction is opened. If calling invokeHook within a transaction, always
-// pass the current transaction, as pool-exhaustion deadlocks are very easy to
-// trigger.
-func (a *API) invokePostgresHook(ctx context.Context, conn *storage.Connection, input, output any) error {
-	config := a.config
-	// Switch based on hook type
-	switch input.(type) {
-	case *hooks.MFAVerificationAttemptInput:
-		hookOutput, ok := output.(*hooks.MFAVerificationAttemptOutput)
-		if !ok {
-			panic("output should be *hooks.MFAVerificationAttemptOutput")
-		}
-
-		if _, err := a.runPostgresHook(ctx, conn, config.Hook.MFAVerificationAttempt.HookName, input, output); err != nil {
-			return internalServerError("Error invoking MFA verification hook.").WithInternalError(err)
-		}
-
 		if hookOutput.IsError() {
 			httpCode := hookOutput.HookError.HTTPCode
 
@@ -247,7 +236,32 @@ func (a *API) invokePostgresHook(ctx context.Context, conn *storage.Connection, 
 
 			return httpError.WithInternalError(&hookOutput.HookError)
 		}
+		return nil
+	case *hooks.MFAVerificationAttemptInput:
+		hookOutput, ok := output.(*hooks.MFAVerificationAttemptOutput)
+		if !ok {
+			panic("output should be *hooks.MFAVerificationAttemptOutput")
+		}
+		if response, err = a.runHook(r, conn, a.config.Hook.MFAVerificationAttempt, input, output, u.Scheme); err != nil {
+			return err
+		}
+		if err := json.Unmarshal(response, hookOutput); err != nil {
+			return internalServerError("Error unmarshaling MFA Verification Attempt output.").WithInternalError(err)
+		}
+		if hookOutput.IsError() {
+			httpCode := hookOutput.HookError.HTTPCode
 
+			if httpCode == 0 {
+				httpCode = http.StatusInternalServerError
+			}
+
+			httpError := &HTTPError{
+				HTTPStatus: httpCode,
+				Message:    hookOutput.HookError.Message,
+			}
+
+			return httpError.WithInternalError(&hookOutput.HookError)
+		}
 		return nil
 	case *hooks.PasswordVerificationAttemptInput:
 		hookOutput, ok := output.(*hooks.PasswordVerificationAttemptOutput)
@@ -255,10 +269,12 @@ func (a *API) invokePostgresHook(ctx context.Context, conn *storage.Connection, 
 			panic("output should be *hooks.PasswordVerificationAttemptOutput")
 		}
 
-		if _, err := a.runPostgresHook(ctx, conn, config.Hook.PasswordVerificationAttempt.HookName, input, output); err != nil {
-			return internalServerError("Error invoking password verification hook.").WithInternalError(err)
+		if response, err = a.runHook(r, conn, a.config.Hook.PasswordVerificationAttempt, input, output, u.Scheme); err != nil {
+			return err
 		}
-
+		if err := json.Unmarshal(response, hookOutput); err != nil {
+			return internalServerError("Error unmarshaling Password Verification Attempt output.").WithInternalError(err)
+		}
 		if hookOutput.IsError() {
 			httpCode := hookOutput.HookError.HTTPCode
 
@@ -280,9 +296,11 @@ func (a *API) invokePostgresHook(ctx context.Context, conn *storage.Connection, 
 		if !ok {
 			panic("output should be *hooks.CustomAccessTokenOutput")
 		}
-
-		if _, err := a.runPostgresHook(ctx, conn, config.Hook.CustomAccessToken.HookName, input, output); err != nil {
-			return internalServerError("Error invoking access token hook.").WithInternalError(err)
+		if response, err = a.runHook(r, conn, a.config.Hook.CustomAccessToken, input, output, u.Scheme); err != nil {
+			return err
+		}
+		if err := json.Unmarshal(response, hookOutput); err != nil {
+			return internalServerError("Error unmarshaling Custom Access Token output.").WithInternalError(err)
 		}
 
 		if hookOutput.IsError() {
@@ -305,7 +323,6 @@ func (a *API) invokePostgresHook(ctx context.Context, conn *storage.Connection, 
 			if httpCode == 0 {
 				httpCode = http.StatusInternalServerError
 			}
-
 			httpError := &HTTPError{
 				HTTPStatus: httpCode,
 				Message:    err.Error(),
@@ -314,8 +331,25 @@ func (a *API) invokePostgresHook(ctx context.Context, conn *storage.Connection, 
 			return httpError
 		}
 		return nil
-
-	default:
-		panic("unknown Postgres hook input type")
 	}
+	return nil
+}
+
+func (a *API) runHook(r *http.Request, conn *storage.Connection, hookConfig conf.ExtensibilityPointConfiguration, input, output any, scheme string) ([]byte, error) {
+	ctx := r.Context()
+	var response []byte
+	var err error
+	switch strings.ToLower(scheme) {
+	case "http", "https":
+		response, err = a.runHTTPHook(r, hookConfig, input, output)
+
+	case "pg-functions":
+		response, err = a.runPostgresHook(ctx, conn, hookConfig, input, output)
+	default:
+		return nil, fmt.Errorf("unsupported protocol: %v only postgres hooks and HTTPS functions are supported at the moment", scheme)
+	}
+	if err != nil {
+		return nil, internalServerError("Error running hook URI: %v", hookConfig.URI).WithInternalError(err)
+	}
+	return response, nil
 }

--- a/internal/api/hooks_test.go
+++ b/internal/api/hooks_test.go
@@ -129,14 +129,14 @@ func (ts *HooksTestSuite) TestShouldRetryWithRetryAfterHeader() {
 		Post("/").
 		MatchType("json").
 		Reply(http.StatusTooManyRequests).
-		SetHeader("retry-after", "true").SetHeader("content-length", "21")
+		SetHeader("retry-after", "true").SetHeader("content-type", "application/json")
 
 	// Simulate an additional response for the retry attempt
 	gock.New(testURL).
 		Post("/").
 		MatchType("json").
 		Reply(http.StatusOK).
-		JSON(successOutput).SetHeader("content-length", "21")
+		JSON(successOutput).SetHeader("content-type", "application/json")
 
 	var output hooks.SendSMSOutput
 
@@ -169,20 +169,19 @@ func (ts *HooksTestSuite) TestInvokeHookIntegration() {
 	testHTTPUri := "http://myauthservice.com/signup"
 	testHTTPSUri := "https://myauthservice.com/signup"
 	testPGUri := "pg-functions://postgres/auth/invoke_test"
-	mockContentLength := "20"
 	successOutput := map[string]interface{}{}
 	authEndpoint := "https://app.myapp.com/otp"
 	gock.New(testHTTPUri).
 		Post("/").
 		MatchType("json").
 		Reply(http.StatusOK).
-		JSON(successOutput).SetHeader("content-length", mockContentLength)
+		JSON(successOutput).SetHeader("content-type", "application/json")
 
 	gock.New(testHTTPSUri).
 		Post("/").
 		MatchType("json").
 		Reply(http.StatusOK).
-		JSON(successOutput).SetHeader("content-length", mockContentLength)
+		JSON(successOutput).SetHeader("content-type", "application/json")
 
 	tests := []struct {
 		description   string

--- a/internal/api/mfa.go
+++ b/internal/api/mfa.go
@@ -242,8 +242,7 @@ func (a *API) VerifyFactor(w http.ResponseWriter, r *http.Request) error {
 		}
 
 		output := hooks.MFAVerificationAttemptOutput{}
-
-		err := a.invokePostgresHook(ctx, nil, &input, &output)
+		err := a.invokeHook(nil, r, &input, &output, a.config.Hook.MFAVerificationAttempt.URI)
 		if err != nil {
 			return err
 		}

--- a/internal/api/phone.go
+++ b/internal/api/phone.go
@@ -102,7 +102,7 @@ func (a *API) sendPhoneConfirmation(ctx context.Context, r *http.Request, tx *st
 				OTP:    otp,
 			}
 			output := hooks.SendSMSOutput{}
-			err := a.invokeHTTPHook(ctx, r, &input, &output)
+			err := a.invokeHook(tx, r, &input, &output, a.config.Hook.SendSMS.URI)
 			if err != nil {
 				return "", err
 			}

--- a/internal/api/phone_test.go
+++ b/internal/api/phone_test.go
@@ -141,6 +141,9 @@ func doTestSendPhoneConfirmation(ts *PhoneTestSuite, useTestOTP bool) {
 			}
 		})
 	}
+	// Reset at end of test
+	ts.API.config.Sms.TestOTP = nil
+
 }
 
 func (ts *PhoneTestSuite) TestSendPhoneConfirmation() {
@@ -260,4 +263,186 @@ func (ts *PhoneTestSuite) TestMissingSmsProviderConfig() {
 			})
 		}
 	}
+}
+func (ts *PhoneTestSuite) TestSendSMSHook() {
+	u, err := models.FindUserByPhoneAndAudience(ts.API.db, "123456789", ts.Config.JWT.Aud)
+	require.NoError(ts.T(), err)
+	now := time.Now()
+	u.PhoneConfirmedAt = &now
+	require.NoError(ts.T(), ts.API.db.Update(u), "Error updating new test user")
+
+	s, err := models.NewSession(u.ID, nil)
+	require.NoError(ts.T(), err)
+	require.NoError(ts.T(), ts.API.db.Create(s))
+
+	req := httptest.NewRequest(http.MethodPost, "/token?grant_type=password", nil)
+	token, _, err := ts.API.generateAccessToken(req, ts.API.db, u, &s.ID, models.PasswordGrant)
+	require.NoError(ts.T(), err)
+
+	// We setup a job table to enqueue SMS requests to send. Similar in spirit to the pg_boss postgres extension
+	createJobsTableSQL := `CREATE TABLE job_queue (
+    id serial PRIMARY KEY,
+    job_type text,
+    payload jsonb,
+    status text DEFAULT 'pending', -- Possible values: 'pending', 'processing', 'completed', 'failed'
+    created_at timestamp without time zone DEFAULT NOW()
+    );`
+	require.NoError(ts.T(), ts.API.db.RawQuery(createJobsTableSQL).Exec())
+
+	type sendSMSHookTestCase struct {
+		desc                   string
+		uri                    string
+		endpoint               string
+		method                 string
+		header                 string
+		body                   map[string]string
+		hookFunctionSQL        string
+		expectedCode           int
+		expectToken            bool
+		hookFunctionIdentifier string
+	}
+	cases := []sendSMSHookTestCase{
+		{
+			desc:     "Phone signup using Hook",
+			endpoint: "/signup",
+			method:   http.MethodPost,
+			uri:      "pg-functions://postgres/auth/send_sms_signup",
+			hookFunctionSQL: `
+                create or replace function send_sms_signup(input jsonb)
+                returns json as $$
+                begin
+                  insert into job_queue(job_type, payload)
+                  values ('sms_signup', input);
+                    return input;
+                end; $$ language plpgsql;`,
+			header: "",
+			body: map[string]string{
+				"phone":    "1234567890",
+				"password": "testpassword",
+			},
+			expectedCode:           http.StatusOK,
+			hookFunctionIdentifier: "send_sms_signup(input jsonb)",
+		},
+		{
+			desc:     "SMS OTP sign in using hook",
+			endpoint: "/otp",
+			method:   http.MethodPost,
+			uri:      "pg-functions://postgres/auth/send_sms_otp",
+			hookFunctionSQL: `
+                create or replace function send_sms_otp(input jsonb)
+                returns json as $$
+                begin
+                  insert into job_queue(job_type, payload)
+                  values ('sms_signup', input);
+                    return input;
+                end; $$ language plpgsql;`,
+			header: "",
+			body: map[string]string{
+				"phone": "123456789",
+			},
+			expectToken:            false,
+			expectedCode:           http.StatusOK,
+			hookFunctionIdentifier: "send_sms_otp(input jsonb)",
+		},
+		{
+			desc:     "Phone Change",
+			endpoint: "/user",
+			method:   http.MethodPut,
+			uri:      "pg-functions://postgres/auth/send_sms_phone_change",
+			hookFunctionSQL: `
+        create or replace function send_sms_phone_change(input jsonb)
+        returns json as $$
+        begin
+           insert into job_queue(job_type, payload)
+           values ('phone_change', input);
+           return input;
+        end; $$ language plpgsql;`,
+			header: token,
+			body: map[string]string{
+				"phone": "111111111",
+			},
+			expectToken:            true,
+			expectedCode:           http.StatusOK,
+			hookFunctionIdentifier: "send_sms_phone_change(input jsonb)",
+		},
+		{
+			desc:     "Reauthenticate",
+			endpoint: "/reauthenticate",
+			method:   http.MethodGet,
+			uri:      "pg-functions://postgres/auth/reauthenticate",
+			hookFunctionSQL: `
+        create or replace function reauthenticate(input jsonb)
+        returns json as $$
+        begin
+            return input;
+       end; $$ language plpgsql;`,
+			header:                 "",
+			body:                   nil,
+			expectToken:            true,
+			expectedCode:           http.StatusOK,
+			hookFunctionIdentifier: "reauthenticate(input jsonb)",
+		},
+		{
+			desc:     "SMS OTP Hook (Error)",
+			endpoint: "/otp",
+			method:   http.MethodPost,
+			uri:      "pg-functions://postgres/auth/send_sms_otp_failure",
+			hookFunctionSQL: `
+                create or replace function send_sms_otp(input jsonb)
+                returns json as $$
+                begin
+                    RAISE EXCEPTION 'Intentional Error for Testing';
+                end; $$ language plpgsql;`,
+			header: "",
+			body: map[string]string{
+				"phone": "123456789",
+			},
+			expectToken:            false,
+			expectedCode:           http.StatusBadRequest,
+			hookFunctionIdentifier: "send_sms_otp_failure(input jsonb)",
+		},
+	}
+
+	for _, c := range cases {
+		ts.T().Run(c.desc, func(t *testing.T) {
+
+			ts.Config.External.Phone.Enabled = true
+			ts.Config.Hook.SendSMS.Enabled = true
+			ts.Config.Hook.SendSMS.URI = c.uri
+			// Disable FrequencyLimit to allow back to back sending
+			ts.Config.Sms.MaxFrequency = 0 * time.Second
+			// We still need a mock provider for hooks to work right now for backward compatibility
+			ts.Config.Sms.Provider = "twilio"
+			ts.Config.Sms.Twilio = conf.TwilioProviderConfiguration{
+				AccountSid:        "test_account_sid",
+				AuthToken:         "test_auth_token",
+				MessageServiceSid: "test_message_service_id",
+			}
+			require.NoError(ts.T(), ts.Config.Hook.SendSMS.PopulateExtensibilityPoint())
+
+			require.NoError(t, ts.API.db.RawQuery(c.hookFunctionSQL).Exec())
+
+			var buffer bytes.Buffer
+			require.NoError(ts.T(), json.NewEncoder(&buffer).Encode(c.body))
+			req := httptest.NewRequest(c.method, "http://localhost"+c.endpoint, &buffer)
+			req.Header.Set("Content-Type", "application/json")
+			req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
+
+			w := httptest.NewRecorder()
+			ts.API.handler.ServeHTTP(w, req)
+
+			require.Equal(t, c.expectedCode, w.Code, "Unexpected HTTP status code")
+
+			// Delete the function and reset env
+			cleanupHookSQL := fmt.Sprintf("drop function if exists %s", ts.Config.Hook.SendSMS.HookName)
+			require.NoError(t, ts.API.db.RawQuery(cleanupHookSQL).Exec())
+			ts.Config.Hook.SendSMS.Enabled = false
+			ts.Config.Sms.MaxFrequency = 1 * time.Second
+		})
+	}
+
+	// Cleanup
+	deleteJobsTableSQL := `drop table if exists job_queue`
+	require.NoError(ts.T(), ts.API.db.RawQuery(deleteJobsTableSQL).Exec())
+
 }

--- a/internal/api/token.go
+++ b/internal/api/token.go
@@ -164,7 +164,7 @@ func (a *API) ResourceOwnerPasswordGrant(ctx context.Context, w http.ResponseWri
 			Valid:  isValidPassword,
 		}
 		output := hooks.PasswordVerificationAttemptOutput{}
-		err := a.invokePostgresHook(ctx, nil, &input, &output)
+		err := a.invokeHook(nil, r, &input, &output, a.config.Hook.PasswordVerificationAttempt.URI)
 		if err != nil {
 			return err
 		}
@@ -292,7 +292,6 @@ func (a *API) PKCE(ctx context.Context, w http.ResponseWriter, r *http.Request) 
 }
 
 func (a *API) generateAccessToken(r *http.Request, tx *storage.Connection, user *models.User, sessionId *uuid.UUID, authenticationMethod models.AuthenticationMethod) (string, int64, error) {
-	ctx := r.Context()
 	config := a.config
 	if sessionId == nil {
 		return "", 0, internalServerError("Session is required to issue access token")
@@ -339,7 +338,7 @@ func (a *API) generateAccessToken(r *http.Request, tx *storage.Connection, user 
 
 		output := hooks.CustomAccessTokenOutput{}
 
-		err := a.invokePostgresHook(ctx, tx, &input, &output)
+		err := a.invokeHook(tx, r, &input, &output, a.config.Hook.CustomAccessToken.URI)
 		if err != nil {
 			return "", 0, err
 		}

--- a/internal/conf/configuration.go
+++ b/internal/conf/configuration.go
@@ -552,8 +552,10 @@ func (e *ExtensibilityPointConfiguration) PopulateExtensibilityPoint() error {
 	if err != nil {
 		return err
 	}
-	pathParts := strings.Split(u.Path, "/")
-	e.HookName = fmt.Sprintf("%q.%q", pathParts[1], pathParts[2])
+	if u.Scheme == "pg-functions" {
+		pathParts := strings.Split(u.Path, "/")
+		e.HookName = fmt.Sprintf("%q.%q", pathParts[1], pathParts[2])
+	}
 	return nil
 }
 

--- a/internal/hooks/auth_hooks.go
+++ b/internal/hooks/auth_hooks.go
@@ -193,8 +193,12 @@ func (cs *SendSMSOutput) Error() string {
 	return cs.HookError.Message
 }
 
-func (cs *SendSMSOutput) IsHTTPHook() bool {
-	return true
+func (cs *SendEmailOutput) IsError() bool {
+	return cs.HookError.Message != ""
+}
+
+func (cs *SendEmailOutput) Error() string {
+	return cs.HookError.Message
 }
 
 type AuthHookError struct {


### PR DESCRIPTION
## What kind of change does this PR introduce?

After this change, users can opt to use either Postgres or HTTP functions on each extensibility/extension point. From an implementation standpoint, all  new extension points must support both HTTP and Postgres functions