### PR TITLE
feat: add timeout middleware

### DIFF
--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -235,6 +235,17 @@ func (a *API) requireManualLinkingEnabled(w http.ResponseWriter, req *http.Reque
 	return ctx, nil
 }
 
+func (a *API) timeoutMiddleware(timeout time.Duration) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			ctx, cancel := context.WithTimeout(r.Context(), timeout)
+			defer cancel()
+
+			next.ServeHTTP(w, r.WithContext(ctx))
+		})
+	}
+}
+
 func (a *API) databaseCleanup(cleanup *models.Cleanup) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## What kind of change does this PR introduce?

We want to set internal timeout for Auth so that  long running
- We can break connection early so that Kong doesn't have to break the timeout
- We have a circuit breaker in that long running requests timeout instead of piling up when service is under load