### PR TITLE
fix: remove unneeded database calls

### DIFF
--- a/internal/api/mfa.go
+++ b/internal/api/mfa.go
@@ -281,10 +281,6 @@ func (a *API) VerifyFactor(w http.ResponseWriter, r *http.Request) error {
 				return terr
 			}
 		}
-		user, terr = models.FindUserByID(tx, user.ID)
-		if terr != nil {
-			return terr
-		}
 		token, terr = a.updateMFASessionAndClaims(r, tx, user, models.TOTPSignIn, models.GrantParams{
 			FactorID: &factor.ID,
 		})

--- a/internal/api/token.go
+++ b/internal/api/token.go
@@ -434,7 +434,7 @@ func (a *API) updateMFASessionAndClaims(r *http.Request, tx *storage.Connection,
 		if terr != nil {
 			return terr
 		}
-		currentToken, terr := models.FindTokenBySessionID(tx, &session.ID)
+		currentToken, terr := session.FindCurrentlyActiveRefreshToken(tx)
 		if terr != nil {
 			return terr
 		}

--- a/internal/models/refresh_token.go
+++ b/internal/models/refresh_token.go
@@ -103,18 +103,6 @@ func RevokeTokenFamily(tx *storage.Connection, token *RefreshToken) error {
 	return nil
 }
 
-func FindTokenBySessionID(tx *storage.Connection, sessionId *uuid.UUID) (*RefreshToken, error) {
-	refreshToken := &RefreshToken{}
-	err := tx.Q().Where("instance_id = ? and session_id = ?", uuid.Nil, sessionId).Order("created_at asc").First(refreshToken)
-	if err != nil {
-		if errors.Cause(err) == sql.ErrNoRows {
-			return nil, RefreshTokenNotFoundError{}
-		}
-		return nil, err
-	}
-	return refreshToken, nil
-}
-
 func createRefreshToken(tx *storage.Connection, user *User, oldToken *RefreshToken, params *GrantParams) (*RefreshToken, error) {
 	token := &RefreshToken{
 		UserID: user.ID,


### PR DESCRIPTION
## What kind of change does this PR introduce?

1. For  the `FindUserByID` call we don't make any modifications to the user and as such there's no need to reload the user again.
2. For `FindTokenBySessionID` We aim to find the active refresh token and invalidate that whcih `FindCurrentlyActiveRefreshToken` seems to already do