### PR TITLE
fix: linkedin_oidc provider error

### DIFF
--- a/internal/api/provider/linkedin_oidc.go
+++ b/internal/api/provider/linkedin_oidc.go
@@ -41,7 +41,7 @@ func NewLinkedinOIDCProvider(ext conf.OAuthProviderConfiguration, scopes string)
 	// Linkedin uses a different issuer from it's oidc discovery url
 	// https://learn.microsoft.com/en-us/linkedin/consumer/integrations/self-serve/sign-in-with-linkedin-v2#validating-id-tokens
 	ctx := oidc.InsecureIssuerURLContext(context.Background(), IssuerLinkedin)
-	oidcProvider, err := oidc.NewProvider(ctx, IssuerLinkedin+"/oauth")
+	oidcProvider, err := oidc.NewProvider(ctx, IssuerLinkedin)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fixes https://github.com/supabase/auth/issues/1533

## What is the current behavior?

Attempting to signInWithOAuth with linkedin_iodc provider results in error 500

## What is the new behavior?

Attempting to signInWithOAuth with linkedin_iodc results in a successful login

## Additional context

Error from Supabase Auth Logs:
`oidc: id token issued by a different provider, expected \"https://www.linkedin.com\" got \"https://www.linkedin.com/oauth\"`
