### PR TITLE
fix: revert patch for linkedin_oidc provider error

### DIFF
--- a/internal/api/provider/linkedin_oidc.go
+++ b/internal/api/provider/linkedin_oidc.go
@@ -41,7 +41,7 @@ func NewLinkedinOIDCProvider(ext conf.OAuthProviderConfiguration, scopes string)
 	// Linkedin uses a different issuer from it's oidc discovery url
 	// https://learn.microsoft.com/en-us/linkedin/consumer/integrations/self-serve/sign-in-with-linkedin-v2#validating-id-tokens
 	ctx := oidc.InsecureIssuerURLContext(context.Background(), IssuerLinkedin)
-	oidcProvider, err := oidc.NewProvider(ctx, IssuerLinkedin)
+	oidcProvider, err := oidc.NewProvider(ctx, IssuerLinkedin+"/oauth")
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Reverts supabase/auth#1534

Doesn't seem to work as expected. Directly testing against the API  by calling `https://localhost:9999/?provider=linkedin_oidc will return a 404 error.