### PR TITLE
fix: update linkedin issuer url

### DIFF
--- a/internal/api/provider/linkedin_oidc.go
+++ b/internal/api/provider/linkedin_oidc.go
@@ -11,7 +11,7 @@ import (
 
 const (
 	defaultLinkedinOIDCAPIBase = "api.linkedin.com"
-	IssuerLinkedin             = "https://www.linkedin.com"
+	IssuerLinkedin             = "https://www.linkedin.com/oauth"
 )
 
 type linkedinOIDCProvider struct {
@@ -38,10 +38,7 @@ func NewLinkedinOIDCProvider(ext conf.OAuthProviderConfiguration, scopes string)
 		oauthScopes = append(oauthScopes, strings.Split(scopes, ",")...)
 	}
 
-	// Linkedin uses a different issuer from it's oidc discovery url
-	// https://learn.microsoft.com/en-us/linkedin/consumer/integrations/self-serve/sign-in-with-linkedin-v2#validating-id-tokens
-	ctx := oidc.InsecureIssuerURLContext(context.Background(), IssuerLinkedin)
-	oidcProvider, err := oidc.NewProvider(ctx, IssuerLinkedin)
+	oidcProvider, err := oidc.NewProvider(context.Background(), IssuerLinkedin)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Linkedin introduced a breaking change by changing the issuer url in their 
discover document from `https://linkedin.com` to `https://linkedin.com/oauth` 

* Fixes #1533, #1534, [#22711](https://github.com/orgs/supabase/discussions/22711), [#22708](https://github.com/orgs/supabase/discussions/22708)

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
