### PR TITLE
fix: return error if session id does not exist

### DIFF
--- a/internal/api/auth.go
+++ b/internal/api/auth.go
@@ -123,8 +123,11 @@ func (a *API) maybeLoadUserOrSession(ctx context.Context) (context.Context, erro
 			return ctx, forbiddenError(ErrorCodeBadJWT, "invalid claim: session_id claim must be a UUID").WithInternalError(err)
 		}
 		session, err = models.FindSessionByID(db, sessionId, false)
-		if err != nil && !models.IsNotFoundError(err) {
-			return ctx, forbiddenError(ErrorCodeSessionNotFound, "Session from session_id claim in JWT does not exist")
+		if err != nil {
+			if models.IsNotFoundError(err) {
+				return ctx, forbiddenError(ErrorCodeSessionNotFound, "Session from session_id claim in JWT does not exist")
+			}
+			return ctx, err
 		}
 		ctx = withSession(ctx, session)
 	}


### PR DESCRIPTION
## What kind of change does this PR introduce?
* return error if session id doesn't exist in the db

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
