### PR TITLE
fix: update MaxFrequency error message to reflect number of seconds

### DIFF
--- a/internal/api/errors.go
+++ b/internal/api/errors.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"os"
 	"runtime/debug"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/supabase/auth/internal/observability"
@@ -310,4 +311,10 @@ func HandleResponseError(err error, w http.ResponseWriter, r *http.Request) {
 			}
 		}
 	}
+}
+
+func generateFrequencyLimitErrorMessage(timeStamp *time.Time, maxFrequency time.Duration) string {
+	now := time.Now()
+	left := timeStamp.Add(maxFrequency).Sub(now) / time.Second
+	return fmt.Sprintf("For security purposes, you can only request this after %d seconds.", left)
 }

--- a/internal/api/external.go
+++ b/internal/api/external.go
@@ -384,7 +384,7 @@ func (a *API) createAccountFromExternalIdentity(tx *storage.Connection, r *http.
 			if decision.CandidateEmail.Email != "" {
 				if terr = a.sendConfirmation(r, tx, user, models.ImplicitFlow); terr != nil {
 					if errors.Is(terr, MaxFrequencyLimitError) {
-						return nil, tooManyRequestsError(ErrorCodeOverEmailSendRateLimit, "For security purposes, you can only request this once every minute")
+						return nil, tooManyRequestsError(ErrorCodeOverEmailSendRateLimit, generateFrequencyLimitErrorMessage(user.ConfirmationSentAt, config.SMTP.MaxFrequency))
 					}
 					return nil, internalServerError("Error sending confirmation mail").WithInternalError(terr)
 				}

--- a/internal/api/magic_link.go
+++ b/internal/api/magic_link.go
@@ -142,7 +142,7 @@ func (a *API) MagicLink(w http.ResponseWriter, r *http.Request) error {
 	})
 	if err != nil {
 		if errors.Is(err, MaxFrequencyLimitError) {
-			return tooManyRequestsError(ErrorCodeOverEmailSendRateLimit, "For security purposes, you can only request this once every 60 seconds")
+			return tooManyRequestsError(ErrorCodeOverEmailSendRateLimit, generateFrequencyLimitErrorMessage(user.RecoverySentAt, config.SMTP.MaxFrequency))
 		}
 		return internalServerError("Error sending magic link").WithInternalError(err)
 	}

--- a/internal/api/reauthenticate.go
+++ b/internal/api/reauthenticate.go
@@ -64,6 +64,7 @@ func (a *API) Reauthenticate(w http.ResponseWriter, r *http.Request) error {
 				reason = ErrorCodeOverSMSSendRateLimit
 			}
 
+			// TODO: convert this
 			return tooManyRequestsError(reason, "For security purposes, you can only request this once every 60 seconds")
 		}
 		return err

--- a/internal/api/recover.go
+++ b/internal/api/recover.go
@@ -32,6 +32,7 @@ func (p *RecoverParams) Validate() error {
 // Recover sends a recovery email
 func (a *API) Recover(w http.ResponseWriter, r *http.Request) error {
 	ctx := r.Context()
+	config := a.config
 	db := a.db.WithContext(ctx)
 	params := &RecoverParams{}
 	if err := retrieveRequestParams(r, params); err != nil {
@@ -68,7 +69,7 @@ func (a *API) Recover(w http.ResponseWriter, r *http.Request) error {
 	})
 	if err != nil {
 		if errors.Is(err, MaxFrequencyLimitError) {
-			return tooManyRequestsError(ErrorCodeOverEmailSendRateLimit, "For security purposes, you can only request this once every 60 seconds")
+			return tooManyRequestsError(ErrorCodeOverEmailSendRateLimit, generateFrequencyLimitErrorMessage(user.RecoverySentAt, config.SMTP.MaxFrequency))
 		}
 		return internalServerError("Unable to process request").WithInternalError(err)
 	}

--- a/internal/api/user.go
+++ b/internal/api/user.go
@@ -203,7 +203,7 @@ func (a *API) UserUpdate(w http.ResponseWriter, r *http.Request) error {
 			}
 			if terr = a.sendEmailChange(r, tx, user, params.Email, flowType); terr != nil {
 				if errors.Is(terr, MaxFrequencyLimitError) {
-					return tooManyRequestsError(ErrorCodeOverEmailSendRateLimit, "For security purposes, you can only request this once every 60 seconds")
+					return tooManyRequestsError(ErrorCodeOverEmailSendRateLimit, generateFrequencyLimitErrorMessage(user.EmailChangeSentAt, config.SMTP.MaxFrequency))
 				}
 				return internalServerError("Error sending change email").WithInternalError(terr)
 			}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Currently we use a constant value on number of seconds left before a developer can send a follow up email confirmation. This can prove confusing if developer has a custom setting  for `MaxFrequency` on `Sms` or `SMTP`