### PR TITLE
feat: add support for Azure CIAM login

### DIFF
--- a/internal/api/errorcodes.go
+++ b/internal/api/errorcodes.go
@@ -47,7 +47,6 @@ const (
 	ErrorCodeSMSSendFailed                     ErrorCode = "sms_send_failed"
 	ErrorCodeEmailNotConfirmed                 ErrorCode = "email_not_confirmed"
 	ErrorCodePhoneNotConfirmed                 ErrorCode = "phone_not_confirmed"
-	ErrorCodeReauthNonceMissing                ErrorCode = "reauth_nonce_missing"
 	ErrorCodeSAMLRelayStateNotFound            ErrorCode = "saml_relay_state_not_found"
 	ErrorCodeSAMLRelayStateExpired             ErrorCode = "saml_relay_state_expired"
 	ErrorCodeSAMLIdPNotFound                   ErrorCode = "saml_idp_not_found"

--- a/internal/api/provider/azure.go
+++ b/internal/api/provider/azure.go
@@ -129,7 +129,7 @@ func (g azureProvider) GetUserData(ctx context.Context, tok *oauth2.Token) (*Use
 		// Allow basic Azure issuers, except when the expected issuer
 		// is configured to be the Azure CIAM issuer, allow CIAM
 		// issuers to pass.
-		if !IsAzureIssuer(issuer) || (IsAzureCIAMIssuer(g.ExpectedIssuer) && !IsAzureCIAMIssuer(issuer)) {
+		if !IsAzureIssuer(issuer) && (IsAzureCIAMIssuer(g.ExpectedIssuer) && !IsAzureCIAMIssuer(issuer)) {
 			return nil, fmt.Errorf("azure: ID token issuer not valid %q", issuer)
 		}
 


### PR DESCRIPTION
Adds support for [Azure's CIAM](https://learn.microsoft.com/en-us/entra/external-id/customers/overview-customers-ciam) login. This is a special B2B Azure account separate from the typical tenant accounts and is meant to be used only when the expected issuer is set to the CIAM tenant.