### PR TITLE
feat: send over user in SendSMS Hook instead of UserID

### DIFF
--- a/internal/api/hooks_test.go
+++ b/internal/api/hooks_test.go
@@ -61,7 +61,7 @@ func (ts *HooksTestSuite) TestRunHTTPHook() {
 
 	input := hooks.SendSMSInput{
 		User: ts.TestUser,
-		PhoneData: hooks.PhoneData{
+		SMS: hooks.SMS{
 			OTP: "123456",
 		},
 	}
@@ -128,7 +128,7 @@ func (ts *HooksTestSuite) TestShouldRetryWithRetryAfterHeader() {
 
 	input := hooks.SendSMSInput{
 		User: ts.TestUser,
-		PhoneData: hooks.PhoneData{
+		SMS: hooks.SMS{
 			OTP: "123456",
 		},
 	}
@@ -171,7 +171,7 @@ func (ts *HooksTestSuite) TestShouldReturnErrorForNonJSONContentType() {
 
 	input := hooks.SendSMSInput{
 		User: ts.TestUser,
-		PhoneData: hooks.PhoneData{
+		SMS: hooks.SMS{
 			OTP: "123456",
 		},
 	}

--- a/internal/api/hooks_test.go
+++ b/internal/api/hooks_test.go
@@ -60,9 +60,10 @@ func (ts *HooksTestSuite) TestRunHTTPHook() {
 	defer gock.OffAll()
 
 	input := hooks.SendSMSInput{
-		User:  ts.TestUser,
-		Phone: "1234567890",
-		OTP:   "123456",
+		User: ts.TestUser,
+		PhoneData: hooks.PhoneData{
+			OTP: "123456",
+		},
 	}
 	successOutput := hooks.SendSMSOutput{Success: true}
 	testURL := "http://localhost:54321/functions/v1/custom-sms-sender"
@@ -126,9 +127,10 @@ func (ts *HooksTestSuite) TestShouldRetryWithRetryAfterHeader() {
 	defer gock.OffAll()
 
 	input := hooks.SendSMSInput{
-		User:  ts.TestUser,
-		Phone: "1234567890",
-		OTP:   "123456",
+		User: ts.TestUser,
+		PhoneData: hooks.PhoneData{
+			OTP: "123456",
+		},
 	}
 	successOutput := hooks.SendSMSOutput{Success: true}
 	testURL := "http://localhost:54321/functions/v1/custom-sms-sender"
@@ -168,9 +170,10 @@ func (ts *HooksTestSuite) TestShouldReturnErrorForNonJSONContentType() {
 	defer gock.OffAll()
 
 	input := hooks.SendSMSInput{
-		User:  ts.TestUser,
-		Phone: "1234567890",
-		OTP:   "123456",
+		User: ts.TestUser,
+		PhoneData: hooks.PhoneData{
+			OTP: "123456",
+		},
 	}
 	testURL := "http://localhost:54321/functions/v1/custom-sms-sender"
 	ts.Config.Hook.SendSMS.URI = testURL

--- a/internal/api/hooks_test.go
+++ b/internal/api/hooks_test.go
@@ -6,12 +6,12 @@ import (
 	"testing"
 
 	"errors"
-	"github.com/gofrs/uuid"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"github.com/supabase/auth/internal/conf"
 	"github.com/supabase/auth/internal/hooks"
+	"github.com/supabase/auth/internal/models"
 	"github.com/supabase/auth/internal/storage"
 	"net/http/httptest"
 
@@ -22,8 +22,9 @@ var handleApiRequest func(*http.Request) (*http.Response, error)
 
 type HooksTestSuite struct {
 	suite.Suite
-	API    *API
-	Config *conf.GlobalConfiguration
+	API      *API
+	Config   *conf.GlobalConfiguration
+	TestUser *models.User
 }
 
 type MockHttpClient struct {
@@ -47,13 +48,21 @@ func TestHooks(t *testing.T) {
 	suite.Run(t, ts)
 }
 
+func (ts *HooksTestSuite) SetupTest() {
+	models.TruncateAll(ts.API.db)
+	u, err := models.NewUser("123456789", "testemail@gmail.com", "securetestpassword", ts.Config.JWT.Aud, nil)
+	require.NoError(ts.T(), err, "Error creating test user model")
+	require.NoError(ts.T(), ts.API.db.Create(u), "Error saving new test user")
+	ts.TestUser = u
+}
+
 func (ts *HooksTestSuite) TestRunHTTPHook() {
 	defer gock.OffAll()
 
 	input := hooks.SendSMSInput{
-		UserID: uuid.Must(uuid.NewV4()),
-		Phone:  "1234567890",
-		OTP:    "123456",
+		User:  ts.TestUser,
+		Phone: "1234567890",
+		OTP:   "123456",
 	}
 	successOutput := hooks.SendSMSOutput{Success: true}
 	testURL := "http://localhost:54321/functions/v1/custom-sms-sender"
@@ -117,9 +126,9 @@ func (ts *HooksTestSuite) TestShouldRetryWithRetryAfterHeader() {
 	defer gock.OffAll()
 
 	input := hooks.SendSMSInput{
-		UserID: uuid.Must(uuid.NewV4()),
-		Phone:  "1234567890",
-		OTP:    "123456",
+		User:  ts.TestUser,
+		Phone: "1234567890",
+		OTP:   "123456",
 	}
 	successOutput := hooks.SendSMSOutput{Success: true}
 	testURL := "http://localhost:54321/functions/v1/custom-sms-sender"
@@ -159,9 +168,9 @@ func (ts *HooksTestSuite) TestShouldReturnErrorForNonJSONContentType() {
 	defer gock.OffAll()
 
 	input := hooks.SendSMSInput{
-		UserID: uuid.Must(uuid.NewV4()),
-		Phone:  "1234567890",
-		OTP:    "123456",
+		User:  ts.TestUser,
+		Phone: "1234567890",
+		OTP:   "123456",
 	}
 	testURL := "http://localhost:54321/functions/v1/custom-sms-sender"
 	ts.Config.Hook.SendSMS.URI = testURL

--- a/internal/api/phone.go
+++ b/internal/api/phone.go
@@ -98,7 +98,7 @@ func (a *API) sendPhoneConfirmation(ctx context.Context, r *http.Request, tx *st
 		if config.Hook.SendSMS.Enabled {
 			input := hooks.SendSMSInput{
 				User: user,
-				PhoneData: hooks.PhoneData{
+				SMS: hooks.SMS{
 					OTP: otp,
 				},
 			}

--- a/internal/api/phone.go
+++ b/internal/api/phone.go
@@ -97,9 +97,9 @@ func (a *API) sendPhoneConfirmation(ctx context.Context, r *http.Request, tx *st
 		}
 		if config.Hook.SendSMS.Enabled {
 			input := hooks.SendSMSInput{
-				UserID: user.ID,
-				Phone:  user.Phone.String(),
-				OTP:    otp,
+				User:  user,
+				Phone: user.Phone.String(),
+				OTP:   otp,
 			}
 			output := hooks.SendSMSOutput{}
 			err := a.invokeHook(tx, r, &input, &output, a.config.Hook.SendSMS.URI)

--- a/internal/api/phone.go
+++ b/internal/api/phone.go
@@ -97,9 +97,10 @@ func (a *API) sendPhoneConfirmation(ctx context.Context, r *http.Request, tx *st
 		}
 		if config.Hook.SendSMS.Enabled {
 			input := hooks.SendSMSInput{
-				User:  user,
-				Phone: user.Phone.String(),
-				OTP:   otp,
+				User: user,
+				PhoneData: hooks.PhoneData{
+					OTP: otp,
+				},
 			}
 			output := hooks.SendSMSOutput{}
 			err := a.invokeHook(tx, r, &input, &output, a.config.Hook.SendSMS.URI)

--- a/internal/hooks/auth_hooks.go
+++ b/internal/hooks/auth_hooks.go
@@ -34,7 +34,7 @@ type HookOutput interface {
 
 // TODO(joel): Move this to phone package
 type PhoneData struct {
-	OTP string
+	OTP string `json:"otp,omitempty"`
 }
 
 // #nosec
@@ -146,8 +146,8 @@ type CustomAccessTokenOutput struct {
 }
 
 type SendSMSInput struct {
-	User      *models.User `json:"user"`
-	PhoneData PhoneData    `json:"phone_data"`
+	User      *models.User `json:"user,omitempty"`
+	PhoneData PhoneData    `json:"phone_data,omitempty"`
 }
 
 type SendSMSOutput struct {

--- a/internal/hooks/auth_hooks.go
+++ b/internal/hooks/auth_hooks.go
@@ -33,7 +33,7 @@ type HookOutput interface {
 }
 
 // TODO(joel): Move this to phone package
-type PhoneData struct {
+type SMS struct {
 	OTP string `json:"otp,omitempty"`
 }
 
@@ -146,8 +146,8 @@ type CustomAccessTokenOutput struct {
 }
 
 type SendSMSInput struct {
-	User      *models.User `json:"user,omitempty"`
-	PhoneData PhoneData    `json:"phone_data,omitempty"`
+	User *models.User `json:"user,omitempty"`
+	SMS  SMS          `json:"sms,omitempty"`
 }
 
 type SendSMSOutput struct {

--- a/internal/hooks/auth_hooks.go
+++ b/internal/hooks/auth_hooks.go
@@ -141,9 +141,9 @@ type CustomAccessTokenOutput struct {
 }
 
 type SendSMSInput struct {
-	UserID uuid.UUID `json:"user_id"`
-	Phone  string    `json:"phone"`
-	OTP    string    `json:"otp"`
+	User  *models.User `json:"user"`
+	Phone string       `json:"phone"`
+	OTP   string       `json:"otp"`
 }
 
 type SendSMSOutput struct {

--- a/internal/hooks/auth_hooks.go
+++ b/internal/hooks/auth_hooks.go
@@ -32,6 +32,11 @@ type HookOutput interface {
 	Error() string
 }
 
+// TODO(joel): Move this to phone package
+type PhoneData struct {
+	OTP string
+}
+
 // #nosec
 const MinimumViableTokenSchema = `{
   "$schema": "http://json-schema.org/draft-07/schema#",
@@ -141,9 +146,8 @@ type CustomAccessTokenOutput struct {
 }
 
 type SendSMSInput struct {
-	User  *models.User `json:"user"`
-	Phone string       `json:"phone"`
-	OTP   string       `json:"otp"`
+	User      *models.User `json:"user"`
+	PhoneData PhoneData    `json:"phone_data"`
 }
 
 type SendSMSOutput struct {


### PR DESCRIPTION
## What kind of change does this PR introduce?

We align convention with `SendEmail` and send over a user to avoid having the user make an additional `getUser` call.  Also allows access to `app_metadata` and `user_metadata` which would be useful for internationalization where you may want the locale of the user to determine which template to send.

We also introduce a `PhoneData` struct through which we can introduce any potential phone related fields. This struct currently lives under the `hooks` package as there is no `phone` package currently and introducing one might require a significant refactor. Importing it as as is under `api` package would cause a circular dependency between `hooks` and `api` packages.

