### PR TITLE
feat: merge provider metadata on link account

### DIFF
--- a/internal/api/external.go
+++ b/internal/api/external.go
@@ -298,6 +298,10 @@ func (a *API) createAccountFromExternalIdentity(tx *storage.Connection, r *http.
 			return nil, terr
 		}
 
+		if terr = user.UpdateUserMetaData(tx, identityData); terr != nil {
+			return nil, terr
+		}
+
 		if terr = user.UpdateAppMetaDataProviders(tx); terr != nil {
 			return nil, terr
 		}


### PR DESCRIPTION
It merges back the identity data into user metadata on link account. This is safe because the user can just sign-in again and have the identity data merged back (AccountExists case).