### PR TITLE
fix: add db conn max idle time setting

### DIFF
--- a/internal/storage/dial.go
+++ b/internal/storage/dial.go
@@ -72,6 +72,7 @@ func Dial(config *conf.GlobalConfiguration) (*Connection, error) {
 		Pool:            config.DB.MaxPoolSize,
 		IdlePool:        config.DB.MaxIdlePoolSize,
 		ConnMaxLifetime: config.DB.ConnMaxLifetime,
+		ConnMaxIdleTime: config.DB.ConnMaxIdleTime,
 		Options:         options,
 	})
 	if err != nil {


### PR DESCRIPTION
Adds the `GOTRUE_DB_CONN_MAX_IDLE_TIME` setting that allows setting the max idle time for a connection.