### PR TITLE
feat: refactor one-time tokens for performance

### DIFF
--- a/internal/api/mail.go
+++ b/internal/api/mail.go
@@ -182,7 +182,7 @@ func (a *API) adminGenerateLink(w http.ResponseWriter, r *http.Request) error {
 			}
 			terr = models.CreateOneTimeToken(tx, user.ID, user.GetEmail(), user.ConfirmationToken, models.ConfirmationToken)
 			if terr != nil {
-				terr = errors.Wrap(terr, "Database error reating confirmation token for invite in admin")
+				terr = errors.Wrap(terr, "Database error creating confirmation token for invite in admin")
 				return terr
 			}
 		case mail.SignupVerification:
@@ -220,7 +220,7 @@ func (a *API) adminGenerateLink(w http.ResponseWriter, r *http.Request) error {
 			}
 			terr = models.CreateOneTimeToken(tx, user.ID, user.GetEmail(), user.ConfirmationToken, models.ConfirmationToken)
 			if terr != nil {
-				terr = errors.Wrap(terr, "Database error reating confirmation token for signup in admin")
+				terr = errors.Wrap(terr, "Database error creating confirmation token for signup in admin")
 				return terr
 			}
 		case mail.EmailChangeCurrentVerification, mail.EmailChangeNewVerification:

--- a/internal/api/mail.go
+++ b/internal/api/mail.go
@@ -1,11 +1,12 @@
 package api
 
 import (
-	"github.com/supabase/auth/internal/hooks"
-	mail "github.com/supabase/auth/internal/mailer"
 	"net/http"
 	"strings"
 	"time"
+
+	"github.com/supabase/auth/internal/hooks"
+	mail "github.com/supabase/auth/internal/mailer"
 
 	"github.com/badoux/checkmail"
 	"github.com/fatih/structs"
@@ -123,6 +124,13 @@ func (a *API) adminGenerateLink(w http.ResponseWriter, r *http.Request) error {
 			terr = tx.UpdateOnly(user, "recovery_token", "recovery_sent_at")
 			if terr != nil {
 				terr = errors.Wrap(terr, "Database error updating user for recovery")
+				return terr
+			}
+
+			terr = models.CreateOneTimeToken(tx, user.ID, user.GetEmail(), user.RecoveryToken, models.RecoveryToken)
+			if terr != nil {
+				terr = errors.Wrap(terr, "Database error creating recovery token in admin")
+				return terr
 			}
 		case mail.InviteVerification:
 			if user != nil {
@@ -170,6 +178,12 @@ func (a *API) adminGenerateLink(w http.ResponseWriter, r *http.Request) error {
 			terr = tx.UpdateOnly(user, "confirmation_token", "confirmation_sent_at", "invited_at")
 			if terr != nil {
 				terr = errors.Wrap(terr, "Database error updating user for invite")
+				return terr
+			}
+			terr = models.CreateOneTimeToken(tx, user.ID, user.GetEmail(), user.ConfirmationToken, models.ConfirmationToken)
+			if terr != nil {
+				terr = errors.Wrap(terr, "Database error reating confirmation token for invite in admin")
+				return terr
 			}
 		case mail.SignupVerification:
 			if user != nil {
@@ -202,6 +216,12 @@ func (a *API) adminGenerateLink(w http.ResponseWriter, r *http.Request) error {
 			terr = tx.UpdateOnly(user, "confirmation_token", "confirmation_sent_at")
 			if terr != nil {
 				terr = errors.Wrap(terr, "Database error updating user for confirmation")
+				return terr
+			}
+			terr = models.CreateOneTimeToken(tx, user.ID, user.GetEmail(), user.ConfirmationToken, models.ConfirmationToken)
+			if terr != nil {
+				terr = errors.Wrap(terr, "Database error reating confirmation token for signup in admin")
+				return terr
 			}
 		case mail.EmailChangeCurrentVerification, mail.EmailChangeNewVerification:
 			if !config.Mailer.SecureEmailChangeEnabled && params.Type == "email_change_current" {
@@ -228,6 +248,21 @@ func (a *API) adminGenerateLink(w http.ResponseWriter, r *http.Request) error {
 			terr = tx.UpdateOnly(user, "email_change_token_current", "email_change_token_new", "email_change", "email_change_sent_at", "email_change_confirm_status")
 			if terr != nil {
 				terr = errors.Wrap(terr, "Database error updating user for email change")
+				return terr
+			}
+			if user.EmailChangeTokenCurrent != "" {
+				terr = models.CreateOneTimeToken(tx, user.ID, user.GetEmail(), user.EmailChangeTokenCurrent, models.EmailChangeTokenCurrent)
+				if terr != nil {
+					terr = errors.Wrap(terr, "Database error creating email change token current in admin")
+					return terr
+				}
+			}
+			if user.EmailChangeTokenNew != "" {
+				terr = models.CreateOneTimeToken(tx, user.ID, user.EmailChange, user.EmailChangeTokenNew, models.EmailChangeTokenNew)
+				if terr != nil {
+					terr = errors.Wrap(terr, "Database error creating email change token new in admin")
+					return terr
+				}
 			}
 		default:
 			return badRequestError(ErrorCodeValidationFailed, "Invalid email action link type requested: %v", params.Type)
@@ -290,6 +325,11 @@ func (a *API) sendConfirmation(r *http.Request, tx *storage.Connection, u *model
 		return errors.Wrap(err, "Database error updating user for confirmation")
 	}
 
+	err = models.CreateOneTimeToken(tx, u.ID, u.GetEmail(), u.ConfirmationToken, models.ConfirmationToken)
+	if err != nil {
+		return errors.Wrap(err, "Database error creating confirmation token")
+	}
+
 	return nil
 }
 
@@ -315,6 +355,11 @@ func (a *API) sendInvite(r *http.Request, tx *storage.Connection, u *models.User
 	err = tx.UpdateOnly(u, "confirmation_token", "confirmation_sent_at", "invited_at")
 	if err != nil {
 		return errors.Wrap(err, "Database error updating user for invite")
+	}
+
+	err = models.CreateOneTimeToken(tx, u.ID, u.GetEmail(), u.ConfirmationToken, models.ConfirmationToken)
+	if err != nil {
+		return errors.Wrap(err, "Database error creating confirmation token for invite")
 	}
 
 	return nil
@@ -349,6 +394,11 @@ func (a *API) sendPasswordRecovery(r *http.Request, tx *storage.Connection, u *m
 		return errors.Wrap(err, "Database error updating user for recovery")
 	}
 
+	err = models.CreateOneTimeToken(tx, u.ID, u.GetEmail(), u.RecoveryToken, models.RecoveryToken)
+	if err != nil {
+		return errors.Wrap(err, "Database error creating recovery token")
+	}
+
 	return nil
 }
 
@@ -379,6 +429,11 @@ func (a *API) sendReauthenticationOtp(r *http.Request, tx *storage.Connection, u
 	err = tx.UpdateOnly(u, "reauthentication_token", "reauthentication_sent_at")
 	if err != nil {
 		return errors.Wrap(err, "Database error updating user for reauthentication")
+	}
+
+	err = models.CreateOneTimeToken(tx, u.ID, u.GetEmail(), u.ReauthenticationToken, models.ReauthenticationToken)
+	if err != nil {
+		return errors.Wrap(err, "Database error creating reauthentication token")
 	}
 
 	return nil
@@ -414,6 +469,11 @@ func (a *API) sendMagicLink(r *http.Request, tx *storage.Connection, u *models.U
 	err = tx.UpdateOnly(u, "recovery_token", "recovery_sent_at")
 	if err != nil {
 		return errors.Wrap(err, "Database error updating user for recovery")
+	}
+
+	err = models.CreateOneTimeToken(tx, u.ID, u.GetEmail(), u.RecoveryToken, models.RecoveryToken)
+	if err != nil {
+		return errors.Wrap(err, "Database error creating recovery token")
 	}
 
 	return nil
@@ -467,6 +527,20 @@ func (a *API) sendEmailChange(r *http.Request, tx *storage.Connection, u *models
 
 	if err != nil {
 		return errors.Wrap(err, "Database error updating user for email change")
+	}
+
+	if u.EmailChangeTokenCurrent != "" {
+		err = models.CreateOneTimeToken(tx, u.ID, u.GetEmail(), u.EmailChangeTokenCurrent, models.EmailChangeTokenCurrent)
+		if err != nil {
+			return errors.Wrap(err, "Database error creating email change token current")
+		}
+	}
+
+	if u.EmailChangeTokenNew != "" {
+		err = models.CreateOneTimeToken(tx, u.ID, u.EmailChange, u.EmailChangeTokenNew, models.EmailChangeTokenNew)
+		if err != nil {
+			return errors.Wrap(err, "Database error creating email change token new")
+		}
 	}
 
 	return nil

--- a/internal/models/errors.go
+++ b/internal/models/errors.go
@@ -25,6 +25,8 @@ func IsNotFoundError(err error) bool {
 		return true
 	case FlowStateNotFoundError, *FlowStateNotFoundError:
 		return true
+	case OneTimeTokenNotFoundError, *OneTimeTokenNotFoundError:
+		return true
 	}
 	return false
 }

--- a/internal/models/one_time_token.go
+++ b/internal/models/one_time_token.go
@@ -1,0 +1,330 @@
+package models
+
+import (
+	"database/sql"
+	"database/sql/driver"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/gofrs/uuid"
+	"github.com/pkg/errors"
+	"github.com/supabase/auth/internal/storage"
+)
+
+type OneTimeTokenType int
+
+const (
+	ConfirmationToken OneTimeTokenType = iota
+	ReauthenticationToken
+	RecoveryToken
+	EmailChangeTokenNew
+	EmailChangeTokenCurrent
+	PhoneChangeToken
+)
+
+func (t OneTimeTokenType) String() string {
+	switch t {
+	case ConfirmationToken:
+		return "confirmation_token"
+
+	case ReauthenticationToken:
+		return "reauthentication_token"
+
+	case RecoveryToken:
+		return "recovery_token"
+
+	case EmailChangeTokenNew:
+		return "email_change_token_new"
+
+	case EmailChangeTokenCurrent:
+		return "email_change_token_current"
+
+	case PhoneChangeToken:
+		return "phone_change_token"
+
+	default:
+		panic("OneTimeToken: unreachable case")
+	}
+}
+
+func ParseOneTimeTokenType(s string) (OneTimeTokenType, error) {
+	switch s {
+	case "confirmation_token":
+		return ConfirmationToken, nil
+
+	case "reauthentication_token":
+		return ReauthenticationToken, nil
+
+	case "recovery_token":
+		return RecoveryToken, nil
+
+	case "email_change_token_new":
+		return EmailChangeTokenNew, nil
+
+	case "email_change_token_current":
+		return EmailChangeTokenCurrent, nil
+
+	case "phone_change_token":
+		return PhoneChangeToken, nil
+
+	default:
+		return 0, fmt.Errorf("OneTimeTokenType: unrecognized string %q", s)
+	}
+}
+
+func (t OneTimeTokenType) Value() (driver.Value, error) {
+	return t.String(), nil
+}
+
+func (t *OneTimeTokenType) Scan(src interface{}) error {
+	s, ok := src.(string)
+	if !ok {
+		return fmt.Errorf("OneTimeTokenType: scan type is not string but is %T", src)
+	}
+
+	parsed, err := ParseOneTimeTokenType(s)
+	if err != nil {
+		return err
+	}
+
+	*t = parsed
+	return nil
+}
+
+type OneTimeTokenNotFoundError struct {
+}
+
+func (e OneTimeTokenNotFoundError) Error() string {
+	return "One-time token not found"
+}
+
+type OneTimeToken struct {
+	ID uuid.UUID `json:"id" db:"id"`
+
+	UserID    uuid.UUID        `json:"user_id" db:"user_id"`
+	TokenType OneTimeTokenType `json:"token_type" db:"token_type"`
+
+	TokenHash string `json:"token_hash" db:"token_hash"`
+	RelatesTo string `json:"relates_to" db:"relates_to"`
+
+	CreatedAt time.Time `json:"created_at" db:"created_at"`
+	UpdatedAt time.Time `json:"updated_at" db:"updated_at"`
+}
+
+func (OneTimeToken) TableName() string {
+	return "one_time_tokens"
+}
+
+func ClearAllOneTimeTokensForUser(tx *storage.Connection, userID uuid.UUID) error {
+	return tx.Q().Where("user_id = ?", userID).Delete(OneTimeToken{})
+}
+
+func ClearOneTimeTokenForUser(tx *storage.Connection, userID uuid.UUID, tokenType OneTimeTokenType) error {
+	if err := tx.Q().Where("token_type = ? and user_id = ?", tokenType, userID).Delete(OneTimeToken{}); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func CreateOneTimeToken(tx *storage.Connection, userID uuid.UUID, relatesTo, tokenHash string, tokenType OneTimeTokenType) error {
+	if err := ClearOneTimeTokenForUser(tx, userID, tokenType); err != nil {
+		return err
+	}
+
+	oneTimeToken := &OneTimeToken{
+		ID:        uuid.Must(uuid.NewV4()),
+		UserID:    userID,
+		TokenType: tokenType,
+		TokenHash: tokenHash,
+		RelatesTo: strings.ToLower(relatesTo),
+	}
+
+	if err := tx.Eager().Create(oneTimeToken); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func FindOneTimeToken(tx *storage.Connection, tokenHash string, tokenTypes ...OneTimeTokenType) (*OneTimeToken, error) {
+	oneTimeToken := &OneTimeToken{}
+
+	query := tx.Eager().Q()
+
+	switch len(tokenTypes) {
+	case 2:
+		query = query.Where("(token_type = ? or token_type = ?) and token_hash = ?", tokenTypes[0], tokenTypes[1], tokenHash)
+
+	case 1:
+		query = query.Where("token_type = ? and token_hash = ?", tokenTypes[0], tokenHash)
+
+	default:
+		panic("at most 2 token types are accepted")
+	}
+
+	if err := query.First(oneTimeToken); err != nil {
+		if errors.Cause(err) == sql.ErrNoRows {
+			return nil, OneTimeTokenNotFoundError{}
+		}
+
+		return nil, errors.Wrap(err, "error finding one time token")
+	}
+
+	return oneTimeToken, nil
+}
+
+// FindUserByConfirmationToken finds users with the matching confirmation token.
+func FindUserByConfirmationOrRecoveryToken(tx *storage.Connection, token string) (*User, error) {
+	ott, err := FindOneTimeToken(tx, token, ConfirmationToken, RecoveryToken)
+	if err != nil && !IsNotFoundError(err) {
+		return nil, err
+	}
+
+	if ott == nil {
+		user, err := findUser(tx, "(confirmation_token = ? or recovery_token = ?) and is_sso_user = false", token, token)
+		if err != nil {
+			if IsNotFoundError(err) {
+				return nil, ConfirmationOrRecoveryTokenNotFoundError{}
+			} else {
+				return nil, err
+			}
+		}
+
+		return user, nil
+	}
+
+	return FindUserByID(tx, ott.UserID)
+}
+
+// FindUserByConfirmationToken finds users with the matching confirmation token.
+func FindUserByConfirmationToken(tx *storage.Connection, token string) (*User, error) {
+	ott, err := FindOneTimeToken(tx, token, ConfirmationToken)
+	if err != nil && !IsNotFoundError(err) {
+		return nil, err
+	}
+
+	if ott == nil {
+		user, err := findUser(tx, "confirmation_token = ? and is_sso_user = false", token)
+		if err != nil {
+			if IsNotFoundError(err) {
+				return nil, ConfirmationTokenNotFoundError{}
+			} else {
+				return nil, err
+			}
+		}
+
+		return user, nil
+	}
+
+	return FindUserByID(tx, ott.UserID)
+}
+
+// FindUserByRecoveryToken finds a user with the matching recovery token.
+func FindUserByRecoveryToken(tx *storage.Connection, token string) (*User, error) {
+	ott, err := FindOneTimeToken(tx, token, RecoveryToken)
+	if err != nil && !IsNotFoundError(err) {
+		return nil, err
+	}
+
+	if ott == nil {
+		return findUser(tx, "recovery_token = ? and is_sso_user = false", token)
+	}
+
+	return FindUserByID(tx, ott.UserID)
+}
+
+// FindUserByEmailChangeToken finds a user with the matching email change token.
+func FindUserByEmailChangeToken(tx *storage.Connection, token string) (*User, error) {
+	ott, err := FindOneTimeToken(tx, token, EmailChangeTokenCurrent, EmailChangeTokenNew)
+	if err != nil && !IsNotFoundError(err) {
+		return nil, err
+	}
+
+	if ott == nil {
+		return findUser(tx, "is_sso_user = false and (email_change_token_current = ? or email_change_token_new = ?)", token, token)
+	}
+
+	return FindUserByID(tx, ott.UserID)
+}
+
+// FindUserByEmailChangeCurrentAndAudience finds a user with the matching email change and audience.
+func FindUserByEmailChangeCurrentAndAudience(tx *storage.Connection, email, token, aud string) (*User, error) {
+	ott, err := FindOneTimeToken(tx, token, EmailChangeTokenCurrent)
+	if err != nil && !IsNotFoundError(err) {
+		return nil, err
+	}
+
+	if ott == nil {
+		ott, err = FindOneTimeToken(tx, "pkce_"+token, EmailChangeTokenCurrent)
+		if err != nil && !IsNotFoundError(err) {
+			return nil, err
+		}
+	}
+
+	if ott == nil {
+		return findUser(
+			tx,
+			"instance_id = ? and LOWER(email) = ? and aud = ? and is_sso_user = false and (email_change_token_current = 'pkce_' || ? or email_change_token_current = ?)",
+			uuid.Nil, strings.ToLower(email), aud, token, token,
+		)
+	}
+
+	user, err := FindUserByID(tx, ott.UserID)
+	if err != nil {
+		return nil, err
+	}
+
+	if user.Aud != aud && strings.EqualFold(user.GetEmail(), email) {
+		return nil, UserNotFoundError{}
+	}
+
+	return user, nil
+}
+
+// FindUserByEmailChangeNewAndAudience finds a user with the matching email change and audience.
+func FindUserByEmailChangeNewAndAudience(tx *storage.Connection, email, token, aud string) (*User, error) {
+	ott, err := FindOneTimeToken(tx, token, EmailChangeTokenNew)
+	if err != nil && !IsNotFoundError(err) {
+		return nil, err
+	}
+
+	if ott == nil {
+		ott, err = FindOneTimeToken(tx, "pkce_"+token, EmailChangeTokenNew)
+		if err != nil && !IsNotFoundError(err) {
+			return nil, err
+		}
+	}
+
+	if ott == nil {
+		return findUser(
+			tx,
+			"instance_id = ? and LOWER(email_change) = ? and aud = ? and is_sso_user = false and (email_change_token_new = 'pkce_' || ? or email_change_token_new = ?)",
+			uuid.Nil, strings.ToLower(email), aud, token, token,
+		)
+	}
+
+	user, err := FindUserByID(tx, ott.UserID)
+	if err != nil {
+		return nil, err
+	}
+
+	if user.Aud != aud && strings.EqualFold(user.EmailChange, email) {
+		return nil, UserNotFoundError{}
+	}
+
+	return user, nil
+}
+
+// FindUserForEmailChange finds a user requesting for an email change
+func FindUserForEmailChange(tx *storage.Connection, email, token, aud string, secureEmailChangeEnabled bool) (*User, error) {
+	if secureEmailChangeEnabled {
+		if user, err := FindUserByEmailChangeCurrentAndAudience(tx, email, token, aud); err == nil {
+			return user, err
+		} else if !IsNotFoundError(err) {
+			return nil, err
+		}
+	}
+	return FindUserByEmailChangeNewAndAudience(tx, email, token, aud)
+}

--- a/migrations/20240427152123_add_one_time_tokens_table.up.sql
+++ b/migrations/20240427152123_add_one_time_tokens_table.up.sql
@@ -1,0 +1,30 @@
+do $$ begin
+  create type one_time_token_type as enum (
+    'confirmation_token',
+    'reauthentication_token',
+    'recovery_token',
+    'email_change_token_new',
+    'email_change_token_current',
+    'phone_change_token'
+  );
+exception
+  when duplicate_object then null;
+end $$;
+
+
+do $$ begin
+  create table if not exists {{ index .Options "Namespace" }}.one_time_tokens (
+    id uuid primary key,
+    user_id uuid not null references {{ index .Options "Namespace" }}.users on delete cascade,
+    token_type one_time_token_type not null,
+    token_hash text not null,
+    relates_to text not null,
+    created_at timestamp without time zone not null default now(),
+    updated_at timestamp without time zone not null default now(),
+    check (char_length(token_hash) > 0)
+  );
+
+  create index if not exists one_time_tokens_token_hash_hash_idx on {{ index .Options "Namespace" }}.one_time_tokens using hash (token_hash);
+  create index if not exists one_time_tokens_relates_to_hash_idx on {{ index .Options "Namespace" }}.one_time_tokens using hash (relates_to);
+  create unique index if not exists one_time_tokens_user_id_token_type_key on {{ index .Options "Namespace" }}.one_time_tokens (user_id, token_type);
+end $$;


### PR DESCRIPTION
Refactors all One-Time Tokens (OTP) used for sign-in with email, SMS, email confirmation, phone confirmation, change... to achieve:

- Performance (as current method does not use an index due to the use of [partial indexes](https://github.com/supabase/auth/blob/master/migrations/20220429102000_add_unique_idx.up.sql#L10-L14) which [cannot be used in practice](https://www.postgresql.org/docs/current/indexes-partial.html))
- Future enhancements (such as OTP verification counters, adaptive OTP lengths, etc.)

Summary of the change:

- A new `one_time_tokens` table is added which uses a double-write mechanism with `users`.
- Each new OTP is both written in the corresponding `users` column and as a new row in `one_time_tokens`.
- Lookup for an OTP hash is performed first in `one_time_tokens` and if not found, using the traditional `users` approach.
- In a few days, once all OTPs using the `users` columns have expired, a new change will be deployed which removes the `users` lookup. This completely solves the performance issue for looking up OTPs.
- In a future change, the `one_time_tokens` table can be used to add a verification counter based on lookups on the `relates_to` (email or phone number) column, enabling new security features.