### PR TITLE
fix: do call send sms hook when SMS autoconfirm is enabled

### DIFF
--- a/internal/api/phone.go
+++ b/internal/api/phone.go
@@ -96,25 +96,23 @@ func (a *API) sendPhoneConfirmation(ctx context.Context, r *http.Request, tx *st
 			return "", err
 		}
 		// We call sendPhoneConfirmation even when autoconfirm is enabled
-		if !config.Sms.Autoconfirm {
-			if config.Hook.SendSMS.Enabled {
-				input := hooks.SendSMSInput{
-					User: user,
-					SMS: hooks.SMS{
-						OTP: otp,
-					},
-				}
-				output := hooks.SendSMSOutput{}
-				err := a.invokeHook(tx, r, &input, &output, a.config.Hook.SendSMS.URI)
-				if err != nil {
-					return "", err
-				}
-			} else {
+		if config.Hook.SendSMS.Enabled && !config.Sms.Autoconfirm {
+			input := hooks.SendSMSInput{
+				User: user,
+				SMS: hooks.SMS{
+					OTP: otp,
+				},
+			}
+			output := hooks.SendSMSOutput{}
+			err := a.invokeHook(tx, r, &input, &output, a.config.Hook.SendSMS.URI)
+			if err != nil {
+				return "", err
+			}
+		} else {
 
-				messageID, err = smsProvider.SendMessage(phone, message, channel, otp)
-				if err != nil {
-					return messageID, err
-				}
+			messageID, err = smsProvider.SendMessage(phone, message, channel, otp)
+			if err != nil {
+				return messageID, err
 			}
 		}
 	}

--- a/internal/api/phone.go
+++ b/internal/api/phone.go
@@ -95,7 +95,8 @@ func (a *API) sendPhoneConfirmation(ctx context.Context, r *http.Request, tx *st
 		if err != nil {
 			return "", err
 		}
-		if config.Hook.SendSMS.Enabled {
+		// We call sendPhoneConfirmation even when autoconfirm is enabled
+		if config.Hook.SendSMS.Enabled && !config.Sms.Autoconfirm {
 			input := hooks.SendSMSInput{
 				User: user,
 				SMS: hooks.SMS{

--- a/internal/api/phone.go
+++ b/internal/api/phone.go
@@ -95,8 +95,8 @@ func (a *API) sendPhoneConfirmation(ctx context.Context, r *http.Request, tx *st
 		if err != nil {
 			return "", err
 		}
-		// We call sendPhoneConfirmation even when autoconfirm is enabled
-		if config.Hook.SendSMS.Enabled && !config.Sms.Autoconfirm {
+		// Hook should only be called if SMS autoconfirm is disabled
+		if !config.Sms.Autoconfirm && config.Hook.SendSMS.Enabled {
 			input := hooks.SendSMSInput{
 				User: user,
 				SMS: hooks.SMS{

--- a/internal/api/phone.go
+++ b/internal/api/phone.go
@@ -96,23 +96,25 @@ func (a *API) sendPhoneConfirmation(ctx context.Context, r *http.Request, tx *st
 			return "", err
 		}
 		// We call sendPhoneConfirmation even when autoconfirm is enabled
-		if config.Hook.SendSMS.Enabled && !config.Sms.Autoconfirm {
-			input := hooks.SendSMSInput{
-				User: user,
-				SMS: hooks.SMS{
-					OTP: otp,
-				},
-			}
-			output := hooks.SendSMSOutput{}
-			err := a.invokeHook(tx, r, &input, &output, a.config.Hook.SendSMS.URI)
-			if err != nil {
-				return "", err
-			}
-		} else {
+		if !config.Sms.Autoconfirm {
+			if config.Hook.SendSMS.Enabled {
+				input := hooks.SendSMSInput{
+					User: user,
+					SMS: hooks.SMS{
+						OTP: otp,
+					},
+				}
+				output := hooks.SendSMSOutput{}
+				err := a.invokeHook(tx, r, &input, &output, a.config.Hook.SendSMS.URI)
+				if err != nil {
+					return "", err
+				}
+			} else {
 
-			messageID, err = smsProvider.SendMessage(phone, message, channel, otp)
-			if err != nil {
-				return messageID, err
+				messageID, err = smsProvider.SendMessage(phone, message, channel, otp)
+				if err != nil {
+					return messageID, err
+				}
 			}
 		}
 	}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Small quirk discovered while testing  - it currently looks like when SMS Autoconfirm is set 
```
 GOTRUE_SMS_AUTOCONFIRM="true" 
```

 and an OTP request is made:

```
curl -X POST http://localhost:9999/otp -H "Content-Type: application/json" -d '{"phone": "<phone>"}'
```
an OTP is still sent.  There's a substantial number projects (see internal for exact number) using this so probably will preserve  this behaviour. 

This  affects the edge case where `SMS_AUTOCONFIRM` is enabled but the Hook returns an error which may leave the developer puzzled since one might expect an SMS not to be sent with autoconfirm similar to `MAILER_AUTOCONFIRM`

Before:
- Enable Send SMS and autoconfirm, make a request with faulty URI - request should fail

After:
- Enable Send SMS and autoconfirm, make a request - message is sent as per current behaviour

