### PR TITLE
feat: update openapi spec with identity and is_anonymous fields

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1840,7 +1840,7 @@ components:
         identities:
           type: array
           items:
-            type: object
+            $ref: "#/components/schemas/IdentitySchema"
         banned_until:
           type: string
           format: date-time
@@ -1853,6 +1853,8 @@ components:
         deleted_at:
           type: string
           format: date-time
+        is_anonymous:
+          type: boolean
 
     SAMLAttributeMappingSchema:
       type: object
@@ -1957,6 +1959,35 @@ components:
           description: |-
             Usually one of:
             - totp
+
+    IdentitySchema:
+      type: object
+      properties:
+        identity_id:
+          type: string
+          format: uuid
+        id:
+          type: string
+          format: uuid
+        user_id:
+          type: string
+          format: uuid
+        identity_data:
+          type: object
+        provider:
+          type: string
+        last_sign_in_at:
+          type: string
+          format: date-time
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+        email:
+          type: string
+          format: email
 
   responses:
     OAuthCallbackRedirectResponse:


### PR DESCRIPTION
## What kind of change does this PR introduce?

Adds the `Identity` and `is_anonymous` fields to OpenAPI spec. This is so we can use the `openapi.yml` as a sgeneral reference  from which to generate Hook Payloads, which contain `User` objects.

Identity Fields taken from the [identity model](https://github.com/supabase/auth/blob/master/internal/api/identity.go)

## More Context

User objects are generated by:

1.  Converting the `openapi.yml` into JSONSchema. Currently this is done via OpenAI though a modified version of [a yml to jsonschema converter should work with modifications as well](https://www.npmjs.com/package/yaml-to-json-schema). We don't use the latter as there's an additional step of converting the output jsonschema into a format that JSON Faker can accept (adding the JSONSchema version etc)
2. Using [JSONSchema to generate a fake payload](https://json-schema-faker.js.org/)

## Use

The plan is to embed the JSONSchema into each Hook example so developers can copy paste into JSONSchema Faker or similar tool to generate a fake payload. 


