### PR TITLE
fix: use api_external_url domain as localname

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -72,7 +72,7 @@ require (
 	github.com/jackc/pgx/v4 v4.18.2
 	github.com/standard-webhooks/standard-webhooks/libraries v0.0.0-20240303152453-e0e82adf1721
 	github.com/supabase/hibp v0.0.0-20231124125943-d225752ae869
-	github.com/supabase/mailme v0.1.0
+	github.com/supabase/mailme v0.2.0
 	github.com/xeipuuv/gojsonschema v1.2.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -492,6 +492,8 @@ github.com/supabase/hibp v0.0.0-20231124125943-d225752ae869 h1:VDuRtwen5Z7QQ5ctu
 github.com/supabase/hibp v0.0.0-20231124125943-d225752ae869/go.mod h1:eHX5nlSMSnyPjUrbYzeqrA8snCe2SKyfizKjU3dkfOw=
 github.com/supabase/mailme v0.1.0 h1:1InJqMMPTFqZfRZ/gnsCwOc+oUWCFuxSXhlCCG6zYUo=
 github.com/supabase/mailme v0.1.0/go.mod h1:kWsnmPfUBZTavlXYkfJrE9unzmmRAIi/kqsxXfEWEY8=
+github.com/supabase/mailme v0.2.0 h1:39LHZ4+YOeqoN4MiuncPBC3JarExAa0flmokM24qHNU=
+github.com/supabase/mailme v0.2.0/go.mod h1:kWsnmPfUBZTavlXYkfJrE9unzmmRAIi/kqsxXfEWEY8=
 github.com/twmb/murmur3 v1.1.6 h1:mqrRot1BRxm+Yct+vavLMou2/iJt0tNVTTC0QoIjaZg=
 github.com/twmb/murmur3 v1.1.6/go.mod h1:Qq/R7NUyOfr65zD+6Q5IHKsJLwP7exErjN6lyyq3OSQ=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f h1:J9EGpcZtP0E/raorCMxlFGSTBrsSlaDGf3jU/qvAE2c=

--- a/internal/mailer/mailer.go
+++ b/internal/mailer/mailer.go
@@ -50,6 +50,7 @@ func NewMailer(globalConfig *conf.GlobalConfiguration) Mailer {
 	mail.SetHeader("Message-ID", fmt.Sprintf("<%s@gotrue-mailer>", uuid.Must(uuid.NewV4()).String()))
 
 	from := mail.FormatAddress(globalConfig.SMTP.AdminEmail, globalConfig.SMTP.SenderName)
+	u, _ := url.ParseRequestURI(globalConfig.API.ExternalURL)
 
 	var mailClient MailClient
 	if globalConfig.SMTP.Host == "" {
@@ -57,13 +58,14 @@ func NewMailer(globalConfig *conf.GlobalConfiguration) Mailer {
 		mailClient = &noopMailClient{}
 	} else {
 		mailClient = &mailme.Mailer{
-			Host:    globalConfig.SMTP.Host,
-			Port:    globalConfig.SMTP.Port,
-			User:    globalConfig.SMTP.User,
-			Pass:    globalConfig.SMTP.Pass,
-			From:    from,
-			BaseURL: globalConfig.SiteURL,
-			Logger:  logrus.StandardLogger(),
+			Host:      globalConfig.SMTP.Host,
+			Port:      globalConfig.SMTP.Port,
+			User:      globalConfig.SMTP.User,
+			Pass:      globalConfig.SMTP.Pass,
+			LocalName: u.Hostname(),
+			From:      from,
+			BaseURL:   globalConfig.SiteURL,
+			Logger:    logrus.StandardLogger(),
 		}
 	}
 


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Fixes an issue where some SMTP providers reject requests when the SMTP client uses a Local Name that is identical to the SMTP Host name.