### PR TITLE
fix: sms verify should update is_anonymous field

### DIFF
--- a/internal/api/anonymous_test.go
+++ b/internal/api/anonymous_test.go
@@ -98,7 +98,7 @@ func (ts *AnonymousTestSuite) TestConvertAnonymousUserToPermanent() {
 			verificationType: "email_change",
 		},
 		{
-			desc: "convert anonymous user to permanent user with email",
+			desc: "convert anonymous user to permanent user with phone",
 			body: map[string]interface{}{
 				"phone": "1234567890",
 			},

--- a/internal/api/verify.go
+++ b/internal/api/verify.go
@@ -406,6 +406,13 @@ func (a *API) smsVerify(r *http.Request, conn *storage.Connection, user *models.
 			}
 		}
 
+		if user.IsAnonymous {
+			user.IsAnonymous = false
+			if terr := tx.UpdateOnly(user, "is_anonymous"); terr != nil {
+				return terr
+			}
+		}
+
 		if terr := tx.Load(user, "Identities"); terr != nil {
 			return internalServerError("Error refetching identities").WithInternalError(terr)
 		}


### PR DESCRIPTION
## What kind of change does this PR introduce?
* verifying the phone number of a user should update the `is_anonymous` field to false
* add test to prevent any future regression