### PR TITLE
feat: new timeout writer implementation

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -102,7 +102,7 @@ func NewAPIWithVersion(globalConfig *conf.GlobalConfiguration, db *storage.Conne
 	r.UseBypass(recoverer)
 
 	if globalConfig.API.MaxRequestDuration > 0 {
-		r.UseBypass(api.timeoutMiddleware(globalConfig.API.MaxRequestDuration))
+		r.UseBypass(timeoutMiddleware(globalConfig.API.MaxRequestDuration))
 	}
 
 	// request tracing should be added only when tracing or metrics is enabled

--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -322,7 +322,7 @@ func (t *timeoutResponseWriter) finallyWrite(w http.ResponseWriter) {
 	}
 }
 
-func (a *API) timeoutMiddleware(timeout time.Duration) func(http.Handler) http.Handler {
+func timeoutMiddleware(timeout time.Duration) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			ctx, cancel := context.WithTimeout(r.Context(), timeout)

--- a/internal/api/middleware_test.go
+++ b/internal/api/middleware_test.go
@@ -335,3 +335,24 @@ func (ts *MiddlewareTestSuite) TestTimeoutMiddleware() {
 	require.Equal(ts.T(), float64(504), data["code"])
 	require.NotNil(ts.T(), data["msg"])
 }
+
+func TestTimeoutResponseWriter(t *testing.T) {
+	// timeoutResponseWriter should exhitbit a similar behavior as http.ResponseWriter
+	req := httptest.NewRequest(http.MethodGet, "http://localhost", nil)
+	w1 := httptest.NewRecorder()
+	w2 := httptest.NewRecorder()
+
+	timeoutHandler := timeoutMiddleware(time.Second * 10)
+
+	redirectHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// tries to redirect twice
+		http.Redirect(w, r, "http://localhost:3001/#message=first_message", http.StatusSeeOther)
+
+		// overwrites the first
+		http.Redirect(w, r, "http://localhost:3001/second", http.StatusSeeOther)
+	})
+	timeoutHandler(redirectHandler).ServeHTTP(w1, req)
+	redirectHandler.ServeHTTP(w2, req)
+
+	require.Equal(t, w1.Result(), w2.Result())
+}

--- a/internal/api/middleware_test.go
+++ b/internal/api/middleware_test.go
@@ -319,7 +319,7 @@ func (ts *MiddlewareTestSuite) TestTimeoutMiddleware() {
 	req := httptest.NewRequest(http.MethodGet, "http://localhost", nil)
 	w := httptest.NewRecorder()
 
-	timeoutHandler := ts.API.timeoutMiddleware(ts.Config.API.MaxRequestDuration)
+	timeoutHandler := timeoutMiddleware(ts.Config.API.MaxRequestDuration)
 
 	slowHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Sleep for 1 second to simulate a slow handler which should trigger the timeout


### PR DESCRIPTION
#1529 introduced timeout middleware, but it appears from working in the wild it has some race conditions that are not particularly helpful.

This PR rewrites the implementation to get rid of race conditions, at the expense of slightly higher RAM usage. It follows the implementation of `http.TimeoutHandler` closely.