### PR TITLE
feat: add SAML specific external URL config

### DIFF
--- a/internal/api/saml.go
+++ b/internal/api/saml.go
@@ -14,10 +14,24 @@ import (
 // getSAMLServiceProvider generates a new service provider object with the
 // (optionally) provided descriptor (metadata) for the identity provider.
 func (a *API) getSAMLServiceProvider(identityProvider *saml.EntityDescriptor, idpInitiated bool) *saml.ServiceProvider {
-	externalURL, err := url.ParseRequestURI(a.config.API.ExternalURL)
-	if err != nil {
-		// this should not fail as a.config should have been validated using #Validate()
-		panic(err)
+	var externalURL *url.URL
+
+	if a.config.SAML.ExternalURL != "" {
+		url, err := url.ParseRequestURI(a.config.SAML.ExternalURL)
+		if err != nil {
+			// this should not fail as a.config should have been validated using #Validate()
+			panic(err)
+		}
+
+		externalURL = url
+	} else {
+		url, err := url.ParseRequestURI(a.config.API.ExternalURL)
+		if err != nil {
+			// this should not fail as a.config should have been validated using #Validate()
+			panic(err)
+		}
+
+		externalURL = url
 	}
 
 	if !strings.HasSuffix(externalURL.Path, "/") {

--- a/internal/conf/saml.go
+++ b/internal/conf/saml.go
@@ -23,6 +23,8 @@ type SAMLConfiguration struct {
 	RSAPublicKey  *rsa.PublicKey    `json:"-"`
 	Certificate   *x509.Certificate `json:"-"`
 
+	ExternalURL string `json:"external_url,omitempty" split_words:"true"`
+
 	RateLimitAssertion float64 `default:"15" split_words:"true"`
 }
 
@@ -53,6 +55,13 @@ func (c *SAMLConfiguration) Validate() error {
 
 		if c.RelayStateValidityPeriod < 0 {
 			return errors.New("SAML RelayState validity period should be a positive duration")
+		}
+
+		if c.ExternalURL != "" {
+			_, err := url.ParseRequestURI(c.ExternalURL)
+			if err != nil {
+				return err
+			}
 		}
 	}
 


### PR DESCRIPTION
Adds a SAML-specific external URL config, which allows the advertised SAML metadata to be different than the one defined with the API external URL.

This is useful in projects that use proxies or custom domains which can be very disruptive with SAML as a new connection with the IDP needs to be established. By configuring `GOTRUE_SAML_EXTERNAL_URL` to the URL before the custom domain was set up, Auth will advertise the correct metadata.