### PR TITLE
ci: upgrade local dockerfile go version

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM golang:1.21-alpine
+FROM golang:1.22.3-alpine3.20
 ENV GO111MODULE=on
 ENV CGO_ENABLED=0
 ENV GOOS=linux


### PR DESCRIPTION
Local Dockerfile needs to use go 1.22.3 too.