### PR TITLE
Update identities email_verified on email signup

### DIFF
--- a/internal/api/verify.go
+++ b/internal/api/verify.go
@@ -337,7 +337,9 @@ func (a *API) signupVerify(r *http.Request, ctx context.Context, conn *storage.C
 		}
 
 		if identity, terr := models.FindIdentityByIdAndProvider(tx, user.ID.String(), "email"); terr != nil {
-			return terr
+			if !models.IsNotFoundError(terr) {
+				return terr
+			}
 		} else {
 			if terr := identity.UpdateIdentityData(tx, map[string]interface{}{
 				"email_verified": true,

--- a/internal/api/verify.go
+++ b/internal/api/verify.go
@@ -335,6 +335,16 @@ func (a *API) signupVerify(r *http.Request, ctx context.Context, conn *storage.C
 		if terr = user.Confirm(tx); terr != nil {
 			return internalServerError("Error confirming user").WithInternalError(terr)
 		}
+
+		if identity, terr := models.FindIdentityByIdAndProvider(tx, user.ID.String(), "email"); terr != nil {
+			return terr
+		} else {
+			if terr := identity.UpdateIdentityData(tx, map[string]interface{}{
+				"email_verified": true,
+			}); terr != nil {
+				return terr
+			}
+		}
 		return nil
 	})
 	if err != nil {

--- a/internal/models/user.go
+++ b/internal/models/user.go
@@ -382,6 +382,12 @@ func (u *User) Confirm(tx *storage.Connection) error {
 		return err
 	}
 
+	if err := u.UpdateUserMetaData(tx, map[string]interface{}{
+		"email_verified": true,
+	}); err != nil {
+		return err
+	}
+
 	if err := ClearAllOneTimeTokensForUser(tx, u.ID); err != nil {
 		return err
 	}


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR fixes a bug where the email_verified field in the identities table is not updated when a user's email is confirmed. This change ensures that the email verification status is correctly reflected in the JWT.

## What is the current behavior?

When the user gets an email confirmation link the GET /verify request is called. This goes through the verifyGet method which then calls the signupVerify method. There the AuditLogEntry is created, then the Confirm method on the user is called which updates the `confirmation_token` and `email_confirmed_at`, and also clears the OneTimeTokens for the user. However, the `email_confirmed` field on the identities table does not get updated to true. 

#1620 

## What is the new behavior?

When a GET /verify request is called for a mail signup verification, the signupVerify method now updates the `email_verified` property to true on the `identity_data` field on the `identities` table