### PR TITLE
fix: add ip based limiter

### DIFF
--- a/internal/conf/configuration.go
+++ b/internal/conf/configuration.go
@@ -223,6 +223,7 @@ type GlobalConfiguration struct {
 	RateLimitTokenRefresh   float64 `split_words:"true" default:"150"`
 	RateLimitSso            float64 `split_words:"true" default:"30"`
 	RateLimitAnonymousUsers float64 `split_words:"true" default:"30"`
+	RateLimitOtp            float64 `split_words:"true" default:"30"`
 
 	SiteURL         string   `json:"site_url" split_words:"true" required:"true"`
 	URIAllowList    []string `json:"uri_allow_list" split_words:"true"`


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Adds ip-based rate limiting on all endpoints that send OTPs either through email or phone with the config `GOTRUE_RATE_LIMIT_OTP` 
* IP-based rate limiting should always come before the shared limiter, so as to prevent the quota of the shared limiter from being consumed too quickly by the same ip-address