### PR TITLE
fix: revert changes to auth functions

### DIFF
--- a/migrations/20240624145325_recreate_auth_functions.up.sql
+++ b/migrations/20240624145325_recreate_auth_functions.up.sql
@@ -1,0 +1,52 @@
+-- set the search_path to an empty string to force fully qualified names in the function 
+do $$ 
+begin
+    -- auth.uid() function
+    create or replace function auth.uid() 
+        returns uuid 
+        set search_path to '' 
+    as $func$
+        select nullif(
+           coalesce(
+             current_setting('request.jwt.claim.sub', true),
+             (current_setting('request.jwt.claims', true)::jsonb ->> 'sub')
+           ),
+           ''
+        )::uuid
+    $func$ language sql stable;
+
+    -- auth.role() function
+    create or replace function {{ index .Options "Namespace" }}.role() 
+        returns text 
+        set search_path to ''
+    as $func$
+        select
+         coalesce(
+           nullif(current_setting('request.jwt.claim.role', true), ''),
+           (nullif(current_setting('request.jwt.claims', true), '')::jsonb ->> 'role')
+         )::text
+    $func$ language sql stable;
+
+    -- auth.email() function
+    create or replace function {{ index .Options "Namespace" }}.email()
+       returns text
+       set search_path to ''
+    as $func$
+       select
+         coalesce(
+           nullif(current_setting('request.jwt.claim.email', true), ''),
+           (nullif(current_setting('request.jwt.claims', true), '')::jsonb ->> 'email')
+         )::text
+    $func$ language sql stable;
+
+    -- auth.jwt() function
+    create or replace function {{ index .Options "Namespace" }}.jwt()
+       returns jsonb
+    as $func$
+      select
+        coalesce(
+          nullif(current_setting('request.jwt.claim', true), ''),
+          nullif(current_setting('request.jwt.claims', true), '')
+        )::jsonb
+    $func$ language sql stable;
+end $$;


### PR DESCRIPTION
## What kind of change does this PR introduce?

The changes in Auth v2.154.1 are not compatible with the User Impersonation feature on the dashboard. 

This is because of changes which affect `auth.*` functions (e.g. `auth.uid()`). Ostensibly, newer versions of PostgREST set store claims under `request.jwt.claims` rather than `request.jwt.claim.sub` which might have lead to  `auth.uid()` etc returning null instead of the user ID as expected.

We revert the change by reinstating the older version of the functions. We preserve `search_path=''` though.

For more context see: https://supabase.slack.com/archives/C07A55TKL3S/p1719237535404369


Draft as it is being tested
