### PR TITLE
fix: search path

### DIFF
--- a/migrations/20240612114525_set_search_path.up.sql
+++ b/migrations/20240612114525_set_search_path.up.sql
@@ -1,0 +1,43 @@
+-- set the search_path to an empty string to force fully qualified names in the function 
+do $$ 
+begin
+    -- auth.uid() function
+    create or replace function auth.uid() 
+        returns uuid 
+        set search_path to '' 
+    as $func$
+        select nullif(current_setting('request.jwt.claim.sub', true), '')::uuid;
+    $func$ language sql stable;
+
+    -- auth.role() function
+    create or replace function {{ index .Options "Namespace" }}.role() 
+        returns text 
+        set search_path to ''
+    as $func$
+        select nullif(current_setting('request.jwt.claim.role', true), '')::text;
+    $func$ language sql stable;
+
+    -- auth.email() function
+    create or replace function {{ index .Options "Namespace" }}.email() 
+        returns text 
+        set search_path to ''
+    as $func$
+        select 
+        coalesce(
+            current_setting('request.jwt.claim.email', true),
+            (current_setting('request.jwt.claims', true)::jsonb ->> 'email')
+        )::text
+    $func$ language sql stable;
+
+    -- auth.jwt() function
+    create or replace function {{ index .Options "Namespace" }}.jwt()
+        returns jsonb
+        set search_path to ''
+    as $func$
+        select 
+        coalesce(
+            nullif(current_setting('request.jwt.claim', true), ''),
+            nullif(current_setting('request.jwt.claims', true), '')
+        )::jsonb;
+    $func$ language sql stable;
+end $$;

--- a/migrations/20240612114525_set_search_path.up.sql
+++ b/migrations/20240612114525_set_search_path.up.sql
@@ -6,7 +6,10 @@ begin
         returns uuid 
         set search_path to '' 
     as $func$
-        select nullif(current_setting('request.jwt.claim.sub', true), '')::uuid;
+        select coalesce(
+            nullif(current_setting('request.jwt.claim.sub', true), ''),
+            (nullif(current_setting('request.jwt.claims', true), '')::jsonb ->> 'sub')
+        )::uuid
     $func$ language sql stable;
 
     -- auth.role() function
@@ -14,7 +17,10 @@ begin
         returns text 
         set search_path to ''
     as $func$
-        select nullif(current_setting('request.jwt.claim.role', true), '')::text;
+        select coalesce(
+            nullif(current_setting('request.jwt.claim.role', true), ''),
+            (nullif(current_setting('request.jwt.claims', true), '')::jsonb ->> 'role')
+        )::text
     $func$ language sql stable;
 
     -- auth.email() function


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Revert https://github.com/supabase/auth/pull/1634
* Also, updates the definition of the `auth.uid()` and `auth.role()` function to account for the change in postgres 14, which made this impossible: `current_setting(`request.jwt.claim.my-claim`, true)` (thus always returning null), so we need to also include `current_setting('request.jwt.claims', true), '')::jsonb ->> 'sub'` (note the s in claims)