### PR TITLE
fix: use pointer for `user.EncryptedPassword`

### DIFF
--- a/internal/api/invite_test.go
+++ b/internal/api/invite_test.go
@@ -207,7 +207,7 @@ func (ts *InviteTestSuite) TestVerifyInvite() {
 			now := time.Now()
 			user.InvitedAt = &now
 			user.ConfirmationSentAt = &now
-			user.EncryptedPassword = ""
+			user.EncryptedPassword = nil
 			user.ConfirmationToken = crypto.GenerateTokenHash(c.email, c.requestBody["token"].(string))
 			require.NoError(ts.T(), err)
 			require.NoError(ts.T(), ts.API.db.Create(user))

--- a/internal/api/user.go
+++ b/internal/api/user.go
@@ -155,7 +155,7 @@ func (a *API) UserUpdate(w http.ResponseWriter, r *http.Request) error {
 		if password != "" {
 			isSamePassword := false
 
-			if user.EncryptedPassword != "" {
+			if user.HasPassword() {
 				auth, _, err := user.Authenticate(ctx, password, config.Security.DBEncryption.DecryptionKeys, false, "")
 				if err != nil {
 					return err

--- a/internal/api/verify.go
+++ b/internal/api/verify.go
@@ -306,7 +306,7 @@ func (a *API) verifyPost(w http.ResponseWriter, r *http.Request, params *VerifyP
 func (a *API) signupVerify(r *http.Request, ctx context.Context, conn *storage.Connection, user *models.User) (*models.User, error) {
 	config := a.config
 
-	if user.EncryptedPassword == "" && user.InvitedAt != nil {
+	if !user.HasPassword() && user.InvitedAt != nil {
 		// sign them up with temporary password, and require application
 		// to present the user with a password set form
 		password, err := password.Generate(64, 10, 0, false, true)
@@ -322,7 +322,7 @@ func (a *API) signupVerify(r *http.Request, ctx context.Context, conn *storage.C
 
 	err := conn.Transaction(func(tx *storage.Connection) error {
 		var terr error
-		if user.EncryptedPassword == "" && user.InvitedAt != nil {
+		if !user.HasPassword() && user.InvitedAt != nil {
 			if terr = user.UpdatePassword(tx, nil); terr != nil {
 				return internalServerError("Error storing password").WithInternalError(terr)
 			}


### PR DESCRIPTION
Makes sure that `NULL` values in the `auth.users.encrypted_password` column are not met with SQL serialization errors.