### PR TITLE
fix: upgrade golang-jwt to v5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,6 @@ require (
 	github.com/gobuffalo/validate/v3 v3.3.3 // indirect
 	github.com/gobwas/glob v0.2.3
 	github.com/gofrs/uuid v4.3.1+incompatible
-	github.com/golang-jwt/jwt v3.2.2+incompatible
 	github.com/jackc/pgconn v1.14.3
 	github.com/jackc/pgerrcode v0.0.0-20201024163028-a0d42d470451
 	github.com/jackc/pgproto3/v2 v2.3.3 // indirect
@@ -38,6 +37,7 @@ require (
 	github.com/bits-and-blooms/bitset v1.10.0 // indirect
 	github.com/go-jose/go-jose/v3 v3.0.3 // indirect
 	github.com/gobuffalo/nulls v0.4.2 // indirect
+	github.com/jackc/pgx/v4 v4.18.2 // indirect
 	github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f // indirect
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
 	golang.org/x/mod v0.9.0 // indirect
@@ -67,7 +67,7 @@ require (
 	github.com/fatih/structs v1.1.0
 	github.com/go-chi/chi/v5 v5.0.12
 	github.com/gobuffalo/pop/v6 v6.1.1
-	github.com/jackc/pgx/v4 v4.18.2
+	github.com/golang-jwt/jwt/v5 v5.2.1
 	github.com/standard-webhooks/standard-webhooks/libraries v0.0.0-20240303152453-e0e82adf1721
 	github.com/supabase/hibp v0.0.0-20231124125943-d225752ae869
 	github.com/supabase/mailme v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -107,10 +107,10 @@ github.com/gofrs/uuid v4.0.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRx
 github.com/gofrs/uuid v4.2.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
 github.com/gofrs/uuid v4.3.1+incompatible h1:0/KbAdpx3UXAx1kEOWHJeOkpbgRFGHVgv+CFIY7dBJI=
 github.com/gofrs/uuid v4.3.1+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
-github.com/golang-jwt/jwt v3.2.2+incompatible h1:IfV12K8xAKAnZqdXVzCZ+TOjboZ2keLg81eXfW3O+oY=
-github.com/golang-jwt/jwt v3.2.2+incompatible/go.mod h1:8pz2t5EyA70fFQQSrl6XZXzqecmYZeUEB8OUGHkxJ+I=
 github.com/golang-jwt/jwt/v4 v4.4.3 h1:Hxl6lhQFj4AnOX6MLrsCb/+7tCj7DxP7VA+2rDIq5AU=
 github.com/golang-jwt/jwt/v4 v4.4.3/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
+github.com/golang-jwt/jwt/v5 v5.2.1 h1:OuVbFODueb089Lh128TAcimifWaLhJwVflnrgM17wHk=
+github.com/golang-jwt/jwt/v5 v5.2.1/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
 github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
 github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek=

--- a/internal/api/admin_test.go
+++ b/internal/api/admin_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"time"
 
-	jwt "github.com/golang-jwt/jwt"
+	jwt "github.com/golang-jwt/jwt/v5"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"

--- a/internal/api/anonymous_test.go
+++ b/internal/api/anonymous_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 
 	"github.com/gofrs/uuid"
-	jwt "github.com/golang-jwt/jwt"
+	jwt "github.com/golang-jwt/jwt/v5"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"

--- a/internal/api/audit_test.go
+++ b/internal/api/audit_test.go
@@ -7,7 +7,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	jwt "github.com/golang-jwt/jwt"
+	jwt "github.com/golang-jwt/jwt/v5"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -58,7 +58,7 @@ func (ts *AuditTestSuite) makeSuperAdmin(email string) string {
 	token, _, err = ts.API.generateAccessToken(req, ts.API.db, u, &session.ID, models.PasswordGrant)
 	require.NoError(ts.T(), err, "Error generating access token")
 
-	p := jwt.Parser{ValidMethods: []string{jwt.SigningMethodHS256.Name}}
+	p := jwt.NewParser(jwt.WithValidMethods([]string{jwt.SigningMethodHS256.Name}))
 	_, err = p.Parse(token, func(token *jwt.Token) (interface{}, error) {
 		return []byte(ts.Config.JWT.Secret), nil
 	})

--- a/internal/api/auth.go
+++ b/internal/api/auth.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 
 	"github.com/gofrs/uuid"
-	jwt "github.com/golang-jwt/jwt"
+	jwt "github.com/golang-jwt/jwt/v5"
 	"github.com/supabase/auth/internal/models"
 	"github.com/supabase/auth/internal/storage"
 )
@@ -75,7 +75,7 @@ func (a *API) parseJWTClaims(bearer string, r *http.Request) (context.Context, e
 	ctx := r.Context()
 	config := a.config
 
-	p := jwt.Parser{ValidMethods: []string{jwt.SigningMethodHS256.Name}}
+	p := jwt.NewParser(jwt.WithValidMethods([]string{jwt.SigningMethodHS256.Name}))
 	token, err := p.ParseWithClaims(bearer, &AccessTokenClaims{}, func(token *jwt.Token) (interface{}, error) {
 		return []byte(config.JWT.Secret), nil
 	})

--- a/internal/api/auth_test.go
+++ b/internal/api/auth_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/gofrs/uuid"
-	jwt "github.com/golang-jwt/jwt"
+	jwt "github.com/golang-jwt/jwt/v5"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"github.com/supabase/auth/internal/conf"
@@ -91,7 +91,7 @@ func (ts *AuthTestSuite) TestMaybeLoadUserOrSession() {
 		{
 			Desc: "Missing Subject Claim",
 			UserJwtClaims: &AccessTokenClaims{
-				StandardClaims: jwt.StandardClaims{
+				RegisteredClaims: jwt.RegisteredClaims{
 					Subject: "",
 				},
 				Role: "authenticated",
@@ -102,7 +102,7 @@ func (ts *AuthTestSuite) TestMaybeLoadUserOrSession() {
 		{
 			Desc: "Valid Subject Claim",
 			UserJwtClaims: &AccessTokenClaims{
-				StandardClaims: jwt.StandardClaims{
+				RegisteredClaims: jwt.RegisteredClaims{
 					Subject: u.ID.String(),
 				},
 				Role: "authenticated",
@@ -113,7 +113,7 @@ func (ts *AuthTestSuite) TestMaybeLoadUserOrSession() {
 		{
 			Desc: "Invalid Subject Claim",
 			UserJwtClaims: &AccessTokenClaims{
-				StandardClaims: jwt.StandardClaims{
+				RegisteredClaims: jwt.RegisteredClaims{
 					Subject: "invalid-subject-claim",
 				},
 				Role: "authenticated",
@@ -124,7 +124,7 @@ func (ts *AuthTestSuite) TestMaybeLoadUserOrSession() {
 		{
 			Desc: "Empty Session ID Claim",
 			UserJwtClaims: &AccessTokenClaims{
-				StandardClaims: jwt.StandardClaims{
+				RegisteredClaims: jwt.RegisteredClaims{
 					Subject: u.ID.String(),
 				},
 				Role:      "authenticated",
@@ -136,7 +136,7 @@ func (ts *AuthTestSuite) TestMaybeLoadUserOrSession() {
 		{
 			Desc: "Invalid Session ID Claim",
 			UserJwtClaims: &AccessTokenClaims{
-				StandardClaims: jwt.StandardClaims{
+				RegisteredClaims: jwt.RegisteredClaims{
 					Subject: u.ID.String(),
 				},
 				Role:      "authenticated",
@@ -148,7 +148,7 @@ func (ts *AuthTestSuite) TestMaybeLoadUserOrSession() {
 		{
 			Desc: "Valid Session ID Claim",
 			UserJwtClaims: &AccessTokenClaims{
-				StandardClaims: jwt.StandardClaims{
+				RegisteredClaims: jwt.RegisteredClaims{
 					Subject: u.ID.String(),
 				},
 				Role:      "authenticated",
@@ -161,7 +161,7 @@ func (ts *AuthTestSuite) TestMaybeLoadUserOrSession() {
 		{
 			Desc: "Session ID doesn't exist",
 			UserJwtClaims: &AccessTokenClaims{
-				StandardClaims: jwt.StandardClaims{
+				RegisteredClaims: jwt.RegisteredClaims{
 					Subject: u.ID.String(),
 				},
 				Role:      "authenticated",

--- a/internal/api/context.go
+++ b/internal/api/context.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"net/url"
 
-	jwt "github.com/golang-jwt/jwt"
+	jwt "github.com/golang-jwt/jwt/v5"
 	"github.com/supabase/auth/internal/models"
 )
 

--- a/internal/api/external.go
+++ b/internal/api/external.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/fatih/structs"
 	"github.com/gofrs/uuid"
-	jwt "github.com/golang-jwt/jwt"
+	jwt "github.com/golang-jwt/jwt/v5"
 	"github.com/sirupsen/logrus"
 	"github.com/supabase/auth/internal/api/provider"
 	"github.com/supabase/auth/internal/models"
@@ -89,8 +89,8 @@ func (a *API) GetExternalProviderRedirectURL(w http.ResponseWriter, r *http.Requ
 
 	claims := ExternalProviderClaims{
 		AuthMicroserviceClaims: AuthMicroserviceClaims{
-			StandardClaims: jwt.StandardClaims{
-				ExpiresAt: time.Now().Add(5 * time.Minute).Unix(),
+			RegisteredClaims: jwt.RegisteredClaims{
+				ExpiresAt: jwt.NewNumericDate(time.Now().Add(5 * time.Minute)),
 			},
 			SiteURL:    config.SiteURL,
 			InstanceID: uuid.Nil.String(),
@@ -481,7 +481,7 @@ func (a *API) processInvite(r *http.Request, tx *storage.Connection, userData *p
 func (a *API) loadExternalState(ctx context.Context, state string) (context.Context, error) {
 	config := a.config
 	claims := ExternalProviderClaims{}
-	p := jwt.Parser{ValidMethods: []string{jwt.SigningMethodHS256.Name}}
+	p := jwt.NewParser(jwt.WithValidMethods([]string{jwt.SigningMethodHS256.Name}))
 	_, err := p.ParseWithClaims(state, &claims, func(token *jwt.Token) (interface{}, error) {
 		return []byte(config.JWT.Secret), nil
 	})

--- a/internal/api/external_apple_test.go
+++ b/internal/api/external_apple_test.go
@@ -5,7 +5,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 
-	jwt "github.com/golang-jwt/jwt"
+	jwt "github.com/golang-jwt/jwt/v5"
 )
 
 func (ts *ExternalTestSuite) TestSignupExternalApple() {
@@ -22,7 +22,7 @@ func (ts *ExternalTestSuite) TestSignupExternalApple() {
 	ts.Equal("email name", q.Get("scope"))
 
 	claims := ExternalProviderClaims{}
-	p := jwt.Parser{ValidMethods: []string{jwt.SigningMethodHS256.Name}}
+	p := jwt.NewParser(jwt.WithValidMethods([]string{jwt.SigningMethodHS256.Name}))
 	_, err = p.ParseWithClaims(q.Get("state"), &claims, func(token *jwt.Token) (interface{}, error) {
 		return []byte(ts.Config.JWT.Secret), nil
 	})

--- a/internal/api/external_azure_test.go
+++ b/internal/api/external_azure_test.go
@@ -15,7 +15,7 @@ import (
 	"time"
 
 	"github.com/coreos/go-oidc/v3/oidc"
-	jwt "github.com/golang-jwt/jwt"
+	jwt "github.com/golang-jwt/jwt/v5"
 	"github.com/supabase/auth/internal/api/provider"
 )
 
@@ -116,7 +116,7 @@ func (ts *ExternalTestSuite) TestSignupExternalAzure() {
 	ts.Equal("openid", q.Get("scope"))
 
 	claims := ExternalProviderClaims{}
-	p := jwt.Parser{ValidMethods: []string{jwt.SigningMethodHS256.Name}}
+	p := jwt.NewParser(jwt.WithValidMethods([]string{jwt.SigningMethodHS256.Name}))
 	_, err = p.ParseWithClaims(q.Get("state"), &claims, func(token *jwt.Token) (interface{}, error) {
 		return []byte(ts.Config.JWT.Secret), nil
 	})

--- a/internal/api/external_bitbucket_test.go
+++ b/internal/api/external_bitbucket_test.go
@@ -6,7 +6,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 
-	jwt "github.com/golang-jwt/jwt"
+	jwt "github.com/golang-jwt/jwt/v5"
 )
 
 const (
@@ -27,7 +27,7 @@ func (ts *ExternalTestSuite) TestSignupExternalBitbucket() {
 	ts.Equal("account email", q.Get("scope"))
 
 	claims := ExternalProviderClaims{}
-	p := jwt.Parser{ValidMethods: []string{jwt.SigningMethodHS256.Name}}
+	p := jwt.NewParser(jwt.WithValidMethods([]string{jwt.SigningMethodHS256.Name}))
 	_, err = p.ParseWithClaims(q.Get("state"), &claims, func(token *jwt.Token) (interface{}, error) {
 		return []byte(ts.Config.JWT.Secret), nil
 	})

--- a/internal/api/external_discord_test.go
+++ b/internal/api/external_discord_test.go
@@ -6,7 +6,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 
-	jwt "github.com/golang-jwt/jwt"
+	jwt "github.com/golang-jwt/jwt/v5"
 )
 
 const (
@@ -29,7 +29,7 @@ func (ts *ExternalTestSuite) TestSignupExternalDiscord() {
 	ts.Equal("email identify", q.Get("scope"))
 
 	claims := ExternalProviderClaims{}
-	p := jwt.Parser{ValidMethods: []string{jwt.SigningMethodHS256.Name}}
+	p := jwt.NewParser(jwt.WithValidMethods([]string{jwt.SigningMethodHS256.Name}))
 	_, err = p.ParseWithClaims(q.Get("state"), &claims, func(token *jwt.Token) (interface{}, error) {
 		return []byte(ts.Config.JWT.Secret), nil
 	})

--- a/internal/api/external_facebook_test.go
+++ b/internal/api/external_facebook_test.go
@@ -6,7 +6,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 
-	jwt "github.com/golang-jwt/jwt"
+	jwt "github.com/golang-jwt/jwt/v5"
 )
 
 const (
@@ -29,7 +29,7 @@ func (ts *ExternalTestSuite) TestSignupExternalFacebook() {
 	ts.Equal("email", q.Get("scope"))
 
 	claims := ExternalProviderClaims{}
-	p := jwt.Parser{ValidMethods: []string{jwt.SigningMethodHS256.Name}}
+	p := jwt.NewParser(jwt.WithValidMethods([]string{jwt.SigningMethodHS256.Name}))
 	_, err = p.ParseWithClaims(q.Get("state"), &claims, func(token *jwt.Token) (interface{}, error) {
 		return []byte(ts.Config.JWT.Secret), nil
 	})

--- a/internal/api/external_figma_test.go
+++ b/internal/api/external_figma_test.go
@@ -11,7 +11,7 @@ import (
 	"net/url"
 	"time"
 
-	jwt "github.com/golang-jwt/jwt"
+	jwt "github.com/golang-jwt/jwt/v5"
 	"github.com/stretchr/testify/require"
 	"github.com/supabase/auth/internal/models"
 )
@@ -30,7 +30,7 @@ func (ts *ExternalTestSuite) TestSignupExternalFigma() {
 	ts.Equal("file_read", q.Get("scope"))
 
 	claims := ExternalProviderClaims{}
-	p := jwt.Parser{ValidMethods: []string{jwt.SigningMethodHS256.Name}}
+	p := jwt.NewParser(jwt.WithValidMethods([]string{jwt.SigningMethodHS256.Name}))
 	_, err = p.ParseWithClaims(q.Get("state"), &claims, func(token *jwt.Token) (interface{}, error) {
 		return []byte(ts.Config.JWT.Secret), nil
 	})

--- a/internal/api/external_fly_test.go
+++ b/internal/api/external_fly_test.go
@@ -11,7 +11,7 @@ import (
 	"net/url"
 	"time"
 
-	jwt "github.com/golang-jwt/jwt"
+	jwt "github.com/golang-jwt/jwt/v5"
 	"github.com/stretchr/testify/require"
 	"github.com/supabase/auth/internal/models"
 )
@@ -30,7 +30,7 @@ func (ts *ExternalTestSuite) TestSignupExternalFly() {
 	ts.Equal("read", q.Get("scope"))
 
 	claims := ExternalProviderClaims{}
-	p := jwt.Parser{ValidMethods: []string{jwt.SigningMethodHS256.Name}}
+	p := jwt.NewParser(jwt.WithValidMethods([]string{jwt.SigningMethodHS256.Name}))
 	_, err = p.ParseWithClaims(q.Get("state"), &claims, func(token *jwt.Token) (interface{}, error) {
 		return []byte(ts.Config.JWT.Secret), nil
 	})

--- a/internal/api/external_github_test.go
+++ b/internal/api/external_github_test.go
@@ -11,7 +11,7 @@ import (
 	"net/url"
 	"time"
 
-	jwt "github.com/golang-jwt/jwt"
+	jwt "github.com/golang-jwt/jwt/v5"
 	"github.com/stretchr/testify/require"
 	"github.com/supabase/auth/internal/models"
 )
@@ -30,7 +30,7 @@ func (ts *ExternalTestSuite) TestSignupExternalGithub() {
 	ts.Equal("user:email", q.Get("scope"))
 
 	claims := ExternalProviderClaims{}
-	p := jwt.Parser{ValidMethods: []string{jwt.SigningMethodHS256.Name}}
+	p := jwt.NewParser(jwt.WithValidMethods([]string{jwt.SigningMethodHS256.Name}))
 	_, err = p.ParseWithClaims(q.Get("state"), &claims, func(token *jwt.Token) (interface{}, error) {
 		return []byte(ts.Config.JWT.Secret), nil
 	})

--- a/internal/api/external_gitlab_test.go
+++ b/internal/api/external_gitlab_test.go
@@ -6,7 +6,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 
-	jwt "github.com/golang-jwt/jwt"
+	jwt "github.com/golang-jwt/jwt/v5"
 )
 
 const (
@@ -29,7 +29,7 @@ func (ts *ExternalTestSuite) TestSignupExternalGitlab() {
 	ts.Equal("read_user", q.Get("scope"))
 
 	claims := ExternalProviderClaims{}
-	p := jwt.Parser{ValidMethods: []string{jwt.SigningMethodHS256.Name}}
+	p := jwt.NewParser(jwt.WithValidMethods([]string{jwt.SigningMethodHS256.Name}))
 	_, err = p.ParseWithClaims(q.Get("state"), &claims, func(token *jwt.Token) (interface{}, error) {
 		return []byte(ts.Config.JWT.Secret), nil
 	})

--- a/internal/api/external_google_test.go
+++ b/internal/api/external_google_test.go
@@ -7,7 +7,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 
-	jwt "github.com/golang-jwt/jwt"
+	jwt "github.com/golang-jwt/jwt/v5"
 	"github.com/stretchr/testify/require"
 	"github.com/supabase/auth/internal/api/provider"
 )
@@ -34,7 +34,7 @@ func (ts *ExternalTestSuite) TestSignupExternalGoogle() {
 	ts.Equal("email profile", q.Get("scope"))
 
 	claims := ExternalProviderClaims{}
-	p := jwt.Parser{ValidMethods: []string{jwt.SigningMethodHS256.Name}}
+	p := jwt.NewParser(jwt.WithValidMethods([]string{jwt.SigningMethodHS256.Name}))
 	_, err = p.ParseWithClaims(q.Get("state"), &claims, func(token *jwt.Token) (interface{}, error) {
 		return []byte(ts.Config.JWT.Secret), nil
 	})

--- a/internal/api/external_kakao_test.go
+++ b/internal/api/external_kakao_test.go
@@ -8,7 +8,7 @@ import (
 	"net/url"
 	"time"
 
-	jwt "github.com/golang-jwt/jwt"
+	jwt "github.com/golang-jwt/jwt/v5"
 	"github.com/stretchr/testify/require"
 	"github.com/supabase/auth/internal/api/provider"
 	"github.com/supabase/auth/internal/models"
@@ -27,7 +27,7 @@ func (ts *ExternalTestSuite) TestSignupExternalKakao() {
 	ts.Equal("code", q.Get("response_type"))
 
 	claims := ExternalProviderClaims{}
-	p := jwt.Parser{ValidMethods: []string{jwt.SigningMethodHS256.Name}}
+	p := jwt.NewParser(jwt.WithValidMethods([]string{jwt.SigningMethodHS256.Name}))
 	_, err = p.ParseWithClaims(q.Get("state"), &claims, func(token *jwt.Token) (interface{}, error) {
 		return []byte(ts.Config.JWT.Secret), nil
 	})

--- a/internal/api/external_keycloak_test.go
+++ b/internal/api/external_keycloak_test.go
@@ -6,7 +6,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 
-	jwt "github.com/golang-jwt/jwt"
+	jwt "github.com/golang-jwt/jwt/v5"
 )
 
 const (
@@ -28,7 +28,7 @@ func (ts *ExternalTestSuite) TestSignupExternalKeycloak() {
 	ts.Equal("profile email", q.Get("scope"))
 
 	claims := ExternalProviderClaims{}
-	p := jwt.Parser{ValidMethods: []string{jwt.SigningMethodHS256.Name}}
+	p := jwt.NewParser(jwt.WithValidMethods([]string{jwt.SigningMethodHS256.Name}))
 	_, err = p.ParseWithClaims(q.Get("state"), &claims, func(token *jwt.Token) (interface{}, error) {
 		return []byte(ts.Config.JWT.Secret), nil
 	})

--- a/internal/api/external_linkedin_test.go
+++ b/internal/api/external_linkedin_test.go
@@ -6,7 +6,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 
-	jwt "github.com/golang-jwt/jwt"
+	jwt "github.com/golang-jwt/jwt/v5"
 )
 
 const (
@@ -30,7 +30,7 @@ func (ts *ExternalTestSuite) TestSignupExternalLinkedin() {
 	ts.Equal("r_emailaddress r_liteprofile", q.Get("scope"))
 
 	claims := ExternalProviderClaims{}
-	p := jwt.Parser{ValidMethods: []string{jwt.SigningMethodHS256.Name}}
+	p := jwt.NewParser(jwt.WithValidMethods([]string{jwt.SigningMethodHS256.Name}))
 	_, err = p.ParseWithClaims(q.Get("state"), &claims, func(token *jwt.Token) (interface{}, error) {
 		return []byte(ts.Config.JWT.Secret), nil
 	})

--- a/internal/api/external_notion_test.go
+++ b/internal/api/external_notion_test.go
@@ -6,7 +6,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 
-	jwt "github.com/golang-jwt/jwt"
+	jwt "github.com/golang-jwt/jwt/v5"
 )
 
 const (
@@ -28,7 +28,7 @@ func (ts *ExternalTestSuite) TestSignupExternalNotion() {
 	ts.Equal("code", q.Get("response_type"))
 
 	claims := ExternalProviderClaims{}
-	p := jwt.Parser{ValidMethods: []string{jwt.SigningMethodHS256.Name}}
+	p := jwt.NewParser(jwt.WithValidMethods([]string{jwt.SigningMethodHS256.Name}))
 	_, err = p.ParseWithClaims(q.Get("state"), &claims, func(token *jwt.Token) (interface{}, error) {
 		return []byte(ts.Config.JWT.Secret), nil
 	})

--- a/internal/api/external_slack_oidc_test.go
+++ b/internal/api/external_slack_oidc_test.go
@@ -5,7 +5,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 
-	jwt "github.com/golang-jwt/jwt"
+	jwt "github.com/golang-jwt/jwt/v5"
 )
 
 func (ts *ExternalTestSuite) TestSignupExternalSlackOIDC() {
@@ -22,7 +22,7 @@ func (ts *ExternalTestSuite) TestSignupExternalSlackOIDC() {
 	ts.Equal("profile email openid", q.Get("scope"))
 
 	claims := ExternalProviderClaims{}
-	p := jwt.Parser{ValidMethods: []string{jwt.SigningMethodHS256.Name}}
+	p := jwt.NewParser(jwt.WithValidMethods([]string{jwt.SigningMethodHS256.Name}))
 	_, err = p.ParseWithClaims(q.Get("state"), &claims, func(token *jwt.Token) (interface{}, error) {
 		return []byte(ts.Config.JWT.Secret), nil
 	})

--- a/internal/api/external_twitch_test.go
+++ b/internal/api/external_twitch_test.go
@@ -6,7 +6,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 
-	jwt "github.com/golang-jwt/jwt"
+	jwt "github.com/golang-jwt/jwt/v5"
 )
 
 const (
@@ -28,7 +28,7 @@ func (ts *ExternalTestSuite) TestSignupExternalTwitch() {
 	ts.Equal("user:read:email", q.Get("scope"))
 
 	claims := ExternalProviderClaims{}
-	p := jwt.Parser{ValidMethods: []string{jwt.SigningMethodHS256.Name}}
+	p := jwt.NewParser(jwt.WithValidMethods([]string{jwt.SigningMethodHS256.Name}))
 	_, err = p.ParseWithClaims(q.Get("state"), &claims, func(token *jwt.Token) (interface{}, error) {
 		return []byte(ts.Config.JWT.Secret), nil
 	})

--- a/internal/api/external_workos_test.go
+++ b/internal/api/external_workos_test.go
@@ -6,7 +6,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 
-	jwt "github.com/golang-jwt/jwt"
+	jwt "github.com/golang-jwt/jwt/v5"
 )
 
 const (
@@ -31,7 +31,7 @@ func (ts *ExternalTestSuite) TestSignupExternalWorkOSWithConnection() {
 	ts.Equal(connection, q.Get("connection"))
 
 	claims := ExternalProviderClaims{}
-	p := jwt.Parser{ValidMethods: []string{jwt.SigningMethodHS256.Name}}
+	p := jwt.NewParser(jwt.WithValidMethods([]string{jwt.SigningMethodHS256.Name}))
 	_, err = p.ParseWithClaims(q.Get("state"), &claims, func(token *jwt.Token) (interface{}, error) {
 		return []byte(ts.Config.JWT.Secret), nil
 	})
@@ -57,7 +57,7 @@ func (ts *ExternalTestSuite) TestSignupExternalWorkOSWithOrganization() {
 	ts.Equal(organization, q.Get("organization"))
 
 	claims := ExternalProviderClaims{}
-	p := jwt.Parser{ValidMethods: []string{jwt.SigningMethodHS256.Name}}
+	p := jwt.NewParser(jwt.WithValidMethods([]string{jwt.SigningMethodHS256.Name}))
 	_, err = p.ParseWithClaims(q.Get("state"), &claims, func(token *jwt.Token) (interface{}, error) {
 		return []byte(ts.Config.JWT.Secret), nil
 	})
@@ -83,7 +83,7 @@ func (ts *ExternalTestSuite) TestSignupExternalWorkOSWithProvider() {
 	ts.Equal(provider, q.Get("provider"))
 
 	claims := ExternalProviderClaims{}
-	p := jwt.Parser{ValidMethods: []string{jwt.SigningMethodHS256.Name}}
+	p := jwt.NewParser(jwt.WithValidMethods([]string{jwt.SigningMethodHS256.Name}))
 	_, err = p.ParseWithClaims(q.Get("state"), &claims, func(token *jwt.Token) (interface{}, error) {
 		return []byte(ts.Config.JWT.Secret), nil
 	})

--- a/internal/api/external_zoom_test.go
+++ b/internal/api/external_zoom_test.go
@@ -6,7 +6,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 
-	jwt "github.com/golang-jwt/jwt"
+	jwt "github.com/golang-jwt/jwt/v5"
 )
 
 const (
@@ -28,7 +28,7 @@ func (ts *ExternalTestSuite) TestSignupExternalZoom() {
 	ts.Equal("code", q.Get("response_type"))
 
 	claims := ExternalProviderClaims{}
-	p := jwt.Parser{ValidMethods: []string{jwt.SigningMethodHS256.Name}}
+	p := jwt.NewParser(jwt.WithValidMethods([]string{jwt.SigningMethodHS256.Name}))
 	_, err = p.ParseWithClaims(q.Get("state"), &claims, func(token *jwt.Token) (interface{}, error) {
 		return []byte(ts.Config.JWT.Secret), nil
 	})

--- a/internal/api/helpers.go
+++ b/internal/api/helpers.go
@@ -36,10 +36,12 @@ func (a *API) requestAud(ctx context.Context, r *http.Request) string {
 
 	// Then check the token
 	claims := getClaims(ctx)
-	aud, _ := claims.GetAudience()
 
-	if claims != nil && len(aud) != 0 {
-		return aud[0]
+	if claims != nil {
+		aud, _ := claims.GetAudience()
+		if len(aud) != 0 {
+			return aud[0]
+		}
 	}
 
 	// Finally, return the default if none of the above methods are successful

--- a/internal/api/helpers.go
+++ b/internal/api/helpers.go
@@ -36,8 +36,10 @@ func (a *API) requestAud(ctx context.Context, r *http.Request) string {
 
 	// Then check the token
 	claims := getClaims(ctx)
-	if claims != nil && claims.Audience != "" {
-		return claims.Audience
+	aud, _ := claims.GetAudience()
+
+	if claims != nil && len(aud) != 0 {
+		return aud[0]
 	}
 
 	// Finally, return the default if none of the above methods are successful

--- a/internal/api/identity.go
+++ b/internal/api/identity.go
@@ -27,7 +27,8 @@ func (a *API) DeleteIdentity(w http.ResponseWriter, r *http.Request) error {
 	}
 
 	aud := a.requestAud(ctx, r)
-	if aud != claims.Audience {
+	audienceFromClaims, _ := claims.GetAudience()
+	if len(audienceFromClaims) == 0 || aud != audienceFromClaims[0] {
 		return forbiddenError(ErrorCodeUnexpectedAudience, "Token audience doesn't match request audience")
 	}
 

--- a/internal/api/invite_test.go
+++ b/internal/api/invite_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"time"
 
-	jwt "github.com/golang-jwt/jwt"
+	jwt "github.com/golang-jwt/jwt/v5"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -70,7 +70,7 @@ func (ts *InviteTestSuite) makeSuperAdmin(email string) string {
 
 	require.NoError(ts.T(), err, "Error generating access token")
 
-	p := jwt.Parser{ValidMethods: []string{jwt.SigningMethodHS256.Name}}
+	p := jwt.NewParser(jwt.WithValidMethods([]string{jwt.SigningMethodHS256.Name}))
 	_, err = p.Parse(token, func(token *jwt.Token) (interface{}, error) {
 		return []byte(ts.Config.JWT.Secret), nil
 	})

--- a/internal/api/mail_test.go
+++ b/internal/api/mail_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 
 	"github.com/gobwas/glob"
-	"github.com/golang-jwt/jwt"
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"github.com/supabase/auth/internal/conf"

--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -20,13 +20,13 @@ import (
 
 	"github.com/didip/tollbooth/v5"
 	"github.com/didip/tollbooth/v5/limiter"
-	jwt "github.com/golang-jwt/jwt"
+	jwt "github.com/golang-jwt/jwt/v5"
 )
 
 type FunctionHooks map[string][]string
 
 type AuthMicroserviceClaims struct {
-	jwt.StandardClaims
+	jwt.RegisteredClaims
 	SiteURL       string        `json:"site_url"`
 	InstanceID    string        `json:"id"`
 	FunctionHooks FunctionHooks `json:"function_hooks"`

--- a/internal/api/middleware_test.go
+++ b/internal/api/middleware_test.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/didip/tollbooth/v5"
 	"github.com/didip/tollbooth/v5/limiter"
-	jwt "github.com/golang-jwt/jwt"
+	jwt "github.com/golang-jwt/jwt/v5"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"

--- a/internal/api/provider/oidc.go
+++ b/internal/api/provider/oidc.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/coreos/go-oidc/v3/oidc"
-	"github.com/golang-jwt/jwt"
+	"github.com/golang-jwt/jwt/v5"
 )
 
 type ParseIDTokenOptions struct {
@@ -120,7 +120,7 @@ func parseGoogleIDToken(token *oidc.IDToken) (*oidc.IDToken, *UserProvidedData, 
 }
 
 type AppleIDTokenClaims struct {
-	jwt.StandardClaims
+	jwt.RegisteredClaims
 
 	Email string `json:"email"`
 
@@ -165,7 +165,7 @@ func parseAppleIDToken(token *oidc.IDToken) (*oidc.IDToken, *UserProvidedData, e
 }
 
 type LinkedinIDTokenClaims struct {
-	jwt.StandardClaims
+	jwt.RegisteredClaims
 
 	Email         string `json:"email"`
 	EmailVerified string `json:"email_verified"`
@@ -210,7 +210,7 @@ func parseLinkedinIDToken(token *oidc.IDToken) (*oidc.IDToken, *UserProvidedData
 }
 
 type AzureIDTokenClaims struct {
-	jwt.StandardClaims
+	jwt.RegisteredClaims
 
 	Email                              string `json:"email"`
 	Name                               string `json:"name"`
@@ -315,7 +315,7 @@ func parseAzureIDToken(token *oidc.IDToken) (*oidc.IDToken, *UserProvidedData, e
 }
 
 type KakaoIDTokenClaims struct {
-	jwt.StandardClaims
+	jwt.RegisteredClaims
 
 	Email    string `json:"email"`
 	Nickname string `json:"nickname"`

--- a/internal/api/sso_test.go
+++ b/internal/api/sso_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 	"time"
 
-	jwt "github.com/golang-jwt/jwt"
+	jwt "github.com/golang-jwt/jwt/v5"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"github.com/supabase/auth/internal/conf"

--- a/internal/api/user.go
+++ b/internal/api/user.go
@@ -66,7 +66,8 @@ func (a *API) UserGet(w http.ResponseWriter, r *http.Request) error {
 	}
 
 	aud := a.requestAud(ctx, r)
-	if aud != claims.Audience {
+	audienceFromClaims, _ := claims.GetAudience()
+	if len(audienceFromClaims) == 0 || aud != audienceFromClaims[0] {
 		return badRequestError(ErrorCodeValidationFailed, "Token audience doesn't match request audience")
 	}
 

--- a/internal/hooks/auth_hooks.go
+++ b/internal/hooks/auth_hooks.go
@@ -2,7 +2,7 @@ package hooks
 
 import (
 	"github.com/gofrs/uuid"
-	"github.com/golang-jwt/jwt"
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/supabase/auth/internal/mailer"
 	"github.com/supabase/auth/internal/models"
 )
@@ -98,7 +98,7 @@ const MinimumViableTokenSchema = `{
 
 // AccessTokenClaims is a struct thats used for JWT claims
 type AccessTokenClaims struct {
-	jwt.StandardClaims
+	jwt.RegisteredClaims
 	Email                         string                 `json:"email"`
 	Phone                         string                 `json:"phone"`
 	AppMetaData                   map[string]interface{} `json:"app_metadata"`

--- a/internal/hooks/auth_hooks.go
+++ b/internal/hooks/auth_hooks.go
@@ -43,7 +43,7 @@ const MinimumViableTokenSchema = `{
   "type": "object",
   "properties": {
     "aud": {
-      "type": "string"
+      "type": "array"
     },
     "exp": {
       "type": "integer"


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Upgrades the golang-jwt package to v5 based on the [migration guide](https://github.com/golang-jwt/jwt/blob/v5/MIGRATION_GUIDE.md), which provides a much nicer API to interact with in-lieu of asymmetric jwts

## Key Changes
* `github.com/golang-jwt/jwt/v5` deprecated [`StandardClaims`](https://pkg.go.dev/github.com/golang-jwt/jwt#StandardClaims) and uses [`RegisteredClaims`](https://pkg.go.dev/github.com/golang-jwt/jwt/v5#RegisteredClaims) instead (uses exactly the same struct fields, just that it has more utility methods)
* in `github.com/golang-jwt/jwt/v5`, you can't just pass set the valid methods when creating a `Parser` struct anymore, you need to use `https://pkg.go.dev/github.com/golang-jwt/jwt/v5#NewParser` 
* Getting the audience claim now returns a string slice instead of a string - this PR just aims to ensure that the dependency upgrade is backward compatible but i'll clean this up in a future PR as well as evaluate if it is still necessary to check the audience claim in the future
* Since the `aud` claim is specified as an array of strings in [RFC7519](https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.3), the token json schema used needs to support the array type instead of string