### PR TITLE
feat: add `password_hash` and `id` fields to admin create user

### DIFF
--- a/internal/api/admin.go
+++ b/internal/api/admin.go
@@ -470,7 +470,7 @@ func (a *API) adminUserCreate(w http.ResponseWriter, r *http.Request) error {
 	})
 
 	if err != nil {
-		if strings.Contains("invalid format for ban duration", err.Error()) {
+		if strings.Contains(err.Error(), "invalid format for ban duration") {
 			return err
 		}
 		return internalServerError("Database error creating new user").WithInternalError(err)

--- a/internal/api/admin.go
+++ b/internal/api/admin.go
@@ -18,6 +18,7 @@ import (
 )
 
 type AdminUserParams struct {
+	Id           string                 `json:"id"`
 	Aud          string                 `json:"aud"`
 	Role         string                 `json:"role"`
 	Email        string                 `json:"email"`
@@ -378,6 +379,17 @@ func (a *API) adminUserCreate(w http.ResponseWriter, r *http.Request) error {
 
 	if err != nil {
 		return internalServerError("Error creating user").WithInternalError(err)
+	}
+
+	if params.Id != "" {
+		customId, err := uuid.FromString(params.Id)
+		if err != nil {
+			return badRequestError(ErrorCodeValidationFailed, "ID must conform to the uuid v4 format")
+		}
+		if customId == uuid.Nil {
+			return badRequestError(ErrorCodeValidationFailed, "ID cannot be a nil uuid")
+		}
+		user.ID = customId
 	}
 
 	user.AppMetaData = map[string]interface{}{

--- a/internal/api/admin_test.go
+++ b/internal/api/admin_test.go
@@ -244,6 +244,7 @@ func (ts *AdminTestSuite) TestAdminUserCreate() {
 				"isAuthenticated": true,
 				"provider":        "phone",
 				"providers":       []string{"phone"},
+				"password":        "test1",
 			},
 		},
 		{
@@ -259,6 +260,7 @@ func (ts *AdminTestSuite) TestAdminUserCreate() {
 				"isAuthenticated": true,
 				"provider":        "email",
 				"providers":       []string{"email", "phone"},
+				"password":        "test1",
 			},
 		},
 		{
@@ -288,6 +290,7 @@ func (ts *AdminTestSuite) TestAdminUserCreate() {
 				"isAuthenticated": false,
 				"provider":        "email",
 				"providers":       []string{"email"},
+				"password":        "",
 			},
 		},
 		{
@@ -304,6 +307,22 @@ func (ts *AdminTestSuite) TestAdminUserCreate() {
 				"isAuthenticated": true,
 				"provider":        "email",
 				"providers":       []string{"email"},
+				"password":        "test1",
+			},
+		},
+		{
+			desc: "With password hash",
+			params: map[string]interface{}{
+				"email":         "test5@example.com",
+				"password_hash": "$2y$10$SXEz2HeT8PUIGQXo9yeUIem8KzNxgG0d7o/.eGj2rj8KbRgAuRVlq",
+			},
+			expected: map[string]interface{}{
+				"email":           "test5@example.com",
+				"phone":           "",
+				"isAuthenticated": true,
+				"provider":        "email",
+				"providers":       []string{"email"},
+				"password":        "test",
 			},
 		},
 	}
@@ -346,8 +365,8 @@ func (ts *AdminTestSuite) TestAdminUserCreate() {
 			}
 
 			var expectedPassword string
-			if _, ok := c.params["password"]; ok {
-				expectedPassword = fmt.Sprintf("%v", c.params["password"])
+			if _, ok := c.expected["password"]; ok {
+				expectedPassword = fmt.Sprintf("%v", c.expected["password"])
 			}
 
 			isAuthenticated, _, err := u.Authenticate(context.Background(), expectedPassword, ts.API.config.Security.DBEncryption.DecryptionKeys, ts.API.config.Security.DBEncryption.Encrypt, ts.API.config.Security.DBEncryption.EncryptionKeyID)

--- a/internal/api/admin_test.go
+++ b/internal/api/admin_test.go
@@ -369,7 +369,7 @@ func (ts *AdminTestSuite) TestAdminUserCreate() {
 				expectedPassword = fmt.Sprintf("%v", c.expected["password"])
 			}
 
-			isAuthenticated, _, err := u.Authenticate(context.Background(), expectedPassword, ts.API.config.Security.DBEncryption.DecryptionKeys, ts.API.config.Security.DBEncryption.Encrypt, ts.API.config.Security.DBEncryption.EncryptionKeyID)
+			isAuthenticated, _, err := u.Authenticate(context.Background(), ts.API.db, expectedPassword, ts.API.config.Security.DBEncryption.DecryptionKeys, ts.API.config.Security.DBEncryption.Encrypt, ts.API.config.Security.DBEncryption.EncryptionKeyID)
 			require.NoError(ts.T(), err)
 
 			assert.Equal(ts.T(), c.expected["isAuthenticated"], isAuthenticated)

--- a/internal/api/token.go
+++ b/internal/api/token.go
@@ -145,7 +145,7 @@ func (a *API) ResourceOwnerPasswordGrant(ctx context.Context, w http.ResponseWri
 		return oauthError("invalid_grant", InvalidLoginMessage)
 	}
 
-	isValidPassword, shouldReEncrypt, err := user.Authenticate(ctx, params.Password, config.Security.DBEncryption.DecryptionKeys, config.Security.DBEncryption.Encrypt, config.Security.DBEncryption.EncryptionKeyID)
+	isValidPassword, shouldReEncrypt, err := user.Authenticate(ctx, db, params.Password, config.Security.DBEncryption.DecryptionKeys, config.Security.DBEncryption.Encrypt, config.Security.DBEncryption.EncryptionKeyID)
 	if err != nil {
 		return err
 	}

--- a/internal/api/user.go
+++ b/internal/api/user.go
@@ -157,7 +157,7 @@ func (a *API) UserUpdate(w http.ResponseWriter, r *http.Request) error {
 			isSamePassword := false
 
 			if user.HasPassword() {
-				auth, _, err := user.Authenticate(ctx, password, config.Security.DBEncryption.DecryptionKeys, false, "")
+				auth, _, err := user.Authenticate(ctx, db, password, config.Security.DBEncryption.DecryptionKeys, false, "")
 				if err != nil {
 					return err
 				}

--- a/internal/api/user_test.go
+++ b/internal/api/user_test.go
@@ -310,7 +310,7 @@ func (ts *UserTestSuite) TestUserUpdatePassword() {
 			u, err = models.FindUserByEmailAndAudience(ts.API.db, "test@example.com", ts.Config.JWT.Aud)
 			require.NoError(ts.T(), err)
 
-			isAuthenticated, _, err := u.Authenticate(context.Background(), c.newPassword, ts.API.config.Security.DBEncryption.DecryptionKeys, ts.API.config.Security.DBEncryption.Encrypt, ts.API.config.Security.DBEncryption.EncryptionKeyID)
+			isAuthenticated, _, err := u.Authenticate(context.Background(), ts.API.db, c.newPassword, ts.API.config.Security.DBEncryption.DecryptionKeys, ts.API.config.Security.DBEncryption.Encrypt, ts.API.config.Security.DBEncryption.EncryptionKeyID)
 			require.NoError(ts.T(), err)
 
 			require.Equal(ts.T(), c.expected.isAuthenticated, isAuthenticated)
@@ -372,7 +372,7 @@ func (ts *UserTestSuite) TestUserUpdatePasswordNoReauthenticationRequired() {
 			u, err = models.FindUserByEmailAndAudience(ts.API.db, "test@example.com", ts.Config.JWT.Aud)
 			require.NoError(ts.T(), err)
 
-			isAuthenticated, _, err := u.Authenticate(context.Background(), c.newPassword, ts.API.config.Security.DBEncryption.DecryptionKeys, ts.API.config.Security.DBEncryption.Encrypt, ts.API.config.Security.DBEncryption.EncryptionKeyID)
+			isAuthenticated, _, err := u.Authenticate(context.Background(), ts.API.db, c.newPassword, ts.API.config.Security.DBEncryption.DecryptionKeys, ts.API.config.Security.DBEncryption.Encrypt, ts.API.config.Security.DBEncryption.EncryptionKeyID)
 			require.NoError(ts.T(), err)
 
 			require.Equal(ts.T(), c.expected.isAuthenticated, isAuthenticated)
@@ -430,7 +430,7 @@ func (ts *UserTestSuite) TestUserUpdatePasswordReauthentication() {
 	u, err = models.FindUserByEmailAndAudience(ts.API.db, "test@example.com", ts.Config.JWT.Aud)
 	require.NoError(ts.T(), err)
 
-	isAuthenticated, _, err := u.Authenticate(context.Background(), "newpass", ts.Config.Security.DBEncryption.DecryptionKeys, ts.Config.Security.DBEncryption.Encrypt, ts.Config.Security.DBEncryption.EncryptionKeyID)
+	isAuthenticated, _, err := u.Authenticate(context.Background(), ts.API.db, "newpass", ts.Config.Security.DBEncryption.DecryptionKeys, ts.Config.Security.DBEncryption.Encrypt, ts.Config.Security.DBEncryption.EncryptionKeyID)
 	require.NoError(ts.T(), err)
 
 	require.True(ts.T(), isAuthenticated)

--- a/internal/crypto/password.go
+++ b/internal/crypto/password.go
@@ -32,6 +32,8 @@ const (
 
 	// BCrypt hashed passwords have a 72 character limit
 	MaxPasswordLength = 72
+
+	Argon2Prefix = "$argon2"
 )
 
 // PasswordHashCost is the current pasword hashing cost
@@ -177,7 +179,7 @@ func compareHashAndPasswordArgon2(ctx context.Context, hash, password string) er
 // password, returns nil if equal otherwise an error. Context can be used to
 // cancel the hashing if the algorithm supports it.
 func CompareHashAndPassword(ctx context.Context, hash, password string) error {
-	if strings.HasPrefix(hash, "$argon2") {
+	if strings.HasPrefix(hash, Argon2Prefix) {
 		return compareHashAndPasswordArgon2(ctx, hash, password)
 	}
 

--- a/internal/crypto/password.go
+++ b/internal/crypto/password.go
@@ -54,11 +54,23 @@ var ErrArgon2MismatchedHashAndPassword = errors.New("crypto: argon2 hash and pas
 // argon2HashRegexp https://github.com/P-H-C/phc-string-format/blob/master/phc-sf-spec.md#argon2-encoding
 var argon2HashRegexp = regexp.MustCompile("^[$](?P<alg>argon2(d|i|id))[$]v=(?P<v>(16|19))[$]m=(?P<m>[0-9]+),t=(?P<t>[0-9]+),p=(?P<p>[0-9]+)(,keyid=(?P<keyid>[^,]+))?(,data=(?P<data>[^$]+))?[$](?P<salt>[^$]+)[$](?P<hash>.+)$")
 
-func compareHashAndPasswordArgon2(ctx context.Context, hash, password string) error {
+type Argon2HashInput struct {
+	alg     string
+	v       string
+	memory  uint64
+	time    uint64
+	threads uint64
+	keyid   string
+	data    string
+	salt    []byte
+	rawHash []byte
+}
+
+func ParseArgon2Hash(hash string) (*Argon2HashInput, error) {
 	submatch := argon2HashRegexp.FindStringSubmatchIndex(hash)
 
 	if submatch == nil {
-		return errors.New("crypto: incorrect argon2 hash format")
+		return nil, errors.New("crypto: incorrect argon2 hash format")
 	}
 
 	alg := string(argon2HashRegexp.ExpandString(nil, "$alg", hash, submatch))
@@ -72,58 +84,68 @@ func compareHashAndPasswordArgon2(ctx context.Context, hash, password string) er
 	hashB64 := string(argon2HashRegexp.ExpandString(nil, "$hash", hash, submatch))
 
 	if alg != "argon2i" && alg != "argon2id" {
-		return fmt.Errorf("crypto: argon2 hash uses unsupported algorithm %q only argon2i and argon2id supported", alg)
+		return nil, fmt.Errorf("crypto: argon2 hash uses unsupported algorithm %q only argon2i and argon2id supported", alg)
 	}
 
 	if v != "19" {
-		return fmt.Errorf("crypto: argon2 hash uses unsupported version %q only %d is supported", v, argon2.Version)
+		return nil, fmt.Errorf("crypto: argon2 hash uses unsupported version %q only %d is supported", v, argon2.Version)
 	}
 
 	if data != "" {
-		return fmt.Errorf("crypto: argon2 hashes with the data parameter not supported")
+		return nil, fmt.Errorf("crypto: argon2 hashes with the data parameter not supported")
 	}
 
 	if keyid != "" {
-		return fmt.Errorf("crypto: argon2 hashes with the keyid parameter not supported")
+		return nil, fmt.Errorf("crypto: argon2 hashes with the keyid parameter not supported")
 	}
 
 	memory, err := strconv.ParseUint(m, 10, 32)
 	if err != nil {
-		return fmt.Errorf("crypto: argon2 hash has invalid m parameter %q %w", m, err)
+		return nil, fmt.Errorf("crypto: argon2 hash has invalid m parameter %q %w", m, err)
 	}
 
 	time, err := strconv.ParseUint(t, 10, 32)
 	if err != nil {
-		return fmt.Errorf("crypto: argon2 hash has invalid t parameter %q %w", t, err)
+		return nil, fmt.Errorf("crypto: argon2 hash has invalid t parameter %q %w", t, err)
 	}
 
 	threads, err := strconv.ParseUint(p, 10, 8)
 	if err != nil {
-		return fmt.Errorf("crypto: argon2 hash has invalid p parameter %q %w", p, err)
+		return nil, fmt.Errorf("crypto: argon2 hash has invalid p parameter %q %w", p, err)
 	}
 
 	rawHash, err := base64.RawStdEncoding.DecodeString(hashB64)
 	if err != nil {
-		return fmt.Errorf("crypto: argon2 hash has invalid base64 in the hash section %w", err)
+		return nil, fmt.Errorf("crypto: argon2 hash has invalid base64 in the hash section %w", err)
 	}
 
 	salt, err := base64.RawStdEncoding.DecodeString(saltB64)
 	if err != nil {
-		return fmt.Errorf("crypto: argon2 hash has invalid base64 in the salt section %w", err)
+		return nil, fmt.Errorf("crypto: argon2 hash has invalid base64 in the salt section %w", err)
+	}
+
+	input := Argon2HashInput{alg, v, memory, time, threads, keyid, data, salt, rawHash}
+
+	return &input, nil
+}
+
+func compareHashAndPasswordArgon2(ctx context.Context, hash, password string) error {
+	input, err := ParseArgon2Hash(hash)
+	if err != nil {
+		return err
+	}
+
+	attributes := []attribute.KeyValue{
+		attribute.String("alg", input.alg),
+		attribute.String("v", input.v),
+		attribute.Int64("m", int64(input.memory)),
+		attribute.Int64("t", int64(input.time)),
+		attribute.Int("p", int(input.threads)),
+		attribute.Int("len", len(input.rawHash)),
 	}
 
 	var match bool
 	var derivedKey []byte
-
-	attributes := []attribute.KeyValue{
-		attribute.String("alg", alg),
-		attribute.String("v", v),
-		attribute.Int64("m", int64(memory)),
-		attribute.Int64("t", int64(time)),
-		attribute.Int("p", int(threads)),
-		attribute.Int("len", len(rawHash)),
-	}
-
 	compareHashAndPasswordSubmittedCounter.Add(ctx, 1, metric.WithAttributes(attributes...))
 	defer func() {
 		attributes = append(attributes, attribute.Bool(
@@ -134,15 +156,15 @@ func compareHashAndPasswordArgon2(ctx context.Context, hash, password string) er
 		compareHashAndPasswordCompletedCounter.Add(ctx, 1, metric.WithAttributes(attributes...))
 	}()
 
-	switch alg {
+	switch input.alg {
 	case "argon2i":
-		derivedKey = argon2.Key([]byte(password), salt, uint32(time), uint32(memory)*1024, uint8(threads), uint32(len(rawHash)))
+		derivedKey = argon2.Key([]byte(password), input.salt, uint32(input.time), uint32(input.memory)*1024, uint8(input.threads), uint32(len(input.rawHash)))
 
 	case "argon2id":
-		derivedKey = argon2.IDKey([]byte(password), salt, uint32(time), uint32(memory)*1024, uint8(threads), uint32(len(rawHash)))
+		derivedKey = argon2.IDKey([]byte(password), input.salt, uint32(input.time), uint32(input.memory)*1024, uint8(input.threads), uint32(len(input.rawHash)))
 	}
 
-	match = subtle.ConstantTimeCompare(derivedKey, rawHash) == 0
+	match = subtle.ConstantTimeCompare(derivedKey, input.rawHash) == 0
 
 	if !match {
 		return ErrArgon2MismatchedHashAndPassword
@@ -181,7 +203,6 @@ func CompareHashAndPassword(ctx context.Context, hash, password string) error {
 	}()
 
 	err = bcrypt.CompareHashAndPassword([]byte(hash), []byte(password))
-
 	return err
 }
 

--- a/internal/models/user.go
+++ b/internal/models/user.go
@@ -14,6 +14,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/supabase/auth/internal/crypto"
 	"github.com/supabase/auth/internal/storage"
+	"golang.org/x/crypto/bcrypt"
 )
 
 // User respresents a registered user with email/password authentication
@@ -69,6 +70,31 @@ type User struct {
 	IsAnonymous bool       `json:"is_anonymous" db:"is_anonymous"`
 
 	DONTUSEINSTANCEID uuid.UUID `json:"-" db:"instance_id"`
+}
+
+func NewUserWithPasswordHash(phone, email, passwordHash, aud string, userData map[string]interface{}) (*User, error) {
+	if strings.HasPrefix(passwordHash, "$argon2") {
+		_, err := crypto.ParseArgon2Hash(passwordHash)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		// verify that the hash is a bcrypt hash
+		_, err := bcrypt.Cost([]byte(passwordHash))
+		if err != nil {
+			return nil, err
+		}
+	}
+	id := uuid.Must(uuid.NewV4())
+	user := &User{
+		ID:                id,
+		Aud:               aud,
+		Email:             storage.NullString(strings.ToLower(email)),
+		Phone:             storage.NullString(phone),
+		UserMetaData:      userData,
+		EncryptedPassword: &passwordHash,
+	}
+	return user, nil
 }
 
 // NewUser initializes a new user from an email, password and user data.


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Add a `password_hash` field to admin create user, which allows an admin to create a user with a given password hash (argon2 or bcrypt)
* Add an `id` field to admin create user, which allows an admin to create a user with a custom id
* To prevent someone from creating a bunch of users with a high bcrypt hashing cost, we opt to rehash the password with the default cost (10) on subsequent sign-in.

## What is the current behavior?
* Only plaintext passwords are allowed, which will subsequently be hashed internally

## What is the new behavior?

Example request using the bcrypt hash of "test":
```bash
$ curl -X POST 'http://localhost:9999/admin/users' \
-H 'Authorization: Bearer <admin_jwt>' \
-H 'Content-Type: application/json' \
-d '{"email": "foo@example.com", "password_hash": "$2y$10$SXEz2HeT8PUIGQXo9yeUIem8KzNxgG0d7o/.eGj2rj8KbRgAuRVlq"}'
```

Example request using a custom id:
```bash
$ curl -X POST 'http://localhost:9999/admin/users' \
-H 'Authorization: Bearer <admin_jwt>' \
-H 'Content-Type: application/json' \
-d '{"id": "2a8813c2-bda7-47f0-94a6-49fcfdf61a70", "email": "foo@example.com"}'
```

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
