### PR TITLE
fix:  return proper error message when invalid email_change token is passed in

### DIFF
--- a/internal/models/one_time_token.go
+++ b/internal/models/one_time_token.go
@@ -228,6 +228,9 @@ func FindUserByEmailChangeCurrentAndAudience(tx *storage.Connection, email, toke
 			return nil, err
 		}
 	}
+	if ott == nil {
+		return nil, err
+	}
 
 	user, err := FindUserByID(tx, ott.UserID)
 	if err != nil {
@@ -253,6 +256,9 @@ func FindUserByEmailChangeNewAndAudience(tx *storage.Connection, email, token, a
 		if err != nil && !IsNotFoundError(err) {
 			return nil, err
 		}
+	}
+	if ott == nil {
+		return nil, err
 	}
 
 	user, err := FindUserByID(tx, ott.UserID)


### PR DESCRIPTION
## What kind of change does this PR introduce?

Currently, when  `SECURE_EMAIL_CHANGE` is enabled and a dev invokes `verifyOtp({type:'email_change', token:'<some-token>', email:'<some-wrong-email>'})` an internalServerError and panic is returned. After this change a 403 is returned as expected.

This is because when an invalid `email_change` OTP is submitted [an access on  ott.UserID (which is nil) is made ](https://github.com/supabase/auth/compare/j0/prevent_panic_on_email_change?expand=1#diff-55a81f8dc53ee75ff592eec9c5e1fcb665f653d7593de7e9c8b8dadf7159fe83L258)

