### PR TITLE
fix: apply mailer autoconfirm config to update user email

### DIFF
--- a/internal/api/verify.go
+++ b/internal/api/verify.go
@@ -491,7 +491,10 @@ func (a *API) prepPKCERedirectURL(rurl, code string) (string, error) {
 
 func (a *API) emailChangeVerify(r *http.Request, conn *storage.Connection, params *VerifyParams, user *models.User) (*models.User, error) {
 	config := a.config
-	if config.Mailer.SecureEmailChangeEnabled && user.EmailChangeConfirmStatus == zeroConfirmation && user.GetEmail() != "" {
+	if !config.Mailer.Autoconfirm &&
+		config.Mailer.SecureEmailChangeEnabled &&
+		user.EmailChangeConfirmStatus == zeroConfirmation &&
+		user.GetEmail() != "" {
 		err := conn.Transaction(func(tx *storage.Connection) error {
 			currentOTT, terr := models.FindOneTimeToken(tx, params.TokenHash, models.EmailChangeTokenCurrent)
 			if terr != nil && !models.IsNotFoundError(terr) {


### PR DESCRIPTION
## What kind of change does this PR introduce?
* `GOTRUE_MAILER_AUTOCONFIRM` setting should be respected in the update email flow via `PUT /user`

## What is the current behavior?
* When `GOTRUE_MAILER_AUTOCONFIRM=true`, updating a user's email still sends an email and requires user confirmation 
* Difficult for anonymous users to upgrade to a permanent user seamlessly without requiring email confirmation
* Fixes #1619 

## What is the new behavior?
* When `GOTRUE_MAILER_AUTOCONFIRM=true`, updating a user's email will not require email confirmation. 

## Additional context

Add any other context or screenshots.
