### PR TITLE
fix: return proper error if sms rate limit is exceeded

### DIFF
--- a/internal/api/user.go
+++ b/internal/api/user.go
@@ -236,6 +236,9 @@ func (a *API) UserUpdate(w http.ResponseWriter, r *http.Request) error {
 					return internalServerError("Error finding SMS provider").WithInternalError(terr)
 				}
 				if _, terr := a.sendPhoneConfirmation(r, tx, user, params.Phone, phoneChangeVerification, smsProvider, params.Channel); terr != nil {
+					if errors.Is(terr, MaxFrequencyLimitError) {
+						return tooManyRequestsError(ErrorCodeOverSMSSendRateLimit, generateFrequencyLimitErrorMessage(user.PhoneChangeSentAt, config.Sms.MaxFrequency))
+					}
 					return internalServerError("Error sending phone change otp").WithInternalError(terr)
 				}
 			}


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Fixes #1629 
* Previously, rate limit errors were being returned as an internal server error, which is incorrect. This PR checks for the underlying error type returned and ensures that rate limit errors are surfaced appropriately.

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
