### PR TITLE
fix: check for empty aud string

### DIFF
--- a/internal/api/helpers.go
+++ b/internal/api/helpers.go
@@ -39,7 +39,7 @@ func (a *API) requestAud(ctx context.Context, r *http.Request) string {
 
 	if claims != nil {
 		aud, _ := claims.GetAudience()
-		if len(aud) != 0 {
+		if len(aud) != 0 && aud[0] != "" {
 			return aud[0]
 		}
 	}

--- a/internal/api/helpers_test.go
+++ b/internal/api/helpers_test.go
@@ -1,10 +1,15 @@
 package api
 
 import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"strconv"
 	"testing"
 
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/stretchr/testify/require"
+	"github.com/supabase/auth/internal/conf"
 )
 
 func TestIsValidCodeChallenge(t *testing.T) {
@@ -71,4 +76,76 @@ func TestIsValidPKCEParams(t *testing.T) {
 			require.Equal(t, c.expected, err)
 		})
 	}
+}
+
+func TestRequestAud(ts *testing.T) {
+	mockAPI := API{
+		config: &conf.GlobalConfiguration{
+			JWT: conf.JWTConfiguration{
+				Aud:    "authenticated",
+				Secret: "test-secret",
+			},
+		},
+	}
+
+	cases := []struct {
+		desc        string
+		headers     map[string]string
+		payload     map[string]interface{}
+		expectedAud string
+	}{
+		{
+			desc: "Valid audience slice",
+			headers: map[string]string{
+				audHeaderName: "my_custom_aud",
+			},
+			payload: map[string]interface{}{
+				"aud": "authenticated",
+			},
+			expectedAud: "my_custom_aud",
+		},
+		{
+			desc: "Valid custom audience",
+			payload: map[string]interface{}{
+				"aud": "my_custom_aud",
+			},
+			expectedAud: "my_custom_aud",
+		},
+		{
+			desc: "Invalid audience",
+			payload: map[string]interface{}{
+				"aud": "",
+			},
+			expectedAud: mockAPI.config.JWT.Aud,
+		},
+		{
+			desc: "Missing audience",
+			payload: map[string]interface{}{
+				"sub": "d6044b6e-b0ec-4efe-a055-0d2d6ff1dbd8",
+			},
+			expectedAud: mockAPI.config.JWT.Aud,
+		},
+	}
+
+	for _, c := range cases {
+		ts.Run(c.desc, func(t *testing.T) {
+			claims := jwt.MapClaims(c.payload)
+			token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+			signed, err := token.SignedString([]byte(mockAPI.config.JWT.Secret))
+			require.NoError(t, err)
+
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			req.Header.Set("Authorization", fmt.Sprintf("Bearer: %s", signed))
+			for k, v := range c.headers {
+				req.Header.Set(k, v)
+			}
+
+			// set the token in the request context for requestAud
+			ctx, err := mockAPI.parseJWTClaims(signed, req)
+			require.NoError(t, err)
+			aud := mockAPI.requestAud(ctx, req)
+			require.Equal(t, c.expectedAud, aud)
+		})
+	}
+
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Fixes an issue where an empty string set as the `aud` claim will cause some methods to fail

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
