### PR TITLE
chore: add default tests for saml assertions

### DIFF
--- a/internal/api/samlassertion_test.go
+++ b/internal/api/samlassertion_test.go
@@ -301,7 +301,7 @@ func TestSAMLAssertionProcessing(t *tst.T) {
 			},
 		},
 		{
-			desc: "use default value even if attribute exists but is not specified in mapping",
+			desc: "use value in XML when attribute exists and is specified in mapping",
 			xml: `<?xml version="1.0" encoding="UTF-8"?>
 <saml2:Assertion xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion" xmlns:xsd="http://www.w3.org/2001/XMLSchema" ID="_72591c79da230cac1457d0ea0f2771ab" IssueInstant="2022-08-11T14:53:38.260Z" Version="2.0">
 	<saml2:AttributeStatement>

--- a/internal/api/samlassertion_test.go
+++ b/internal/api/samlassertion_test.go
@@ -150,6 +150,7 @@ func TestSAMLAssertionUserID(t *tst.T) {
 
 func TestSAMLAssertionProcessing(t *tst.T) {
 	type spec struct {
+		desc     string
 		xml      string
 		mapping  models.SAMLAttributeMapping
 		expected map[string]interface{}
@@ -157,6 +158,7 @@ func TestSAMLAssertionProcessing(t *tst.T) {
 
 	examples := []spec{
 		{
+			desc: "valid attribute and mapping",
 			xml: `<?xml version="1.0" encoding="UTF-8"?>
 <saml2:Assertion xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion" xmlns:xsd="http://www.w3.org/2001/XMLSchema" ID="_72591c79da230cac1457d0ea0f2771ab" IssueInstant="2022-08-11T14:53:38.260Z" Version="2.0">
 	<saml2:AttributeStatement>
@@ -178,6 +180,7 @@ func TestSAMLAssertionProcessing(t *tst.T) {
 			},
 		},
 		{
+			desc: "valid attributes, use first attribute found in Names",
 			xml: `<?xml version="1.0" encoding="UTF-8"?>
 <saml2:Assertion xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion" xmlns:xsd="http://www.w3.org/2001/XMLSchema" ID="_72591c79da230cac1457d0ea0f2771ab" IssueInstant="2022-08-11T14:53:38.260Z" Version="2.0">
 	<saml2:AttributeStatement>
@@ -205,6 +208,7 @@ func TestSAMLAssertionProcessing(t *tst.T) {
 			},
 		},
 		{
+			desc: "valid groups attribute",
 			xml: `<?xml version="1.0" encoding="UTF-8"?>
 <saml2:Assertion xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion" xmlns:xsd="http://www.w3.org/2001/XMLSchema" ID="_72591c79da230cac1457d0ea0f2771ab" IssueInstant="2022-08-11T14:53:38.260Z" Version="2.0">
 	<saml2:AttributeStatement>
@@ -240,6 +244,92 @@ func TestSAMLAssertionProcessing(t *tst.T) {
 				},
 			},
 		},
+		{
+			desc: "missing attribute, use default value",
+			xml: `<?xml version="1.0" encoding="UTF-8"?>
+<saml2:Assertion xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion" xmlns:xsd="http://www.w3.org/2001/XMLSchema" ID="_72591c79da230cac1457d0ea0f2771ab" IssueInstant="2022-08-11T14:53:38.260Z" Version="2.0">
+	<saml2:AttributeStatement>
+		<saml2:Attribute Name="urn:oid:0.9.2342.19200300.100.1.3" FriendlyName="mail" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
+			<saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xsd:string">someone@example.com</saml2:AttributeValue>
+		</saml2:Attribute>
+	</saml2:AttributeStatement>
+</saml2:Assertion>
+`,
+			mapping: models.SAMLAttributeMapping{
+				Keys: map[string]models.SAMLAttribute{
+					"email": {
+						Name: "mail",
+					},
+					"role": {
+						Name:    "role",
+						Default: "member",
+					},
+				},
+			},
+			expected: map[string]interface{}{
+				"email": "someone@example.com",
+				"role":  "member",
+			},
+		},
+		{
+			desc: "use default value even if attribute exists but is not specified in mapping",
+			xml: `<?xml version="1.0" encoding="UTF-8"?>
+<saml2:Assertion xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion" xmlns:xsd="http://www.w3.org/2001/XMLSchema" ID="_72591c79da230cac1457d0ea0f2771ab" IssueInstant="2022-08-11T14:53:38.260Z" Version="2.0">
+	<saml2:AttributeStatement>
+		<saml2:Attribute Name="urn:oid:0.9.2342.19200300.100.1.3" FriendlyName="mail" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
+			<saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xsd:string">someone@example.com</saml2:AttributeValue>
+		</saml2:Attribute>
+		<saml2:Attribute Name="urn:oid:0.9.2342.19200300.100.1.3" FriendlyName="role" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
+			<saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xsd:string">admin</saml2:AttributeValue>
+		</saml2:Attribute>
+	</saml2:AttributeStatement>
+</saml2:Assertion>
+`,
+			mapping: models.SAMLAttributeMapping{
+				Keys: map[string]models.SAMLAttribute{
+					"email": {
+						Name: "mail",
+					},
+					"role": {
+						Default: "member",
+					},
+				},
+			},
+			expected: map[string]interface{}{
+				"email": "someone@example.com",
+				"role":  "member",
+			},
+		},
+		{
+			desc: "use default value even if attribute exists but is not specified in mapping",
+			xml: `<?xml version="1.0" encoding="UTF-8"?>
+<saml2:Assertion xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion" xmlns:xsd="http://www.w3.org/2001/XMLSchema" ID="_72591c79da230cac1457d0ea0f2771ab" IssueInstant="2022-08-11T14:53:38.260Z" Version="2.0">
+	<saml2:AttributeStatement>
+		<saml2:Attribute Name="urn:oid:0.9.2342.19200300.100.1.3" FriendlyName="mail" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
+			<saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xsd:string">someone@example.com</saml2:AttributeValue>
+		</saml2:Attribute>
+		<saml2:Attribute Name="urn:oid:0.9.2342.19200300.100.1.3" FriendlyName="role" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
+			<saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xsd:string">admin</saml2:AttributeValue>
+		</saml2:Attribute>
+	</saml2:AttributeStatement>
+</saml2:Assertion>
+`,
+			mapping: models.SAMLAttributeMapping{
+				Keys: map[string]models.SAMLAttribute{
+					"email": {
+						Name: "mail",
+					},
+					"role": {
+						Name:    "role",
+						Default: "member",
+					},
+				},
+			},
+			expected: map[string]interface{}{
+				"email": "someone@example.com",
+				"role":  "admin",
+			},
+		},
 	}
 
 	for i, example := range examples {
@@ -252,6 +342,6 @@ func TestSAMLAssertionProcessing(t *tst.T) {
 
 		result := assertion.Process(example.mapping)
 
-		require.Equal(t, result, example.expected, "example %d had different processing", i)
+		require.Equal(t, example.expected, result, "example %d had different processing", i)
 	}
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Add test cases to ensure that the default attribute is respected
  * If the attribute is missing, the default value in the mapping will be used
  * If the attribute is present, but the mapping doesn't specify the name, then the default value will be used
  * The name will always be respected over the default
 
## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
