### PR TITLE
fix: set rate limit log level to warn

### DIFF
--- a/internal/api/errors.go
+++ b/internal/api/errors.go
@@ -232,11 +232,14 @@ func HandleResponseError(err error, w http.ResponseWriter, r *http.Request) {
 		}
 
 	case *HTTPError:
-		if e.HTTPStatus >= http.StatusInternalServerError {
+		switch {
+		case e.HTTPStatus >= http.StatusInternalServerError:
 			e.ErrorID = errorID
 			// this will get us the stack trace too
 			log.WithError(e.Cause()).Error(e.Error())
-		} else {
+		case e.HTTPStatus == http.StatusTooManyRequests:
+			log.WithError(e.Cause()).Warn(e.Error())
+		default:
 			log.WithError(e.Cause()).Info(e.Error())
 		}
 


### PR DESCRIPTION
## What kind of change does this PR introduce?
* set the log level for rate limit errors to "warn"

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
