### PR TITLE
fix: serialize jwt as string

### DIFF
--- a/internal/api/token.go
+++ b/internal/api/token.go
@@ -329,7 +329,7 @@ func (a *API) generateAccessToken(r *http.Request, tx *storage.Connection, user 
 	claims := &hooks.AccessTokenClaims{
 		RegisteredClaims: jwt.RegisteredClaims{
 			Subject:   user.ID.String(),
-			Audience:  []string{user.Aud},
+			Audience:  jwt.ClaimStrings{user.Aud},
 			IssuedAt:  jwt.NewNumericDate(issuedAt),
 			ExpiresAt: jwt.NewNumericDate(expiresAt),
 			Issuer:    config.JWT.Issuer,
@@ -375,6 +375,8 @@ func (a *API) generateAccessToken(r *http.Request, tx *storage.Connection, user 
 		token.Header["kid"] = config.JWT.KeyID
 	}
 
+	// this serializes the aud claim was a string
+	jwt.MarshalSingleStringAsArray = false
 	signed, err := token.SignedString([]byte(config.JWT.Secret))
 	if err != nil {
 		return "", 0, err

--- a/internal/hooks/auth_hooks.go
+++ b/internal/hooks/auth_hooks.go
@@ -43,7 +43,7 @@ const MinimumViableTokenSchema = `{
   "type": "object",
   "properties": {
     "aud": {
-      "type": "array"
+      "type": ["string", "array"]
     },
     "exp": {
       "type": "integer"


### PR DESCRIPTION
## What kind of change does this PR introduce?
* serializes the jwt as a string rather than a slice of strings

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
