### PR TITLE
fix: treat empty string as nil in `encrypted_password`

### DIFF
--- a/internal/api/token.go
+++ b/internal/api/token.go
@@ -141,6 +141,10 @@ func (a *API) ResourceOwnerPasswordGrant(ctx context.Context, w http.ResponseWri
 		return internalServerError("Database error querying schema").WithInternalError(err)
 	}
 
+	if !user.HasPassword() {
+		return oauthError("invalid_grant", InvalidLoginMessage)
+	}
+
 	if user.IsBanned() {
 		return oauthError("invalid_grant", InvalidLoginMessage)
 	}

--- a/internal/models/user.go
+++ b/internal/models/user.go
@@ -384,6 +384,10 @@ func (u *User) Authenticate(ctx context.Context, tx *storage.Connection, passwor
 
 	hash := *u.EncryptedPassword
 
+	if hash == "" {
+		return false, false, nil
+	}
+
 	es := crypto.ParseEncryptedString(hash)
 	if es != nil {
 		h, err := es.Decrypt(u.ID.String(), decryptionKeys)


### PR DESCRIPTION
`Authenticate` should treat empty string as nil, as both mean the same thing.