### PR TITLE
fix: don't update attribute mapping if nil

### DIFF
--- a/internal/api/ssoadmin.go
+++ b/internal/api/ssoadmin.go
@@ -349,10 +349,13 @@ func (a *API) adminSSOProvidersUpdate(w http.ResponseWriter, r *http.Request) er
 		}
 	}
 
-	updateAttributeMapping := !provider.SAMLProvider.AttributeMapping.Equal(&params.AttributeMapping)
-	if updateAttributeMapping {
-		modified = true
-		provider.SAMLProvider.AttributeMapping = params.AttributeMapping
+	updateAttributeMapping := false
+	if params.AttributeMapping.Keys != nil {
+		updateAttributeMapping = !provider.SAMLProvider.AttributeMapping.Equal(&params.AttributeMapping)
+		if updateAttributeMapping {
+			modified = true
+			provider.SAMLProvider.AttributeMapping = params.AttributeMapping
+		}
 	}
 
 	nameIDFormat := ""


### PR DESCRIPTION
## What kind of change does this PR introduce?
* when the `attribute_mapping` key is not provided in the payload, the update should not delete the existing attribute mapping

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
