### PR TITLE
fix: use deep equal

### DIFF
--- a/internal/models/sso.go
+++ b/internal/models/sso.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"database/sql/driver"
 	"encoding/json"
+	"reflect"
 	"strings"
 	"time"
 
@@ -76,7 +77,7 @@ func (m *SAMLAttributeMapping) Equal(o *SAMLAttributeMapping) bool {
 			}
 		}
 
-		if mvalue.Default != value.Default {
+		if !reflect.DeepEqual(mvalue.Default, value.Default) {
 			return false
 		}
 


### PR DESCRIPTION
## What kind of change does this PR introduce?
* `Default` field in SAMLAttribute uses an `interface{}` type which requires using deep equality for comparisons 

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
