### PR TITLE
fix: update status code returned when max number of enrolled factors is exceeded

### DIFF
--- a/internal/api/mfa.go
+++ b/internal/api/mfa.go
@@ -107,11 +107,11 @@ func (a *API) EnrollFactor(w http.ResponseWriter, r *http.Request) error {
 	}
 
 	if factorCount >= int(config.MFA.MaxEnrolledFactors) {
-		return forbiddenError(ErrorCodeTooManyEnrolledMFAFactors, "Maximum number of verified factors reached, unenroll to continue")
+		return unprocessableEntityError(ErrorCodeTooManyEnrolledMFAFactors, "Maximum number of verified factors reached, unenroll to continue")
 	}
 
 	if numVerifiedFactors >= config.MFA.MaxVerifiedFactors {
-		return forbiddenError(ErrorCodeTooManyEnrolledMFAFactors, "Maximum number of verified factors reached, unenroll to continue")
+		return unprocessableEntityError(ErrorCodeTooManyEnrolledMFAFactors, "Maximum number of verified factors reached, unenroll to continue")
 	}
 
 	if numVerifiedFactors > 0 && !session.IsAAL2() {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Return un-processable entity error instead of forbidden error when a user has exceeded the maximum allowable number of enrolled factors. 

 I am guessing that is unlikely that folks depend on the specific status code. Open to suggestions if there are concrete ways to confirm / disconfirm this though

Addresses: https://github.com/supabase/auth/pull/1668#discussion_r1689475352