### PR TITLE
fix: restrict autoconfirm email change to anonymous users

### DIFF
--- a/internal/api/user.go
+++ b/internal/api/user.go
@@ -206,7 +206,9 @@ func (a *API) UserUpdate(w http.ResponseWriter, r *http.Request) error {
 		}
 
 		if params.Email != "" && params.Email != user.GetEmail() {
-			if config.Mailer.Autoconfirm {
+			if user.IsAnonymous && config.Mailer.Autoconfirm {
+				// anonymous users can add an email with automatic confirmation, which is similar to signing up
+				// permanent users always need to verify their email address when changing it
 				user.EmailChange = params.Email
 				if _, terr := a.emailChangeVerify(r, tx, &VerifyParams{
 					Type:  mailer.EmailChangeVerification,


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Restricts auto-confirmation of emails on email change to anonymous users only
* Permanent users will still need to verify the email change request regardless of whether auto-confirmation is enabled or not
* This bug was introduced in #1646

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
