### PR TITLE
feat: add hook log entry with `run_hook` action

### DIFF
--- a/internal/api/hooks_test.go
+++ b/internal/api/hooks_test.go
@@ -262,7 +262,7 @@ func (ts *HooksTestSuite) TestInvokeHookIntegration() {
 			input:         &hooks.SendEmailInput{},
 			output:        &hooks.SendEmailOutput{},
 			uri:           "ftp://example.com/path",
-			expectedError: errors.New("unsupported protocol: ftp only postgres hooks and HTTPS functions are supported at the moment"),
+			expectedError: errors.New("unsupported protocol: \"ftp://example.com/path\" only postgres hooks and HTTPS functions are supported at the moment"),
 		},
 	}
 
@@ -274,7 +274,7 @@ func (ts *HooksTestSuite) TestInvokeHookIntegration() {
 		require.NoError(ts.T(), ts.Config.Hook.SendEmail.PopulateExtensibilityPoint())
 
 		ts.Run(tc.description, func() {
-			err = ts.API.invokeHook(tc.conn, tc.request, tc.input, tc.output, tc.uri)
+			err = ts.API.invokeHook(tc.conn, tc.request, tc.input, tc.output)
 			if tc.expectedError != nil {
 				require.EqualError(ts.T(), err, tc.expectedError.Error())
 			} else {

--- a/internal/api/mail.go
+++ b/internal/api/mail.go
@@ -589,7 +589,7 @@ func (a *API) sendEmail(r *http.Request, tx *storage.Connection, u *models.User,
 			EmailData: emailData,
 		}
 		output := hooks.SendEmailOutput{}
-		return a.invokeHook(tx, r, &input, &output, a.config.Hook.SendEmail.URI)
+		return a.invokeHook(tx, r, &input, &output)
 	}
 
 	switch emailActionType {

--- a/internal/api/mfa.go
+++ b/internal/api/mfa.go
@@ -261,7 +261,7 @@ func (a *API) VerifyFactor(w http.ResponseWriter, r *http.Request) error {
 		}
 
 		output := hooks.MFAVerificationAttemptOutput{}
-		err := a.invokeHook(nil, r, &input, &output, a.config.Hook.MFAVerificationAttempt.URI)
+		err := a.invokeHook(nil, r, &input, &output)
 		if err != nil {
 			return err
 		}

--- a/internal/api/phone.go
+++ b/internal/api/phone.go
@@ -104,7 +104,7 @@ func (a *API) sendPhoneConfirmation(r *http.Request, tx *storage.Connection, use
 				},
 			}
 			output := hooks.SendSMSOutput{}
-			err := a.invokeHook(tx, r, &input, &output, a.config.Hook.SendSMS.URI)
+			err := a.invokeHook(tx, r, &input, &output)
 			if err != nil {
 				return "", err
 			}

--- a/internal/api/token.go
+++ b/internal/api/token.go
@@ -185,7 +185,7 @@ func (a *API) ResourceOwnerPasswordGrant(ctx context.Context, w http.ResponseWri
 			Valid:  isValidPassword,
 		}
 		output := hooks.PasswordVerificationAttemptOutput{}
-		err := a.invokeHook(nil, r, &input, &output, a.config.Hook.PasswordVerificationAttempt.URI)
+		err := a.invokeHook(nil, r, &input, &output)
 		if err != nil {
 			return err
 		}
@@ -360,7 +360,7 @@ func (a *API) generateAccessToken(r *http.Request, tx *storage.Connection, user 
 
 		output := hooks.CustomAccessTokenOutput{}
 
-		err := a.invokeHook(tx, r, &input, &output, a.config.Hook.CustomAccessToken.URI)
+		err := a.invokeHook(tx, r, &input, &output)
 		if err != nil {
 			return "", 0, err
 		}


### PR DESCRIPTION
Adds a log entry when hooks run. Also refactors the `invokeHook` API to not require redundant parameters like the URI.