### PR TITLE
fix: update mfa phone migration to be idempotent

### DIFF
--- a/migrations/20240729123726_add_mfa_phone_config.up.sql
+++ b/migrations/20240729123726_add_mfa_phone_config.up.sql
@@ -11,4 +11,4 @@ alter table {{ index .Options "Namespace" }}.mfa_challenges add column if not ex
 
 create index if not exists idx_sent_at on {{ index .Options "Namespace" }}.mfa_challenges(sent_at);
 
-create unique index unique_verified_phone_factor on {{ index .Options "Namespace" }}.mfa_factors (user_id, phone) where status = 'verified';
+create unique index if not exists unique_verified_phone_factor on {{ index .Options "Namespace" }}.mfa_factors (user_id, phone) where status = 'verified';

--- a/migrations/20240729123726_add_mfa_phone_config.up.sql
+++ b/migrations/20240729123726_add_mfa_phone_config.up.sql
@@ -11,4 +11,4 @@ alter table {{ index .Options "Namespace" }}.mfa_challenges add column if not ex
 
 create index if not exists idx_sent_at on {{ index .Options "Namespace" }}.mfa_challenges(sent_at);
 
-create unique index if not exists unique_verified_phone_factor on {{ index .Options "Namespace" }}.mfa_factors (user_id, phone) where status = 'verified';
+create unique index if not exists unique_verified_phone_factor on {{ index .Options "Namespace" }}.mfa_factors (user_id, phone);


### PR DESCRIPTION
## What kind of change does this PR introduce?

- Add `if not exists` so the migration is idempotent
- Also drops the partial unique constraint on phone factors to avoid potential database bloat