### PR TITLE
fix: update openapi spec for MFA (Phone) 

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -693,11 +693,15 @@ paths:
                   type: string
                   enum:
                     - totp
+                    - phone
                 friendly_name:
                   type: string
                 issuer:
                   type: string
                   format: uri
+                phone:
+                  type: string
+                  format: phone
       responses:
         200:
           description: >

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -729,6 +729,7 @@ paths:
                         type: string
                   phone:
                     type: string
+                    format: phone
         400:
           $ref: "#/components/responses/BadRequestResponse"
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -717,6 +717,7 @@ paths:
                     type: string
                     enum:
                       - totp
+                      - phone
                   totp:
                     type: object
                     properties:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -726,6 +726,8 @@ paths:
                         type: string
                       uri:
                         type: string
+                  phone:
+                    type: string
         400:
           $ref: "#/components/responses/BadRequestResponse"
 
@@ -745,6 +747,18 @@ paths:
           schema:
             type: string
             format: uuid
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                channel:
+                  type: string
+                  enum:
+                    - sms
+                    - whatsapp
+
       responses:
         200:
           description: >
@@ -1963,6 +1977,11 @@ components:
           description: |-
             Usually one of:
             - totp
+            - phone
+        phone:
+          type: string
+          format: phone
+
 
     IdentitySchema:
       type: object


### PR DESCRIPTION
## What kind of change does this PR introduce?

Complement to #1668 

Add OpenAPI specification for MFA (Phone). In particular, updates the parameters and `/enroll` `/challenge` and `/verify`
