### PR TITLE
fix: maintain backward compatibility for asymmetric JWTs

### DIFF
--- a/internal/api/token.go
+++ b/internal/api/token.go
@@ -379,8 +379,9 @@ func (a *API) generateAccessToken(r *http.Request, tx *storage.Connection, user 
 	}
 
 	if _, ok := token.Header["kid"]; !ok {
-		kid := signingJwk.KeyID()
-		token.Header["kid"] = kid
+		if kid := signingJwk.KeyID(); kid != "" {
+			token.Header["kid"] = kid
+		}
 	}
 
 	// this serializes the aud claim to a string

--- a/internal/conf/configuration.go
+++ b/internal/conf/configuration.go
@@ -713,11 +713,7 @@ func (config *GlobalConfiguration) ApplyDefaults() error {
 
 	if config.JWT.Keys == nil || len(config.JWT.Keys) == 0 {
 		// transform the secret into a JWK for consistency
-		bytes, err := base64.StdEncoding.DecodeString(config.JWT.Secret)
-		if err != nil {
-			bytes = []byte(config.JWT.Secret)
-		}
-		privKey, err := jwk.FromRaw(bytes)
+		privKey, err := jwk.FromRaw([]byte(config.JWT.Secret))
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Use the original value of `GOTRUE_JWT_SECRET` - no need to check for base64 decoding.
* Don't include the kid claim if the kid is an empty string

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
