### PR TITLE
fix: enforce uniqueness on verified phone numbers 

### DIFF
--- a/internal/api/errorcodes.go
+++ b/internal/api/errorcodes.go
@@ -81,4 +81,6 @@ const (
 	ErrorCodeMFAPhoneVerifyDisabled            ErrorCode = "mfa_phone_verify_not_enabled"
 	ErrorCodeMFATOTPEnrollDisabled             ErrorCode = "mfa_totp_enroll_not_enabled"
 	ErrorCodeMFATOTPVerifyDisabled             ErrorCode = "mfa_totp_verify_not_enabled"
+	// TOOD: Find a better name for this error code
+	ErrorCodeVerifiedPhoneFactorExists ErrorCode = "mfa_verified_phone_factor_exists"
 )

--- a/internal/api/errorcodes.go
+++ b/internal/api/errorcodes.go
@@ -81,6 +81,5 @@ const (
 	ErrorCodeMFAPhoneVerifyDisabled            ErrorCode = "mfa_phone_verify_not_enabled"
 	ErrorCodeMFATOTPEnrollDisabled             ErrorCode = "mfa_totp_enroll_not_enabled"
 	ErrorCodeMFATOTPVerifyDisabled             ErrorCode = "mfa_totp_verify_not_enabled"
-	// TOOD: Find a better name for this error code
-	ErrorCodeVerifiedPhoneFactorExists ErrorCode = "mfa_verified_phone_factor_exists"
+	ErrorCodeVerifiedFactorExists              ErrorCode = "mfa_verified_factor_exists"
 )

--- a/internal/api/mfa.go
+++ b/internal/api/mfa.go
@@ -106,7 +106,7 @@ func (a *API) enrollPhoneFactor(w http.ResponseWriter, r *http.Request, params *
 		case factor.IsVerified():
 			numVerifiedFactors++
 
-		case factor.IsUnverified() && factor.IsPhoneFactor() && factor.Phone == params.Phone:
+		case factor.IsUnverified() && factor.IsPhoneFactor() && factor.Phone.String() == params.Phone:
 			if err := db.Destroy(factor); err != nil {
 				return internalServerError("Database error deleting factor").WithInternalError(err)
 			}

--- a/internal/api/mfa.go
+++ b/internal/api/mfa.go
@@ -113,10 +113,8 @@ func (a *API) enrollPhoneFactor(w http.ResponseWriter, r *http.Request, params *
 		}
 	}
 
-	for _, factorToDelete := range factorsToDelete {
-		if err := db.Destroy(&factorToDelete); err != nil {
-			return internalServerError("Database error deleting factor").WithInternalError(err)
-		}
+	if err := db.Destroy(&factorsToDelete); err != nil {
+		return internalServerError("Database error deleting unverified phone factors").WithInternalError(err)
 	}
 
 	if factorCount >= int(config.MFA.MaxEnrolledFactors) {

--- a/internal/api/mfa.go
+++ b/internal/api/mfa.go
@@ -129,7 +129,6 @@ func (a *API) enrollPhoneFactor(w http.ResponseWriter, r *http.Request, params *
 	if numVerifiedFactors > 0 && !session.IsAAL2() {
 		return forbiddenError(ErrorCodeInsufficientAAL, "AAL2 required to enroll a new factor")
 	}
-
 	factor := models.NewPhoneFactor(user, phone, params.FriendlyName)
 	err = db.Transaction(func(tx *storage.Connection) error {
 		if terr := tx.Create(factor); terr != nil {
@@ -150,7 +149,7 @@ func (a *API) enrollPhoneFactor(w http.ResponseWriter, r *http.Request, params *
 		ID:           factor.ID,
 		Type:         models.Phone,
 		FriendlyName: factor.FriendlyName,
-		Phone:        string(factor.Phone),
+		Phone:        params.Phone,
 	})
 }
 

--- a/internal/api/mfa.go
+++ b/internal/api/mfa.go
@@ -99,14 +99,14 @@ func (a *API) enrollPhoneFactor(w http.ResponseWriter, r *http.Request, params *
 
 		case factor.IsVerified() && factor.IsPhoneFactor():
 			return unprocessableEntityError(
-				ErrorCodeVerifiedPhoneFactorExists,
+				ErrorCodeVerifiedFactorExists,
 				"A verified phone factor already exists, unenroll the existing factor to continue",
 			)
 
 		case factor.IsVerified():
 			numVerifiedFactors++
 
-		case factor.IsUnverified() && factor.IsPhoneFactor():
+		case factor.IsUnverified() && factor.IsPhoneFactor() && factor.Phone == params.Phone:
 			if err := db.Destroy(factor); err != nil {
 				return internalServerError("Database error deleting factor").WithInternalError(err)
 			}

--- a/internal/api/mfa.go
+++ b/internal/api/mfa.go
@@ -99,14 +99,16 @@ func (a *API) enrollPhoneFactor(w http.ResponseWriter, r *http.Request, params *
 			)
 
 		case factor.IsPhoneFactor():
-			if factor.IsVerified() {
-				return unprocessableEntityError(
-					ErrorCodeVerifiedFactorExists,
-					"A verified phone factor already exists, unenroll the existing factor to continue",
-				)
-			}
-			if factor.IsUnverified() && factor.Phone.String() == phone {
-				factorsToDelete = append(factorsToDelete, factor)
+			if factor.Phone.String() == phone {
+				if factor.IsVerified() {
+					return unprocessableEntityError(
+						ErrorCodeVerifiedFactorExists,
+						"A verified phone factor already exists, unenroll the existing factor to continue",
+					)
+				} else if factor.IsUnverified() {
+					factorsToDelete = append(factorsToDelete, factor)
+				}
+
 			}
 
 		case factor.IsVerified():

--- a/internal/api/mfa_test.go
+++ b/internal/api/mfa_test.go
@@ -210,7 +210,7 @@ func (ts *MFATestSuite) TestDuplicateEnrollPhoneFactor() {
 		earlierFactorName       string
 		laterFactorName         string
 		phone                   string
-		altPhone                string
+		secondPhone             string
 		expectedCode            int
 		expectedNumberOfFactors int
 	}{
@@ -219,7 +219,7 @@ func (ts *MFATestSuite) TestDuplicateEnrollPhoneFactor() {
 			earlierFactorName:       friendlyName,
 			laterFactorName:         altFriendlyName,
 			phone:                   testPhoneNumber,
-			altPhone:                testPhoneNumber,
+			secondPhone:             testPhoneNumber,
 			expectedNumberOfFactors: 1,
 		},
 
@@ -228,7 +228,7 @@ func (ts *MFATestSuite) TestDuplicateEnrollPhoneFactor() {
 			earlierFactorName:       friendlyName,
 			laterFactorName:         altFriendlyName,
 			phone:                   testPhoneNumber,
-			altPhone:                altPhoneNumber,
+			secondPhone:             altPhoneNumber,
 			expectedNumberOfFactors: 2,
 		},
 	}
@@ -239,7 +239,7 @@ func (ts *MFATestSuite) TestDuplicateEnrollPhoneFactor() {
 			require.NoError(ts.T(), ts.API.db.Destroy(ts.TestUser.Factors))
 			_ = performEnrollFlow(ts, token, c.earlierFactorName, models.Phone, ts.TestDomain, c.phone, http.StatusOK)
 
-			w := performEnrollFlow(ts, token, c.laterFactorName, models.Phone, ts.TestDomain, c.altPhone, http.StatusOK)
+			w := performEnrollFlow(ts, token, c.laterFactorName, models.Phone, ts.TestDomain, c.secondPhone, http.StatusOK)
 			enrollResp := EnrollFactorResponse{}
 			require.NoError(ts.T(), json.NewDecoder(w.Body).Decode(&enrollResp))
 

--- a/internal/api/mfa_test.go
+++ b/internal/api/mfa_test.go
@@ -260,7 +260,7 @@ func (ts *MFATestSuite) TestDuplicateEnrollPhoneFactorWithVerified() {
 	altFriendlyName := "alt_phone_factor"
 	token := ts.generateAAL1Token(ts.TestUser, &ts.TestSession.ID)
 
-	ts.Run("Phone: Enrolling a factor with a verified phone factor present should fail", func() {
+	ts.Run("Phone: Enrolling a factor with the same number as an existing verified phone factor should result in an error", func() {
 		require.NoError(ts.T(), ts.API.db.Destroy(ts.TestUser.Factors))
 
 		// Setup verified factor

--- a/internal/api/mfa_test.go
+++ b/internal/api/mfa_test.go
@@ -198,6 +198,109 @@ func (ts *MFATestSuite) TestEnrollFactor() {
 	}
 }
 
+func (ts *MFATestSuite) TestDuplicateEnrollPhoneFactor() {
+	testPhoneNumber := "+12345677889"
+	altPhoneNumber := "+987412444444"
+	friendlyName := "phone_factor"
+	altFriendlyName := "alt_phone_factor"
+	token := ts.generateAAL1Token(ts.TestUser, &ts.TestSession.ID)
+
+	var cases = []struct {
+		desc                    string
+		firstName               string
+		secondName              string
+		phone                   string
+		altPhone                string
+		expectedCode            int
+		expectedNumberOfFactors int
+		manualVerify            bool
+	}{
+		{
+			desc:                    "Phone: Duplicate enrollment with same number removes first unverified factor",
+			firstName:               friendlyName,
+			secondName:              altFriendlyName,
+			phone:                   testPhoneNumber,
+			altPhone:                testPhoneNumber,
+			expectedCode:            http.StatusOK,
+			expectedNumberOfFactors: 1,
+			manualVerify:            false,
+		},
+
+		{
+			desc:                    "Phone: Enroll two different numbers, both unverified",
+			firstName:               friendlyName,
+			secondName:              altFriendlyName,
+			phone:                   testPhoneNumber,
+			altPhone:                altPhoneNumber,
+			expectedCode:            http.StatusOK,
+			expectedNumberOfFactors: 2,
+			manualVerify:            false,
+		},
+	}
+
+	for _, c := range cases {
+		ts.Run(c.desc, func() {
+			// First enrollment
+			// Create corresponding session
+			// First factor is a TOTP factor
+			// Cleanup: Destroy all factors
+			for _, factor := range ts.TestUser.Factors {
+				err := ts.API.db.Destroy(&factor)
+				require.NoError(ts.T(), err)
+			}
+
+			_ = performEnrollFlow(ts, token, c.firstName, models.Phone, ts.TestDomain, c.phone, http.StatusOK)
+			factors, err := FindFactorsByUser(ts.API.db, ts.TestUser)
+			ts.Require().NoError(err)
+
+			// Second enrollment
+			_ = performEnrollFlow(ts, token, c.secondName, models.Phone, ts.TestDomain, c.altPhone, c.expectedCode)
+
+			// Verify the factors in the database
+			factors, err = FindFactorsByUser(ts.API.db, ts.TestUser)
+			require.NoError(ts.T(), err)
+			require.Equal(ts.T(), len(factors), c.expectedNumberOfFactors)
+
+			if c.expectedCode == http.StatusOK {
+				require.Equal(ts.T(), c.secondName, factors[len(factors)-1].FriendlyName)
+				require.False(ts.T(), factors[len(factors)-1].IsVerified())
+			}
+
+		})
+	}
+}
+
+func (ts *MFATestSuite) TestDuplicateEnrollPhoneFactorWithVerified() {
+	testPhoneNumber := "+12345677889"
+	friendlyName := "phone_factor"
+	altFriendlyName := "alt_phone_factor"
+	token := ts.generateAAL1Token(ts.TestUser, &ts.TestSession.ID)
+
+	ts.Run("Phone: Enroll same number with verified number present", func() {
+
+		// First enrollment
+		_ = performEnrollFlow(ts, token, friendlyName, models.Phone, ts.TestDomain, testPhoneNumber, http.StatusOK)
+		factors, err := FindFactorsByUser(ts.API.db, ts.TestUser)
+		require.NoError(ts.T(), err)
+
+		// Manually verify the first factor
+		err = factors[1].UpdateStatus(ts.API.db, models.FactorStateVerified)
+		require.NoError(ts.T(), err)
+
+		// Second enrollment with same phone number
+		_ = performEnrollFlow(ts, token, altFriendlyName, models.Phone, ts.TestDomain, testPhoneNumber, http.StatusUnprocessableEntity)
+
+		// Verify the factors in the database
+		factors, err = FindFactorsByUser(ts.API.db, ts.TestUser)
+		require.NoError(ts.T(), err)
+		require.Equal(ts.T(), len(factors), 2) // Including the one existing test factor
+
+		if factors[0].FriendlyName == altFriendlyName {
+			require.True(ts.T(), factors[0].IsVerified())
+		}
+	})
+}
+
 func (ts *MFATestSuite) TestDuplicateTOTPEnrollsReturnExpectedMessage() {
 	friendlyName := "mary"
 	issuer := "https://issuer.com"

--- a/internal/api/mfa_test.go
+++ b/internal/api/mfa_test.go
@@ -244,20 +244,17 @@ func (ts *MFATestSuite) TestDuplicateEnrollPhoneFactor() {
 			// Create corresponding session
 			// First factor is a TOTP factor
 			// Cleanup: Destroy all factors
-			for _, factor := range ts.TestUser.Factors {
-				err := ts.API.db.Destroy(&factor)
-				require.NoError(ts.T(), err)
-			}
+
+			err := ts.API.db.Destroy(ts.TestUser.Factors)
+			require.NoError(ts.T(), err)
 
 			_ = performEnrollFlow(ts, token, c.firstName, models.Phone, ts.TestDomain, c.phone, http.StatusOK)
-			factors, err := FindFactorsByUser(ts.API.db, ts.TestUser)
-			ts.Require().NoError(err)
 
 			// Second enrollment
 			_ = performEnrollFlow(ts, token, c.secondName, models.Phone, ts.TestDomain, c.altPhone, c.expectedCode)
 
 			// Verify the factors in the database
-			factors, err = FindFactorsByUser(ts.API.db, ts.TestUser)
+			factors, err := FindFactorsByUser(ts.API.db, ts.TestUser)
 			require.NoError(ts.T(), err)
 			require.Equal(ts.T(), len(factors), c.expectedNumberOfFactors)
 

--- a/internal/models/factor.go
+++ b/internal/models/factor.go
@@ -197,8 +197,8 @@ func FindFactorByFactorID(conn *storage.Connection, factorID uuid.UUID) (*Factor
 	return &factor, nil
 }
 
-func DeleteUnverifiedFactors(tx *storage.Connection, user *User) error {
-	if err := tx.RawQuery("DELETE FROM "+(&pop.Model{Value: Factor{}}).TableName()+" WHERE user_id = ? and status = ?", user.ID, FactorStateUnverified.String()).Exec(); err != nil {
+func DeleteUnverifiedFactors(tx *storage.Connection, user *User, factorType string) error {
+	if err := tx.RawQuery("DELETE FROM "+(&pop.Model{Value: Factor{}}).TableName()+" WHERE user_id = ? and status = ? and factor_type = ?", user.ID, FactorStateUnverified.String(), factorType).Exec(); err != nil {
 		return err
 	}
 

--- a/internal/models/factor.go
+++ b/internal/models/factor.go
@@ -117,7 +117,8 @@ func ParseAuthenticationMethod(authMethod string) (AuthenticationMethod, error) 
 }
 
 type Factor struct {
-	ID           uuid.UUID          `json:"id" db:"id"`
+	ID uuid.UUID `json:"id" db:"id"`
+	// TODO: Consider removing this nested user field. We don't use it.
 	User         User               `json:"-" belongs_to:"user"`
 	UserID       uuid.UUID          `json:"-" db:"user_id"`
 	CreatedAt    time.Time          `json:"created_at" db:"created_at"`

--- a/internal/models/factor.go
+++ b/internal/models/factor.go
@@ -263,6 +263,14 @@ func (f *Factor) IsVerified() bool {
 	return f.Status == FactorStateVerified.String()
 }
 
+func (f *Factor) IsUnverified() bool {
+	return f.Status == FactorStateUnverified.String()
+}
+
+func (f *Factor) IsPhoneFactor() bool {
+	return f.FactorType == Phone
+}
+
 func (f *Factor) FindChallengeByID(conn *storage.Connection, challengeID uuid.UUID) (*Challenge, error) {
 	var challenge Challenge
 	err := conn.Q().Where("id = ? and factor_id = ?", challengeID, f.ID).First(&challenge)


### PR DESCRIPTION
## What kind of change does this PR introduce?

With this change:
- Multiple verified phone mfa factors can exist so long as they have distinct phone numbers (see discussion below)
- Enrolling a factor with a number that is the same as the existing verified factor will result in a 422 status code
- Enrolling a factor with a number that is the same as another existing unverified factor will result in the deletion of the older factor.

Also includes:
- A refactor to check for duplicate constraints at application level then at the Postgres layer.
- A narrowing of deletion so that only unverified factors of the same type are deleted upon first successful verification

Follow up to #1687 to support the unique constraint on phone factors. 