### PR TITLE
fix: treat `GOTRUE_MFA_ENABLED` as meaning TOTP enabled on enroll and verify

### DIFF
--- a/internal/api/mfa.go
+++ b/internal/api/mfa.go
@@ -159,7 +159,11 @@ func (a *API) EnrollFactor(w http.ResponseWriter, r *http.Request) error {
 		}
 		return a.enrollPhoneFactor(w, r, params)
 	case models.TOTP:
-		if !config.MFA.TOTP.EnrollEnabled {
+		// Prior to the introduction of MFA.TOTP.EnrollEnabled,
+		// MFA.Enabled was used to configure whether TOTP was on. So
+		// both have to be set to false to regard the feature as
+		// disabled.
+		if !config.MFA.Enabled && !config.MFA.TOTP.EnrollEnabled {
 			return unprocessableEntityError(ErrorCodeMFATOTPEnrollDisabled, "MFA enroll is disabled for TOTP")
 		}
 	default:
@@ -362,7 +366,11 @@ func (a *API) ChallengeFactor(w http.ResponseWriter, r *http.Request) error {
 		return a.challengePhoneFactor(w, r)
 
 	case models.TOTP:
-		if !config.MFA.TOTP.VerifyEnabled {
+		// Prior to the introduction of MFA.TOTP.VerifyEnabled,
+		// MFA.Enabled was used to configure whether TOTP was on. So
+		// both have to be set to false to regard the feature as
+		// disabled.
+		if !config.MFA.Enabled && !config.MFA.TOTP.VerifyEnabled {
 			return unprocessableEntityError(ErrorCodeMFATOTPEnrollDisabled, "MFA verification is disabled for TOTP")
 		}
 	default:

--- a/internal/conf/configuration.go
+++ b/internal/conf/configuration.go
@@ -123,7 +123,9 @@ type PhoneFactorTypeConfiguration struct {
 
 // MFAConfiguration holds all the MFA related Configuration
 type MFAConfiguration struct {
-	Enabled                     bool                         `default:"false"`
+	// Enabled is deprecated, but still used to signal TOTP.EnrollEnabled and TOTP.VerifyEnabled.
+	Enabled bool `default:"false"`
+
 	ChallengeExpiryDuration     float64                      `json:"challenge_expiry_duration" default:"300" split_words:"true"`
 	FactorExpiryDuration        time.Duration                `json:"factor_expiry_duration" default:"300s" split_words:"true"`
 	RateLimitChallengeAndVerify float64                      `split_words:"true" default:"15"`


### PR DESCRIPTION
`GOTRUE_MFA_ENABLED` used to control whether TOTP enroll and verify were on, but with #1668 this config option was disregarded, meaning that TOTP will stop working for already configured projects.