### PR TITLE
fix: remove check for content-length

### DIFF
--- a/internal/api/errorcodes.go
+++ b/internal/api/errorcodes.go
@@ -75,6 +75,7 @@ const (
 	ErrorCodeAnonymousProviderDisabled         ErrorCode = "anonymous_provider_disabled"
 	ErrorCodeHookTimeout                       ErrorCode = "hook_timeout"
 	ErrorCodeHookTimeoutAfterRetry             ErrorCode = "hook_timeout_after_retry"
+	ErrorCodeHookPayloadOverSizeLimit          ErrorCode = "hook_payload_over_size_limit"
 	ErrorCodeRequestTimeout                    ErrorCode = "request_timeout"
 	ErrorCodeMFAPhoneEnrollDisabled            ErrorCode = "mfa_phone_enroll_not_enabled"
 	ErrorCodeMFAPhoneVerifyDisabled            ErrorCode = "mfa_phone_verify_not_enabled"

--- a/internal/api/errorcodes.go
+++ b/internal/api/errorcodes.go
@@ -75,8 +75,6 @@ const (
 	ErrorCodeAnonymousProviderDisabled         ErrorCode = "anonymous_provider_disabled"
 	ErrorCodeHookTimeout                       ErrorCode = "hook_timeout"
 	ErrorCodeHookTimeoutAfterRetry             ErrorCode = "hook_timeout_after_retry"
-	ErrorCodeHookPayloadOverSizeLimit          ErrorCode = "hook_payload_over_size_limit"
-	ErrorCodeHookPayloadUnknownSize            ErrorCode = "hook_payload_unknown_size"
 	ErrorCodeRequestTimeout                    ErrorCode = "request_timeout"
 	ErrorCodeMFAPhoneEnrollDisabled            ErrorCode = "mfa_phone_enroll_not_enabled"
 	ErrorCodeMFAPhoneVerifyDisabled            ErrorCode = "mfa_phone_verify_not_enabled"

--- a/internal/api/hooks.go
+++ b/internal/api/hooks.go
@@ -152,14 +152,8 @@ func (a *API) runHTTPHook(r *http.Request, hookConfig conf.ExtensibilityPointCon
 			if rsp.Body == nil {
 				return nil, nil
 			}
-			contentLength := rsp.ContentLength
-			if contentLength == -1 {
-				return nil, unprocessableEntityError(ErrorCodeHookPayloadUnknownSize, "Payload size not known")
-			}
-			if contentLength >= PayloadLimit {
-				return nil, unprocessableEntityError(ErrorCodeHookPayloadOverSizeLimit, fmt.Sprintf("Payload size is: %d bytes exceeded size limit of %d bytes", contentLength, PayloadLimit))
-			}
-			limitedReader := io.LimitedReader{R: rsp.Body, N: contentLength}
+			// TODO: Check if there is excess data in the response body to be read
+			limitedReader := io.LimitedReader{R: rsp.Body, N: PayloadLimit}
 			body, err := io.ReadAll(&limitedReader)
 			if err != nil {
 				return nil, err


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Not all responses are gonna contain the `Content-Length` header. According to the HTTP/2 spec, it is not required to return the content-length header in the response. If the "Transfer Encoding" is chunked, the content-length header will also not be present as the response is sent in chunks and the content-length is unknown initially.

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
