### PR TITLE
fix: drop the MFA_ENABLED config

### DIFF
--- a/internal/api/mfa.go
+++ b/internal/api/mfa.go
@@ -257,11 +257,7 @@ func (a *API) EnrollFactor(w http.ResponseWriter, r *http.Request) error {
 		}
 		return a.enrollPhoneFactor(w, r, params)
 	case models.TOTP:
-		// Prior to the introduction of MFA.TOTP.EnrollEnabled,
-		// MFA.Enabled was used to configure whether TOTP was on. So
-		// both have to be set to false to regard the feature as
-		// disabled.
-		if !config.MFA.Enabled && !config.MFA.TOTP.EnrollEnabled {
+		if !config.MFA.TOTP.EnrollEnabled {
 			return unprocessableEntityError(ErrorCodeMFATOTPEnrollDisabled, "MFA enroll is disabled for TOTP")
 		}
 		return a.enrollTOTPFactor(w, r, params)
@@ -405,11 +401,7 @@ func (a *API) ChallengeFactor(w http.ResponseWriter, r *http.Request) error {
 		return a.challengePhoneFactor(w, r)
 
 	case models.TOTP:
-		// Prior to the introduction of MFA.TOTP.VerifyEnabled,
-		// MFA.Enabled was used to configure whether TOTP was on. So
-		// both have to be set to false to regard the feature as
-		// disabled.
-		if !config.MFA.Enabled && !config.MFA.TOTP.VerifyEnabled {
+		if !config.MFA.TOTP.VerifyEnabled {
 			return unprocessableEntityError(ErrorCodeMFATOTPEnrollDisabled, "MFA verification is disabled for TOTP")
 		}
 		if !factor.IsOwnedBy(user) {

--- a/internal/api/settings.go
+++ b/internal/api/settings.go
@@ -36,7 +36,6 @@ type Settings struct {
 	MailerAutoconfirm bool             `json:"mailer_autoconfirm"`
 	PhoneAutoconfirm  bool             `json:"phone_autoconfirm"`
 	SmsProvider       string           `json:"sms_provider"`
-	MFAEnabled        bool             `json:"mfa_enabled"`
 	SAMLEnabled       bool             `json:"saml_enabled"`
 }
 
@@ -75,7 +74,6 @@ func (a *API) Settings(w http.ResponseWriter, r *http.Request) error {
 		MailerAutoconfirm: config.Mailer.Autoconfirm,
 		PhoneAutoconfirm:  config.Sms.Autoconfirm,
 		SmsProvider:       config.Sms.Provider,
-		MFAEnabled:        config.MFA.Enabled,
 		SAMLEnabled:       config.SAML.Enabled,
 	})
 }

--- a/internal/conf/configuration.go
+++ b/internal/conf/configuration.go
@@ -123,9 +123,6 @@ type PhoneFactorTypeConfiguration struct {
 
 // MFAConfiguration holds all the MFA related Configuration
 type MFAConfiguration struct {
-	// Enabled is deprecated, but still used to signal TOTP.EnrollEnabled and TOTP.VerifyEnabled.
-	Enabled bool `default:"false"`
-
 	ChallengeExpiryDuration     float64                      `json:"challenge_expiry_duration" default:"300" split_words:"true"`
 	FactorExpiryDuration        time.Duration                `json:"factor_expiry_duration" default:"300s" split_words:"true"`
 	RateLimitChallengeAndVerify float64                      `split_words:"true" default:"15"`


### PR DESCRIPTION
## What kind of change does this PR introduce?

The `MFA_ENABLED` config is deprecated and not in active use.