### PR TITLE
fix: allow enabling sms hook without setting up sms provider

### DIFF
--- a/internal/api/hooks.go
+++ b/internal/api/hooks.go
@@ -354,7 +354,7 @@ func (a *API) runHook(r *http.Request, conn *storage.Connection, hookConfig conf
 	case strings.HasPrefix(hookConfig.URI, "pg-functions:"):
 		response, err = a.runPostgresHook(ctx, conn, hookConfig, input, output)
 	default:
-		return nil, fmt.Errorf("unsupported protocol: %q only postgres hooks and HTTPS functions are supported at the moment", hookConfig.URI)
+		return nil, internalServerError("unsupported protocol: %q only postgres hooks and HTTPS functions are supported at the moment", hookConfig.URI)
 	}
 
 	duration := time.Since(hookStart)

--- a/internal/api/hooks.go
+++ b/internal/api/hooks.go
@@ -354,7 +354,7 @@ func (a *API) runHook(r *http.Request, conn *storage.Connection, hookConfig conf
 	case strings.HasPrefix(hookConfig.URI, "pg-functions:"):
 		response, err = a.runPostgresHook(ctx, conn, hookConfig, input, output)
 	default:
-		return nil, internalServerError("unsupported protocol: %q only postgres hooks and HTTPS functions are supported at the moment", hookConfig.URI)
+		return nil, fmt.Errorf("unsupported protocol: %q only postgres hooks and HTTPS functions are supported at the moment", hookConfig.URI)
 	}
 
 	duration := time.Since(hookStart)

--- a/internal/api/hooks_test.go
+++ b/internal/api/hooks_test.go
@@ -5,9 +5,9 @@ import (
 	"net/http"
 	"testing"
 
-	"errors"
 	"net/http/httptest"
 
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"

--- a/internal/api/mfa.go
+++ b/internal/api/mfa.go
@@ -286,7 +286,7 @@ func (a *API) challengePhoneFactor(w http.ResponseWriter, r *http.Request) error
 	if channel == "" {
 		channel = sms_provider.SMSProvider
 	}
-	if !sms_provider.IsValidMessageChannel(channel, config) {
+	if !sms_provider.IsValidMessageChannel(channel, config.Sms.Provider) {
 		return badRequestError(ErrorCodeValidationFailed, InvalidChannelError)
 	}
 	latestValidChallenge, err := factor.FindLatestUnexpiredChallenge(a.db, config.MFA.ChallengeExpiryDuration)

--- a/internal/api/mfa.go
+++ b/internal/api/mfa.go
@@ -286,7 +286,7 @@ func (a *API) challengePhoneFactor(w http.ResponseWriter, r *http.Request) error
 	if channel == "" {
 		channel = sms_provider.SMSProvider
 	}
-	if !sms_provider.IsValidMessageChannel(channel, config.Sms.Provider) {
+	if !sms_provider.IsValidMessageChannel(channel, config) {
 		return badRequestError(ErrorCodeValidationFailed, InvalidChannelError)
 	}
 	latestValidChallenge, err := factor.FindLatestUnexpiredChallenge(a.db, config.MFA.ChallengeExpiryDuration)

--- a/internal/api/mfa.go
+++ b/internal/api/mfa.go
@@ -283,13 +283,8 @@ func (a *API) challengePhoneFactor(w http.ResponseWriter, r *http.Request) error
 		return err
 	}
 	channel := params.Channel
-
 	if channel == "" {
 		channel = sms_provider.SMSProvider
-	}
-	smsProvider, err := sms_provider.GetSmsProvider(*config)
-	if err != nil {
-		return internalServerError("Failed to get SMS provider").WithInternalError(err)
 	}
 	if !sms_provider.IsValidMessageChannel(channel, config.Sms.Provider) {
 		return badRequestError(ErrorCodeValidationFailed, InvalidChannelError)
@@ -302,19 +297,17 @@ func (a *API) challengePhoneFactor(w http.ResponseWriter, r *http.Request) error
 	} else if latestValidChallenge != nil && !latestValidChallenge.SentAt.Add(config.MFA.Phone.MaxFrequency).Before(time.Now()) {
 		return tooManyRequestsError(ErrorCodeOverSMSSendRateLimit, generateFrequencyLimitErrorMessage(latestValidChallenge.SentAt, config.MFA.Phone.MaxFrequency))
 	}
-
 	otp, err := crypto.GenerateOtp(config.MFA.Phone.OtpLength)
 	if err != nil {
 		panic(err)
 	}
-	challenge, err := factor.CreatePhoneChallenge(ipAddress, otp, config.Security.DBEncryption.Encrypt, config.Security.DBEncryption.EncryptionKeyID, config.Security.DBEncryption.EncryptionKey)
-	if err != nil {
-		return internalServerError("error creating SMS Challenge")
-	}
-
 	message, err := generateSMSFromTemplate(config.MFA.Phone.SMSTemplate, otp)
 	if err != nil {
 		return internalServerError("error generating sms template").WithInternalError(err)
+	}
+	challenge, err := factor.CreatePhoneChallenge(ipAddress, otp, config.Security.DBEncryption.Encrypt, config.Security.DBEncryption.EncryptionKeyID, config.Security.DBEncryption.EncryptionKey)
+	if err != nil {
+		return internalServerError("error creating SMS Challenge")
 	}
 	if config.Hook.SendSMS.Enabled {
 		input := hooks.SendSMSInput{
@@ -330,10 +323,12 @@ func (a *API) challengePhoneFactor(w http.ResponseWriter, r *http.Request) error
 			return internalServerError("error invoking hook")
 		}
 	} else {
-
-		// We omit messageID for now, can consider reinstating if there are requests.
-		_, err := smsProvider.SendMessage(string(factor.Phone), message, channel, otp)
+		smsProvider, err := sms_provider.GetSmsProvider(*config)
 		if err != nil {
+			return internalServerError("Failed to get SMS provider").WithInternalError(err)
+		}
+		// We omit messageID for now, can consider reinstating if there are requests.
+		if _, err = smsProvider.SendMessage(string(factor.Phone), message, channel, otp); err != nil {
 			return internalServerError("error sending message").WithInternalError(err)
 		}
 	}

--- a/internal/api/mfa_test.go
+++ b/internal/api/mfa_test.go
@@ -265,6 +265,14 @@ func (ts *MFATestSuite) TestChallengeSMSFactor() {
         begin
             return input;
        end; $$ language plpgsql;`).Exec())
+	// We still need a mock provider for hooks to work right now for backward compatibility
+	// The WhatsApp channel is only valid when twilio or twilio verify is set.
+	ts.Config.Sms.Provider = "twilio"
+	ts.Config.Sms.Twilio = conf.TwilioProviderConfiguration{
+		AccountSid:        "test_account_sid",
+		AuthToken:         "test_auth_token",
+		MessageServiceSid: "test_message_service_id",
+	}
 
 	phone := "+1234567"
 	friendlyName := "testchallengesmsfactor"
@@ -483,6 +491,7 @@ func (ts *MFATestSuite) TestUnenrollVerifiedFactor() {
 func (ts *MFATestSuite) TestUnenrollUnverifiedFactor() {
 	var buffer bytes.Buffer
 	f := ts.TestUser.Factors[0]
+	f.Secret = ts.TestOTPKey.Secret()
 
 	token := ts.generateAAL1Token(ts.TestUser, &ts.TestSession.ID)
 	require.NoError(ts.T(), json.NewEncoder(&buffer).Encode(map[string]interface{}{

--- a/internal/api/mfa_test.go
+++ b/internal/api/mfa_test.go
@@ -265,14 +265,6 @@ func (ts *MFATestSuite) TestChallengeSMSFactor() {
         begin
             return input;
        end; $$ language plpgsql;`).Exec())
-	// We still need a mock provider for hooks to work right now for backward compatibility
-	// The WhatsApp channel is only valid when twilio or twilio verify is set.
-	ts.Config.Sms.Provider = "twilio"
-	ts.Config.Sms.Twilio = conf.TwilioProviderConfiguration{
-		AccountSid:        "test_account_sid",
-		AuthToken:         "test_auth_token",
-		MessageServiceSid: "test_message_service_id",
-	}
 
 	phone := "+1234567"
 	friendlyName := "testchallengesmsfactor"
@@ -491,7 +483,6 @@ func (ts *MFATestSuite) TestUnenrollVerifiedFactor() {
 func (ts *MFATestSuite) TestUnenrollUnverifiedFactor() {
 	var buffer bytes.Buffer
 	f := ts.TestUser.Factors[0]
-	f.Secret = ts.TestOTPKey.Secret()
 
 	token := ts.generateAAL1Token(ts.TestUser, &ts.TestSession.ID)
 	require.NoError(ts.T(), json.NewEncoder(&buffer).Encode(map[string]interface{}{

--- a/internal/api/otp.go
+++ b/internal/api/otp.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/sethvargo/go-password/password"
 	"github.com/supabase/auth/internal/api/sms_provider"
+	"github.com/supabase/auth/internal/conf"
 	"github.com/supabase/auth/internal/models"
 	"github.com/supabase/auth/internal/storage"
 )
@@ -45,17 +46,15 @@ func (p *OtpParams) Validate() error {
 	return nil
 }
 
-func (p *SmsParams) Validate(smsProvider string) error {
-	if p.Phone != "" && !sms_provider.IsValidMessageChannel(p.Channel, smsProvider) {
-		return badRequestError(ErrorCodeValidationFailed, InvalidChannelError)
-	}
-
+func (p *SmsParams) Validate(config *conf.GlobalConfiguration) error {
 	var err error
 	p.Phone, err = validatePhone(p.Phone)
 	if err != nil {
 		return err
 	}
-
+	if !sms_provider.IsValidMessageChannel(p.Channel, config) {
+		return badRequestError(ErrorCodeValidationFailed, InvalidChannelError)
+	}
 	return nil
 }
 
@@ -119,7 +118,7 @@ func (a *API) SmsOtp(w http.ResponseWriter, r *http.Request) error {
 		params.Channel = sms_provider.SMSProvider
 	}
 
-	if err := params.Validate(config.Sms.Provider); err != nil {
+	if err := params.Validate(config); err != nil {
 		return err
 	}
 

--- a/internal/api/otp.go
+++ b/internal/api/otp.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/sethvargo/go-password/password"
 	"github.com/supabase/auth/internal/api/sms_provider"
-	"github.com/supabase/auth/internal/conf"
 	"github.com/supabase/auth/internal/models"
 	"github.com/supabase/auth/internal/storage"
 )
@@ -46,8 +45,8 @@ func (p *OtpParams) Validate() error {
 	return nil
 }
 
-func (p *SmsParams) Validate(config *conf.GlobalConfiguration) error {
-	if p.Phone != "" && !sms_provider.IsValidMessageChannel(p.Channel, config) {
+func (p *SmsParams) Validate(smsProvider string) error {
+	if p.Phone != "" && !sms_provider.IsValidMessageChannel(p.Channel, smsProvider) {
 		return badRequestError(ErrorCodeValidationFailed, InvalidChannelError)
 	}
 
@@ -120,7 +119,7 @@ func (a *API) SmsOtp(w http.ResponseWriter, r *http.Request) error {
 		params.Channel = sms_provider.SMSProvider
 	}
 
-	if err := params.Validate(config); err != nil {
+	if err := params.Validate(config.Sms.Provider); err != nil {
 		return err
 	}
 

--- a/internal/api/otp.go
+++ b/internal/api/otp.go
@@ -193,7 +193,7 @@ func (a *API) SmsOtp(w http.ResponseWriter, r *http.Request) error {
 		}
 		mID, serr := a.sendPhoneConfirmation(r, tx, user, params.Phone, phoneConfirmationOtp, params.Channel)
 		if serr != nil {
-			return badRequestError(ErrorCodeSMSSendFailed, "Error sending sms OTP: %v", serr).WithInternalError(serr)
+			return serr
 		}
 		messageID = mID
 		return nil

--- a/internal/api/otp.go
+++ b/internal/api/otp.go
@@ -191,11 +191,7 @@ func (a *API) SmsOtp(w http.ResponseWriter, r *http.Request) error {
 		}); err != nil {
 			return err
 		}
-		smsProvider, terr := sms_provider.GetSmsProvider(*config)
-		if terr != nil {
-			return internalServerError("Unable to get SMS provider").WithInternalError(err)
-		}
-		mID, serr := a.sendPhoneConfirmation(r, tx, user, params.Phone, phoneConfirmationOtp, smsProvider, params.Channel)
+		mID, serr := a.sendPhoneConfirmation(r, tx, user, params.Phone, phoneConfirmationOtp, params.Channel)
 		if serr != nil {
 			return badRequestError(ErrorCodeSMSSendFailed, "Error sending sms OTP: %v", serr).WithInternalError(serr)
 		}

--- a/internal/api/otp.go
+++ b/internal/api/otp.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/sethvargo/go-password/password"
 	"github.com/supabase/auth/internal/api/sms_provider"
+	"github.com/supabase/auth/internal/conf"
 	"github.com/supabase/auth/internal/models"
 	"github.com/supabase/auth/internal/storage"
 )
@@ -45,8 +46,8 @@ func (p *OtpParams) Validate() error {
 	return nil
 }
 
-func (p *SmsParams) Validate(smsProvider string) error {
-	if p.Phone != "" && !sms_provider.IsValidMessageChannel(p.Channel, smsProvider) {
+func (p *SmsParams) Validate(config *conf.GlobalConfiguration) error {
+	if p.Phone != "" && !sms_provider.IsValidMessageChannel(p.Channel, config) {
 		return badRequestError(ErrorCodeValidationFailed, InvalidChannelError)
 	}
 
@@ -119,7 +120,7 @@ func (a *API) SmsOtp(w http.ResponseWriter, r *http.Request) error {
 		params.Channel = sms_provider.SMSProvider
 	}
 
-	if err := params.Validate(config.Sms.Provider); err != nil {
+	if err := params.Validate(config); err != nil {
 		return err
 	}
 

--- a/internal/api/phone.go
+++ b/internal/api/phone.go
@@ -95,8 +95,7 @@ func (a *API) sendPhoneConfirmation(r *http.Request, tx *storage.Connection, use
 			return "", err
 		}
 
-		// Hook should only be called if SMS autoconfirm is disabled
-		if !config.Sms.Autoconfirm && config.Hook.SendSMS.Enabled {
+		if config.Hook.SendSMS.Enabled {
 			input := hooks.SendSMSInput{
 				User: user,
 				SMS: hooks.SMS{

--- a/internal/api/phone.go
+++ b/internal/api/phone.go
@@ -71,7 +71,7 @@ func (a *API) sendPhoneConfirmation(r *http.Request, tx *storage.Connection, use
 	// intentionally keeping this before the test OTP, so that the behavior
 	// of regular and test OTPs is similar
 	if sentAt != nil && !sentAt.Add(config.Sms.MaxFrequency).Before(time.Now()) {
-		return "", MaxFrequencyLimitError
+		return "", tooManyRequestsError(ErrorCodeOverSMSSendRateLimit, generateFrequencyLimitErrorMessage(sentAt, config.Sms.MaxFrequency))
 	}
 
 	now := time.Now()
@@ -108,11 +108,11 @@ func (a *API) sendPhoneConfirmation(r *http.Request, tx *storage.Connection, use
 			}
 			message, err := generateSMSFromTemplate(config.Sms.SMSTemplate, otp)
 			if err != nil {
-				return "", err
+				return "", internalServerError("error generating sms template").WithInternalError(err)
 			}
 			messageID, err := smsProvider.SendMessage(phone, message, channel, otp)
 			if err != nil {
-				return messageID, err
+				return messageID, unprocessableEntityError(ErrorCodeSMSSendFailed, "Error sending %s OTP to provider: %v", otpType, err)
 			}
 		}
 	}
@@ -132,21 +132,24 @@ func (a *API) sendPhoneConfirmation(r *http.Request, tx *storage.Connection, use
 		return messageID, errors.Wrap(err, "Database error updating user for phone")
 	}
 
+	var ottErr error
 	switch otpType {
 	case phoneConfirmationOtp:
 		if err := models.CreateOneTimeToken(tx, user.ID, user.GetPhone(), user.ConfirmationToken, models.ConfirmationToken); err != nil {
-			return messageID, errors.Wrap(err, "Database error creating confirmation token for phone")
+			ottErr = errors.Wrap(err, "Database error creating confirmation token for phone")
 		}
 	case phoneChangeVerification:
 		if err := models.CreateOneTimeToken(tx, user.ID, user.PhoneChange, user.PhoneChangeToken, models.PhoneChangeToken); err != nil {
-			return messageID, errors.Wrap(err, "Database error creating phone change token")
+			ottErr = errors.Wrap(err, "Database error creating phone change token")
 		}
 	case phoneReauthenticationOtp:
 		if err := models.CreateOneTimeToken(tx, user.ID, user.GetPhone(), user.ReauthenticationToken, models.ReauthenticationToken); err != nil {
-			return messageID, errors.Wrap(err, "Database error creating reauthentication token for phone")
+			ottErr = errors.Wrap(err, "Database error creating reauthentication token for phone")
 		}
 	}
-
+	if ottErr != nil {
+		return messageID, internalServerError("error creating one time token").WithInternalError(ottErr)
+	}
 	return messageID, nil
 }
 

--- a/internal/api/phone_test.go
+++ b/internal/api/phone_test.go
@@ -112,7 +112,7 @@ func doTestSendPhoneConfirmation(ts *PhoneTestSuite, useTestOTP bool) {
 		ts.Run(c.desc, func() {
 			provider := &TestSmsProvider{}
 
-			_, err = ts.API.sendPhoneConfirmation(req, ts.API.db, u, "123456789", c.otpType, provider, sms_provider.SMSProvider)
+			_, err = ts.API.sendPhoneConfirmation(req, ts.API.db, u, "123456789", c.otpType, sms_provider.SMSProvider)
 			require.Equal(ts.T(), c.expected, err)
 			u, err = models.FindUserByPhoneAndAudience(ts.API.db, "123456789", ts.Config.JWT.Aud)
 			require.NoError(ts.T(), err)
@@ -144,9 +144,12 @@ func doTestSendPhoneConfirmation(ts *PhoneTestSuite, useTestOTP bool) {
 
 }
 
-func (ts *PhoneTestSuite) TestSendPhoneConfirmation() {
-	doTestSendPhoneConfirmation(ts, false)
-}
+// TODO(km): Figure out how to mock the SMS provider
+// now that it cannot be passed in as an argument to sendPhoneConfirmation
+//
+// func (ts *PhoneTestSuite) TestSendPhoneConfirmation() {
+// 	doTestSendPhoneConfirmation(ts, false)
+// }
 
 func (ts *PhoneTestSuite) TestSendPhoneConfirmationWithTestOTP() {
 	doTestSendPhoneConfirmation(ts, true)

--- a/internal/api/phone_test.go
+++ b/internal/api/phone_test.go
@@ -307,13 +307,13 @@ func (ts *PhoneTestSuite) TestSendSMSHook() {
 			method:   http.MethodPost,
 			uri:      "pg-functions://postgres/auth/send_sms_signup",
 			hookFunctionSQL: `
-                create or replace function send_sms_signup(input jsonb)
-                returns json as $$
-                begin
-                  insert into job_queue(job_type, payload)
-                  values ('sms_signup', input);
-                    return input;
-                end; $$ language plpgsql;`,
+		            create or replace function send_sms_signup(input jsonb)
+		            returns json as $$
+		            begin
+		              insert into job_queue(job_type, payload)
+		              values ('sms_signup', input);
+		                return input;
+		            end; $$ language plpgsql;`,
 			header: "",
 			body: map[string]string{
 				"phone":    "1234567890",
@@ -328,13 +328,13 @@ func (ts *PhoneTestSuite) TestSendSMSHook() {
 			method:   http.MethodPost,
 			uri:      "pg-functions://postgres/auth/send_sms_otp",
 			hookFunctionSQL: `
-                create or replace function send_sms_otp(input jsonb)
-                returns json as $$
-                begin
-                  insert into job_queue(job_type, payload)
-                  values ('sms_signup', input);
-                    return input;
-                end; $$ language plpgsql;`,
+		            create or replace function send_sms_otp(input jsonb)
+		            returns json as $$
+		            begin
+		              insert into job_queue(job_type, payload)
+		              values ('sms_signup', input);
+		                return input;
+		            end; $$ language plpgsql;`,
 			header: "",
 			body: map[string]string{
 				"phone": "123456789",
@@ -349,13 +349,13 @@ func (ts *PhoneTestSuite) TestSendSMSHook() {
 			method:   http.MethodPut,
 			uri:      "pg-functions://postgres/auth/send_sms_phone_change",
 			hookFunctionSQL: `
-        create or replace function send_sms_phone_change(input jsonb)
-        returns json as $$
-        begin
-           insert into job_queue(job_type, payload)
-           values ('phone_change', input);
-           return input;
-        end; $$ language plpgsql;`,
+		    create or replace function send_sms_phone_change(input jsonb)
+		    returns json as $$
+		    begin
+		       insert into job_queue(job_type, payload)
+		       values ('phone_change', input);
+		       return input;
+		    end; $$ language plpgsql;`,
 			header: token,
 			body: map[string]string{
 				"phone": "111111111",
@@ -370,11 +370,11 @@ func (ts *PhoneTestSuite) TestSendSMSHook() {
 			method:   http.MethodGet,
 			uri:      "pg-functions://postgres/auth/reauthenticate",
 			hookFunctionSQL: `
-        create or replace function reauthenticate(input jsonb)
-        returns json as $$
-        begin
-            return input;
-       end; $$ language plpgsql;`,
+		    create or replace function reauthenticate(input jsonb)
+		    returns json as $$
+		    begin
+		        return input;
+		   end; $$ language plpgsql;`,
 			header:                 "",
 			body:                   nil,
 			expectToken:            true,
@@ -397,7 +397,7 @@ func (ts *PhoneTestSuite) TestSendSMSHook() {
 				"phone": "123456789",
 			},
 			expectToken:            false,
-			expectedCode:           http.StatusBadRequest,
+			expectedCode:           http.StatusInternalServerError,
 			hookFunctionIdentifier: "send_sms_otp_failure(input jsonb)",
 		},
 	}
@@ -410,13 +410,6 @@ func (ts *PhoneTestSuite) TestSendSMSHook() {
 			ts.Config.Hook.SendSMS.URI = c.uri
 			// Disable FrequencyLimit to allow back to back sending
 			ts.Config.Sms.MaxFrequency = 0 * time.Second
-			// We still need a mock provider for hooks to work right now for backward compatibility
-			ts.Config.Sms.Provider = "twilio"
-			ts.Config.Sms.Twilio = conf.TwilioProviderConfiguration{
-				AccountSid:        "test_account_sid",
-				AuthToken:         "test_auth_token",
-				MessageServiceSid: "test_message_service_id",
-			}
 			require.NoError(ts.T(), ts.Config.Hook.SendSMS.PopulateExtensibilityPoint())
 
 			require.NoError(t, ts.API.db.RawQuery(c.hookFunctionSQL).Exec())

--- a/internal/api/phone_test.go
+++ b/internal/api/phone_test.go
@@ -111,6 +111,7 @@ func doTestSendPhoneConfirmation(ts *PhoneTestSuite, useTestOTP bool) {
 	for _, c := range cases {
 		ts.Run(c.desc, func() {
 			provider := &TestSmsProvider{}
+			sms_provider.MockProvider = provider
 
 			_, err = ts.API.sendPhoneConfirmation(req, ts.API.db, u, "123456789", c.otpType, sms_provider.SMSProvider)
 			require.Equal(ts.T(), c.expected, err)
@@ -144,12 +145,9 @@ func doTestSendPhoneConfirmation(ts *PhoneTestSuite, useTestOTP bool) {
 
 }
 
-// TODO(km): Figure out how to mock the SMS provider
-// now that it cannot be passed in as an argument to sendPhoneConfirmation
-//
-// func (ts *PhoneTestSuite) TestSendPhoneConfirmation() {
-// 	doTestSendPhoneConfirmation(ts, false)
-// }
+func (ts *PhoneTestSuite) TestSendPhoneConfirmation() {
+	doTestSendPhoneConfirmation(ts, false)
+}
 
 func (ts *PhoneTestSuite) TestSendPhoneConfirmationWithTestOTP() {
 	doTestSendPhoneConfirmation(ts, true)

--- a/internal/api/reauthenticate.go
+++ b/internal/api/reauthenticate.go
@@ -17,7 +17,6 @@ const InvalidNonceMessage = "Nonce has expired or is invalid"
 func (a *API) Reauthenticate(w http.ResponseWriter, r *http.Request) error {
 	ctx := r.Context()
 	db := a.db.WithContext(ctx)
-	config := a.config
 
 	user := getUser(ctx)
 	email, phone := user.GetEmail(), user.GetPhone()
@@ -44,11 +43,7 @@ func (a *API) Reauthenticate(w http.ResponseWriter, r *http.Request) error {
 		if email != "" {
 			return a.sendReauthenticationOtp(r, tx, user)
 		} else if phone != "" {
-			smsProvider, terr := sms_provider.GetSmsProvider(*config)
-			if terr != nil {
-				return internalServerError("Failed to get SMS provider").WithInternalError(terr)
-			}
-			mID, err := a.sendPhoneConfirmation(r, tx, user, phone, phoneReauthenticationOtp, smsProvider, sms_provider.SMSProvider)
+			mID, err := a.sendPhoneConfirmation(r, tx, user, phone, phoneReauthenticationOtp, sms_provider.SMSProvider)
 			if err != nil {
 				return err
 			}

--- a/internal/api/resend.go
+++ b/internal/api/resend.go
@@ -127,11 +127,7 @@ func (a *API) Resend(w http.ResponseWriter, r *http.Request) error {
 			if terr := models.NewAuditLogEntry(r, tx, user, models.UserRecoveryRequestedAction, "", nil); terr != nil {
 				return terr
 			}
-			smsProvider, terr := sms_provider.GetSmsProvider(*config)
-			if terr != nil {
-				return terr
-			}
-			mID, terr := a.sendPhoneConfirmation(r, tx, user, params.Phone, phoneConfirmationOtp, smsProvider, sms_provider.SMSProvider)
+			mID, terr := a.sendPhoneConfirmation(r, tx, user, params.Phone, phoneConfirmationOtp, sms_provider.SMSProvider)
 			if terr != nil {
 				return terr
 			}
@@ -139,11 +135,7 @@ func (a *API) Resend(w http.ResponseWriter, r *http.Request) error {
 		case mail.EmailChangeVerification:
 			return a.sendEmailChange(r, tx, user, user.EmailChange, models.ImplicitFlow)
 		case phoneChangeVerification:
-			smsProvider, terr := sms_provider.GetSmsProvider(*config)
-			if terr != nil {
-				return terr
-			}
-			mID, terr := a.sendPhoneConfirmation(r, tx, user, user.PhoneChange, phoneChangeVerification, smsProvider, sms_provider.SMSProvider)
+			mID, terr := a.sendPhoneConfirmation(r, tx, user, user.PhoneChange, phoneChangeVerification, sms_provider.SMSProvider)
 			if terr != nil {
 				return terr
 			}

--- a/internal/api/signup.go
+++ b/internal/api/signup.go
@@ -267,11 +267,7 @@ func (a *API) Signup(w http.ResponseWriter, r *http.Request) error {
 				}); terr != nil {
 					return terr
 				}
-				smsProvider, terr := sms_provider.GetSmsProvider(*config)
-				if terr != nil {
-					return internalServerError("Unable to get SMS provider").WithInternalError(terr)
-				}
-				if _, terr := a.sendPhoneConfirmation(r, tx, user, params.Phone, phoneConfirmationOtp, smsProvider, params.Channel); terr != nil {
+				if _, terr := a.sendPhoneConfirmation(r, tx, user, params.Phone, phoneConfirmationOtp, params.Channel); terr != nil {
 					return unprocessableEntityError(ErrorCodeSMSSendFailed, "Error sending confirmation sms: %v", terr).WithInternalError(terr)
 				}
 			}

--- a/internal/api/signup.go
+++ b/internal/api/signup.go
@@ -268,7 +268,7 @@ func (a *API) Signup(w http.ResponseWriter, r *http.Request) error {
 					return terr
 				}
 				if _, terr := a.sendPhoneConfirmation(r, tx, user, params.Phone, phoneConfirmationOtp, params.Channel); terr != nil {
-					return unprocessableEntityError(ErrorCodeSMSSendFailed, "Error sending confirmation sms: %v", terr).WithInternalError(terr)
+					return terr
 				}
 			}
 		}

--- a/internal/api/signup.go
+++ b/internal/api/signup.go
@@ -41,7 +41,7 @@ func (a *API) validateSignupParams(ctx context.Context, p *SignupParams) error {
 	if p.Email != "" && p.Phone != "" {
 		return badRequestError(ErrorCodeValidationFailed, "Only an email address or phone number should be provided on signup.")
 	}
-	if p.Provider == "phone" && !sms_provider.IsValidMessageChannel(p.Channel, config.Sms.Provider) {
+	if p.Provider == "phone" && !sms_provider.IsValidMessageChannel(p.Channel, config) {
 		return badRequestError(ErrorCodeValidationFailed, InvalidChannelError)
 	}
 	// PKCE not needed as phone signups already return access token in body

--- a/internal/api/signup.go
+++ b/internal/api/signup.go
@@ -41,7 +41,7 @@ func (a *API) validateSignupParams(ctx context.Context, p *SignupParams) error {
 	if p.Email != "" && p.Phone != "" {
 		return badRequestError(ErrorCodeValidationFailed, "Only an email address or phone number should be provided on signup.")
 	}
-	if p.Provider == "phone" && !sms_provider.IsValidMessageChannel(p.Channel, config) {
+	if p.Provider == "phone" && !sms_provider.IsValidMessageChannel(p.Channel, config.Sms.Provider) {
 		return badRequestError(ErrorCodeValidationFailed, InvalidChannelError)
 	}
 	// PKCE not needed as phone signups already return access token in body

--- a/internal/api/sms_provider/sms_provider.go
+++ b/internal/api/sms_provider/sms_provider.go
@@ -53,12 +53,13 @@ func GetSmsProvider(config conf.GlobalConfiguration) (SmsProvider, error) {
 	}
 }
 
-func IsValidMessageChannel(channel string, smsProvider string) bool {
+func IsValidMessageChannel(channel string, config *conf.GlobalConfiguration) bool {
+	smsProvider := config.Sms.Provider
 	switch channel {
 	case SMSProvider:
 		return true
 	case WhatsappProvider:
-		return smsProvider == "twilio" || smsProvider == "twilio_verify"
+		return smsProvider == "twilio" || smsProvider == "twilio_verify" || config.Hook.SendSMS.Enabled
 	default:
 		return false
 	}

--- a/internal/api/sms_provider/sms_provider.go
+++ b/internal/api/sms_provider/sms_provider.go
@@ -9,6 +9,9 @@ import (
 	"github.com/supabase/auth/internal/conf"
 )
 
+// overrides the SmsProvider set to always return the mock provider
+var MockProvider SmsProvider = nil
+
 var defaultTimeout time.Duration = time.Second * 10
 
 const SMSProvider = "sms"
@@ -30,6 +33,10 @@ type SmsProvider interface {
 }
 
 func GetSmsProvider(config conf.GlobalConfiguration) (SmsProvider, error) {
+	if MockProvider != nil {
+		return MockProvider, nil
+	}
+
 	switch name := config.Sms.Provider; name {
 	case "twilio":
 		return NewTwilioProvider(config.Sms.Twilio)

--- a/internal/api/sms_provider/sms_provider.go
+++ b/internal/api/sms_provider/sms_provider.go
@@ -53,12 +53,16 @@ func GetSmsProvider(config conf.GlobalConfiguration) (SmsProvider, error) {
 	}
 }
 
-func IsValidMessageChannel(channel string, smsProvider string) bool {
+func IsValidMessageChannel(channel string, config *conf.GlobalConfiguration) bool {
+	if config.Hook.SendSMS.Enabled {
+		// channel doesn't matter if SMS hook is enabled
+		return true
+	}
 	switch channel {
 	case SMSProvider:
 		return true
 	case WhatsappProvider:
-		return smsProvider == "twilio" || smsProvider == "twilio_verify"
+		return config.Sms.Provider == "twilio" || config.Sms.Provider == "twilio_verify"
 	default:
 		return false
 	}

--- a/internal/api/sms_provider/sms_provider.go
+++ b/internal/api/sms_provider/sms_provider.go
@@ -53,13 +53,12 @@ func GetSmsProvider(config conf.GlobalConfiguration) (SmsProvider, error) {
 	}
 }
 
-func IsValidMessageChannel(channel string, config *conf.GlobalConfiguration) bool {
-	smsProvider := config.Sms.Provider
+func IsValidMessageChannel(channel string, smsProvider string) bool {
 	switch channel {
 	case SMSProvider:
 		return true
 	case WhatsappProvider:
-		return smsProvider == "twilio" || smsProvider == "twilio_verify" || config.Hook.SendSMS.Enabled
+		return smsProvider == "twilio" || smsProvider == "twilio_verify"
 	default:
 		return false
 	}

--- a/internal/api/user.go
+++ b/internal/api/user.go
@@ -246,10 +246,7 @@ func (a *API) UserUpdate(w http.ResponseWriter, r *http.Request) error {
 				}
 			} else {
 				if _, terr := a.sendPhoneConfirmation(r, tx, user, params.Phone, phoneChangeVerification, params.Channel); terr != nil {
-					if errors.Is(terr, MaxFrequencyLimitError) {
-						return tooManyRequestsError(ErrorCodeOverSMSSendRateLimit, generateFrequencyLimitErrorMessage(user.PhoneChangeSentAt, config.Sms.MaxFrequency))
-					}
-					return internalServerError("Error sending phone change otp").WithInternalError(terr)
+					return terr
 				}
 			}
 		}

--- a/internal/api/user.go
+++ b/internal/api/user.go
@@ -44,7 +44,7 @@ func (a *API) validateUserUpdateParams(ctx context.Context, p *UserUpdateParams)
 		if p.Channel == "" {
 			p.Channel = sms_provider.SMSProvider
 		}
-		if !sms_provider.IsValidMessageChannel(p.Channel, config) {
+		if !sms_provider.IsValidMessageChannel(p.Channel, config.Sms.Provider) {
 			return badRequestError(ErrorCodeValidationFailed, InvalidChannelError)
 		}
 	}

--- a/internal/api/user.go
+++ b/internal/api/user.go
@@ -245,11 +245,7 @@ func (a *API) UserUpdate(w http.ResponseWriter, r *http.Request) error {
 					return terr
 				}
 			} else {
-				smsProvider, terr := sms_provider.GetSmsProvider(*config)
-				if terr != nil {
-					return internalServerError("Error finding SMS provider").WithInternalError(terr)
-				}
-				if _, terr := a.sendPhoneConfirmation(r, tx, user, params.Phone, phoneChangeVerification, smsProvider, params.Channel); terr != nil {
+				if _, terr := a.sendPhoneConfirmation(r, tx, user, params.Phone, phoneChangeVerification, params.Channel); terr != nil {
 					if errors.Is(terr, MaxFrequencyLimitError) {
 						return tooManyRequestsError(ErrorCodeOverSMSSendRateLimit, generateFrequencyLimitErrorMessage(user.PhoneChangeSentAt, config.Sms.MaxFrequency))
 					}

--- a/internal/api/user.go
+++ b/internal/api/user.go
@@ -44,7 +44,7 @@ func (a *API) validateUserUpdateParams(ctx context.Context, p *UserUpdateParams)
 		if p.Channel == "" {
 			p.Channel = sms_provider.SMSProvider
 		}
-		if !sms_provider.IsValidMessageChannel(p.Channel, config.Sms.Provider) {
+		if !sms_provider.IsValidMessageChannel(p.Channel, config) {
 			return badRequestError(ErrorCodeValidationFailed, InvalidChannelError)
 		}
 	}


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Resolves issue where the custom SMS hook cannot be used unless a SMS provider is configured by moving `GetSmsProvider` into `sendPhoneConfirmation` and only calls it if the hook is not enabled.
* Allows `channel` to be set for MFA (phone) if hook is enabled 

## What is the current behavior?
* It's not possible to set up a hook without adding config for a SMS provider

## TODO
- [x] Fix broken tests 
