### PR TITLE
fix: remove FindFactorsByUser

### DIFF
--- a/internal/api/mfa_test.go
+++ b/internal/api/mfa_test.go
@@ -12,8 +12,6 @@ import (
 
 	"github.com/gofrs/uuid"
 
-	"database/sql"
-
 	"github.com/pkg/errors"
 	"github.com/pquerna/otp"
 	"github.com/supabase/auth/internal/api/sms_provider"

--- a/internal/api/mfa_test.go
+++ b/internal/api/mfa_test.go
@@ -12,13 +12,11 @@ import (
 
 	"github.com/gofrs/uuid"
 
-	"github.com/pkg/errors"
 	"github.com/pquerna/otp"
 	"github.com/supabase/auth/internal/api/sms_provider"
 	"github.com/supabase/auth/internal/conf"
 	"github.com/supabase/auth/internal/crypto"
 	"github.com/supabase/auth/internal/models"
-	"github.com/supabase/auth/internal/storage"
 	"github.com/supabase/auth/internal/utilities"
 
 	"github.com/pquerna/otp/totp"
@@ -487,7 +485,6 @@ func (ts *MFATestSuite) TestUnenrollVerifiedFactor() {
 func (ts *MFATestSuite) TestUnenrollUnverifiedFactor() {
 	var buffer bytes.Buffer
 	f := ts.TestUser.Factors[0]
-	f.Secret = ts.TestOTPKey.Secret()
 
 	token := ts.generateAAL1Token(ts.TestUser, &ts.TestSession.ID)
 	require.NoError(ts.T(), json.NewEncoder(&buffer).Encode(map[string]interface{}{


### PR DESCRIPTION
## What kind of change does this PR introduce?

Refactors the tests and removes FindFactorsByUser. There shouldn't be a need to call it as it's possible to directly load the Factors.

We note that there is significant opportunity for refactoring [in this test](https://github.com/supabase/auth/pull/1707/files#diff-776a4afc31ddc19c68d15827910389a0f2598c3351ec1df5495344d3e286c36cL309) this will be done later in the week  in the interest of time



