### PR TITLE
fix: expose factor type on challenge

### DIFF
--- a/internal/api/mfa.go
+++ b/internal/api/mfa.go
@@ -57,6 +57,7 @@ type VerifyFactorParams struct {
 
 type ChallengeFactorResponse struct {
 	ID        uuid.UUID `json:"id"`
+	Type      string    `json:"type"`
 	ExpiresAt int64     `json:"expires_at"`
 }
 
@@ -343,6 +344,7 @@ func (a *API) challengePhoneFactor(w http.ResponseWriter, r *http.Request) error
 	}
 	return sendJSON(w, http.StatusOK, &ChallengeFactorResponse{
 		ID:        challenge.ID,
+		Type:      factor.FactorType,
 		ExpiresAt: challenge.GetExpiryTime(config.MFA.ChallengeExpiryDuration).Unix(),
 	})
 }
@@ -374,6 +376,7 @@ func (a *API) challengeTOTPFactor(w http.ResponseWriter, r *http.Request) error 
 
 	return sendJSON(w, http.StatusOK, &ChallengeFactorResponse{
 		ID:        challenge.ID,
+		Type:      factor.FactorType,
 		ExpiresAt: challenge.GetExpiryTime(config.MFA.ChallengeExpiryDuration).Unix(),
 	})
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Expose factor type on challenge so that developers can know whether it is a phone or TOTP factor they have challenged and redirect to appropriate page or perform relevant action

Also helps us distinguish between the two so we can prevent unintended behaviour (e.g. the use of `challengeAndVerify` with a phone factor)


As typescript follow structural typing I think addition of a new field should be fine. We will test this before proceeding. However, putting it out there first for early review or consideration

Update - tested and should be fine