### PR TITLE
chore: remove unused hook outputs

### DIFF
--- a/internal/hooks/auth_hooks.go
+++ b/internal/hooks/auth_hooks.go
@@ -153,7 +153,6 @@ type SendSMSInput struct {
 }
 
 type SendSMSOutput struct {
-	Success   bool          `json:"success"`
 	HookError AuthHookError `json:"error,omitempty"`
 }
 
@@ -163,7 +162,6 @@ type SendEmailInput struct {
 }
 
 type SendEmailOutput struct {
-	Success   bool          `json:"success"`
 	HookError AuthHookError `json:"error,omitempty"`
 }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Remove unused "Success" field in the hook outputs for "Send SMS" and "Send Email" 

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
