### PR TITLE
fix: add error codes to password login flow

### DIFF
--- a/internal/api/errorcodes.go
+++ b/internal/api/errorcodes.go
@@ -82,6 +82,5 @@ const (
 	ErrorCodeMFATOTPEnrollDisabled             ErrorCode = "mfa_totp_enroll_not_enabled"
 	ErrorCodeMFATOTPVerifyDisabled             ErrorCode = "mfa_totp_verify_not_enabled"
 	ErrorCodeVerifiedFactorExists              ErrorCode = "mfa_verified_factor_exists"
-	//#nosec G101 -- Not a secret value.
-	ErrorCodeInvalidLoginCredentials ErrorCode = "invalid_login_credentials"
+	ErrorCodeInvalidCredentials                ErrorCode = "invalid_credentials"
 )

--- a/internal/api/errorcodes.go
+++ b/internal/api/errorcodes.go
@@ -82,5 +82,6 @@ const (
 	ErrorCodeMFATOTPEnrollDisabled             ErrorCode = "mfa_totp_enroll_not_enabled"
 	ErrorCodeMFATOTPVerifyDisabled             ErrorCode = "mfa_totp_verify_not_enabled"
 	ErrorCodeVerifiedFactorExists              ErrorCode = "mfa_verified_factor_exists"
-	ErrorCodeInvalidLoginCredentials           ErrorCode = "invalid_login_credentials"
+	//#nosec G101 -- Not a secret value.
+	ErrorCodeInvalidLoginCredentials ErrorCode = "invalid_login_credentials"
 )

--- a/internal/api/errorcodes.go
+++ b/internal/api/errorcodes.go
@@ -82,4 +82,5 @@ const (
 	ErrorCodeMFATOTPEnrollDisabled             ErrorCode = "mfa_totp_enroll_not_enabled"
 	ErrorCodeMFATOTPVerifyDisabled             ErrorCode = "mfa_totp_verify_not_enabled"
 	ErrorCodeVerifiedFactorExists              ErrorCode = "mfa_verified_factor_exists"
+	ErrorCodeInvalidLoginCredentials           ErrorCode = "invalid_login_credentials"
 )

--- a/internal/api/errorcodes.go
+++ b/internal/api/errorcodes.go
@@ -81,7 +81,7 @@ const (
 	ErrorCodeMFAPhoneVerifyDisabled            ErrorCode = "mfa_phone_verify_not_enabled"
 	ErrorCodeMFATOTPEnrollDisabled             ErrorCode = "mfa_totp_enroll_not_enabled"
 	ErrorCodeMFATOTPVerifyDisabled             ErrorCode = "mfa_totp_verify_not_enabled"
-	ErrorCodeVerifiedFactorExists              ErrorCode = "mfa_verified_factor_exists"
+	ErrorCodeMFAVerifiedFactorExists           ErrorCode = "mfa_verified_factor_exists"
 	//#nosec G101 -- Not a secret value.
 	ErrorCodeInvalidCredentials ErrorCode = "invalid_credentials"
 )

--- a/internal/api/errorcodes.go
+++ b/internal/api/errorcodes.go
@@ -82,5 +82,6 @@ const (
 	ErrorCodeMFATOTPEnrollDisabled             ErrorCode = "mfa_totp_enroll_not_enabled"
 	ErrorCodeMFATOTPVerifyDisabled             ErrorCode = "mfa_totp_verify_not_enabled"
 	ErrorCodeVerifiedFactorExists              ErrorCode = "mfa_verified_factor_exists"
-	ErrorCodeInvalidCredentials                ErrorCode = "invalid_credentials"
+	//#nosec G101 -- Not a secret value.
+	ErrorCodeInvalidCredentials ErrorCode = "invalid_credentials"
 )

--- a/internal/api/mfa.go
+++ b/internal/api/mfa.go
@@ -103,7 +103,7 @@ func (a *API) enrollPhoneFactor(w http.ResponseWriter, r *http.Request, params *
 			if factor.Phone.String() == phone {
 				if factor.IsVerified() {
 					return unprocessableEntityError(
-						ErrorCodeVerifiedFactorExists,
+						ErrorCodeMFAVerifiedFactorExists,
 						"A verified phone factor already exists, unenroll the existing factor to continue",
 					)
 				} else if factor.IsUnverified() {

--- a/internal/api/token.go
+++ b/internal/api/token.go
@@ -146,7 +146,7 @@ func (a *API) ResourceOwnerPasswordGrant(ctx context.Context, w http.ResponseWri
 	}
 
 	if user.IsBanned() {
-		return forbiddenError(ErrorCodeUserBanned, "User is banned")
+		return badRequestError(ErrorCodeUserBanned, "User is banned")
 	}
 
 	isValidPassword, shouldReEncrypt, err := user.Authenticate(ctx, db, params.Password, config.Security.DBEncryption.DecryptionKeys, config.Security.DBEncryption.Encrypt, config.Security.DBEncryption.EncryptionKeyID)

--- a/internal/api/token.go
+++ b/internal/api/token.go
@@ -91,7 +91,7 @@ func (a *API) Token(w http.ResponseWriter, r *http.Request) error {
 	case "pkce":
 		return a.PKCE(ctx, w, r)
 	default:
-		return badRequestError(ErrorCodeInvalidLoginCredentials, "unsupported_grant_type")
+		return badRequestError(ErrorCodeInvalidCredentials, "unsupported_grant_type")
 	}
 }
 
@@ -131,18 +131,18 @@ func (a *API) ResourceOwnerPasswordGrant(ctx context.Context, w http.ResponseWri
 		params.Phone = formatPhoneNumber(params.Phone)
 		user, err = models.FindUserByPhoneAndAudience(db, params.Phone, aud)
 	} else {
-		return badRequestError(ErrorCodeInvalidLoginCredentials, "missing email or phone")
+		return badRequestError(ErrorCodeInvalidCredentials, "missing email or phone")
 	}
 
 	if err != nil {
 		if models.IsNotFoundError(err) {
-			return badRequestError(ErrorCodeInvalidLoginCredentials, InvalidLoginMessage)
+			return badRequestError(ErrorCodeInvalidCredentials, InvalidLoginMessage)
 		}
 		return internalServerError("Database error querying schema").WithInternalError(err)
 	}
 
 	if !user.HasPassword() {
-		return badRequestError(ErrorCodeInvalidLoginCredentials, InvalidLoginMessage)
+		return badRequestError(ErrorCodeInvalidCredentials, InvalidLoginMessage)
 	}
 
 	if user.IsBanned() {
@@ -199,17 +199,17 @@ func (a *API) ResourceOwnerPasswordGrant(ctx context.Context, w http.ResponseWri
 					return err
 				}
 			}
-			return badRequestError(ErrorCodeInvalidLoginCredentials, InvalidLoginMessage)
+			return badRequestError(ErrorCodeInvalidCredentials, InvalidLoginMessage)
 		}
 	}
 	if !isValidPassword {
-		return badRequestError(ErrorCodeInvalidLoginCredentials, InvalidLoginMessage)
+		return badRequestError(ErrorCodeInvalidCredentials, InvalidLoginMessage)
 	}
 
 	if params.Email != "" && !user.IsConfirmed() {
-		return badRequestError(ErrorCodeInvalidLoginCredentials, "Email not confirmed")
+		return badRequestError(ErrorCodeInvalidCredentials, "Email not confirmed")
 	} else if params.Phone != "" && !user.IsPhoneConfirmed() {
-		return badRequestError(ErrorCodeInvalidLoginCredentials, "Phone not confirmed")
+		return badRequestError(ErrorCodeInvalidCredentials, "Phone not confirmed")
 	}
 
 	var token *AccessTokenResponse

--- a/internal/api/token.go
+++ b/internal/api/token.go
@@ -91,7 +91,7 @@ func (a *API) Token(w http.ResponseWriter, r *http.Request) error {
 	case "pkce":
 		return a.PKCE(ctx, w, r)
 	default:
-		return oauthError("unsupported_grant_type", "")
+		return badRequestError(ErrorCodeInvalidLoginCredentials, "unsupported_grant_type")
 	}
 }
 
@@ -131,22 +131,22 @@ func (a *API) ResourceOwnerPasswordGrant(ctx context.Context, w http.ResponseWri
 		params.Phone = formatPhoneNumber(params.Phone)
 		user, err = models.FindUserByPhoneAndAudience(db, params.Phone, aud)
 	} else {
-		return oauthError("invalid_grant", InvalidLoginMessage)
+		return badRequestError(ErrorCodeInvalidLoginCredentials, "missing email or phone")
 	}
 
 	if err != nil {
 		if models.IsNotFoundError(err) {
-			return oauthError("invalid_grant", InvalidLoginMessage)
+			return badRequestError(ErrorCodeInvalidLoginCredentials, InvalidLoginMessage)
 		}
 		return internalServerError("Database error querying schema").WithInternalError(err)
 	}
 
 	if !user.HasPassword() {
-		return oauthError("invalid_grant", InvalidLoginMessage)
+		return badRequestError(ErrorCodeInvalidLoginCredentials, InvalidLoginMessage)
 	}
 
 	if user.IsBanned() {
-		return oauthError("invalid_grant", InvalidLoginMessage)
+		return forbiddenError(ErrorCodeUserBanned, "User is banned")
 	}
 
 	isValidPassword, shouldReEncrypt, err := user.Authenticate(ctx, db, params.Password, config.Security.DBEncryption.DecryptionKeys, config.Security.DBEncryption.Encrypt, config.Security.DBEncryption.EncryptionKeyID)
@@ -199,17 +199,17 @@ func (a *API) ResourceOwnerPasswordGrant(ctx context.Context, w http.ResponseWri
 					return err
 				}
 			}
-			return oauthError("invalid_grant", InvalidLoginMessage)
+			return badRequestError(ErrorCodeInvalidLoginCredentials, InvalidLoginMessage)
 		}
 	}
 	if !isValidPassword {
-		return oauthError("invalid_grant", InvalidLoginMessage)
+		return badRequestError(ErrorCodeInvalidLoginCredentials, InvalidLoginMessage)
 	}
 
 	if params.Email != "" && !user.IsConfirmed() {
-		return oauthError("invalid_grant", "Email not confirmed")
+		return badRequestError(ErrorCodeInvalidLoginCredentials, "Email not confirmed")
 	} else if params.Phone != "" && !user.IsPhoneConfirmed() {
-		return oauthError("invalid_grant", "Phone not confirmed")
+		return badRequestError(ErrorCodeInvalidLoginCredentials, "Phone not confirmed")
 	}
 
 	var token *AccessTokenResponse
@@ -292,7 +292,8 @@ func (a *API) PKCE(ctx context.Context, w http.ResponseWriter, r *http.Request) 
 		}
 		token, terr = a.issueRefreshToken(r, tx, user, authMethod, grantParams)
 		if terr != nil {
-			return oauthError("server_error", terr.Error())
+			// error type is already handled in issueRefreshToken
+			return terr
 		}
 		token.ProviderAccessToken = flowState.ProviderAccessToken
 		// Because not all providers give out a refresh token

--- a/internal/conf/configuration.go
+++ b/internal/conf/configuration.go
@@ -732,7 +732,7 @@ func (config *GlobalConfiguration) ApplyDefaults() error {
 		config.JWT.AdminGroupName = "admin"
 	}
 
-	if config.JWT.AdminRoles == nil || len(config.JWT.AdminRoles) == 0 {
+	if len(config.JWT.AdminRoles) == 0 {
 		config.JWT.AdminRoles = []string{"service_role", "supabase_admin"}
 	}
 
@@ -740,7 +740,7 @@ func (config *GlobalConfiguration) ApplyDefaults() error {
 		config.JWT.Exp = 3600
 	}
 
-	if config.JWT.Keys == nil || len(config.JWT.Keys) == 0 {
+	if len(config.JWT.Keys) == 0 {
 		// transform the secret into a JWK for consistency
 		privKey, err := jwk.FromRaw([]byte(config.JWT.Secret))
 		if err != nil {


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Add error codes to the password login flow, which fixes #1631 

## What is the current behavior?
* Most errors in the password login flow are returned as `oauthError`, which doesn't have support for an error code as the struct conforms to the [oauth error response](https://datatracker.ietf.org/doc/html/rfc6749#section-5.2) specified in the RFC

## What is the new behavior?
* Errors which were previously returned as an `oauthError` struct now return `badRequestError` instead with the following error code `invalid_login_credentials`
* In certain cases, we can return existing error codes like `ErrorCodeUserBanned`, `ErrorCodeEmailNotConfirmed`, `ErrorCodePhoneNotConfirmed` or `ErrorCodeValidationFailed`
* Some error messages are updated to provide more clarity on the underlying error

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
