### PR TITLE
fix: redirect invalid state errors to site url

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -274,7 +274,7 @@ func NewAPIWithVersion(globalConfig *conf.GlobalConfiguration, db *storage.Conne
 					tollbooth.NewLimiter(api.config.SAML.RateLimitAssertion/(60*5), &limiter.ExpirableOptions{
 						DefaultExpirationTTL: time.Hour,
 					}).SetBurst(30),
-				)).Post("/acs", api.SAMLACS)
+				)).Post("/acs", api.SamlAcs)
 			})
 		})
 

--- a/internal/api/external.go
+++ b/internal/api/external.go
@@ -138,7 +138,7 @@ func (a *API) ExternalProviderCallback(w http.ResponseWriter, r *http.Request) e
 	if err != nil {
 		return err
 	}
-	a.redirectErrors(a.internalExternalProviderCallback, w, r, u)
+	redirectErrors(a.internalExternalProviderCallback, w, r, u)
 	return nil
 }
 
@@ -573,7 +573,7 @@ func (a *API) Provider(ctx context.Context, name string, scopes string) (provide
 	}
 }
 
-func (a *API) redirectErrors(handler apiHandler, w http.ResponseWriter, r *http.Request, u *url.URL) {
+func redirectErrors(handler apiHandler, w http.ResponseWriter, r *http.Request, u *url.URL) {
 	ctx := r.Context()
 	log := observability.GetLogEntry(r).Entry
 	errorID := utilities.GetRequestID(ctx)

--- a/internal/api/external.go
+++ b/internal/api/external.go
@@ -478,7 +478,17 @@ func (a *API) processInvite(r *http.Request, tx *storage.Connection, userData *p
 	return user, nil
 }
 
-func (a *API) loadExternalState(ctx context.Context, state string) (context.Context, error) {
+func (a *API) loadExternalState(ctx context.Context, r *http.Request) (context.Context, error) {
+	var state string
+	switch r.Method {
+	case http.MethodPost:
+		state = r.FormValue("state")
+	default:
+		state = r.URL.Query().Get("state")
+	}
+	if state == "" {
+		return ctx, badRequestError(ErrorCodeBadOAuthCallback, "OAuth state parameter missing")
+	}
 	config := a.config
 	claims := ExternalProviderClaims{}
 	p := jwt.NewParser(jwt.WithValidMethods([]string{jwt.SigningMethodHS256.Name}))
@@ -486,10 +496,10 @@ func (a *API) loadExternalState(ctx context.Context, state string) (context.Cont
 		return []byte(config.JWT.Secret), nil
 	})
 	if err != nil {
-		return nil, badRequestError(ErrorCodeBadOAuthState, "OAuth callback with invalid state").WithInternalError(err)
+		return ctx, badRequestError(ErrorCodeBadOAuthState, "OAuth callback with invalid state").WithInternalError(err)
 	}
 	if claims.Provider == "" {
-		return nil, badRequestError(ErrorCodeBadOAuthState, "OAuth callback with invalid state (missing provider)")
+		return ctx, badRequestError(ErrorCodeBadOAuthState, "OAuth callback with invalid state (missing provider)")
 	}
 	if claims.InviteToken != "" {
 		ctx = withInviteToken(ctx, claims.InviteToken)

--- a/internal/api/external_oauth.go
+++ b/internal/api/external_oauth.go
@@ -10,6 +10,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/supabase/auth/internal/api/provider"
 	"github.com/supabase/auth/internal/observability"
+	"github.com/supabase/auth/internal/utilities"
 )
 
 // OAuthProviderData contains the userData and token returned by the oauth provider
@@ -23,17 +24,6 @@ type OAuthProviderData struct {
 // loadFlowState parses the `state` query parameter as a JWS payload,
 // extracting the provider requested
 func (a *API) loadFlowState(w http.ResponseWriter, r *http.Request) (context.Context, error) {
-	var state string
-	if r.Method == http.MethodPost {
-		state = r.FormValue("state")
-	} else {
-		state = r.URL.Query().Get("state")
-	}
-
-	if state == "" {
-		return nil, badRequestError(ErrorCodeBadOAuthCallback, "OAuth state parameter missing")
-	}
-
 	ctx := r.Context()
 	oauthToken := r.URL.Query().Get("oauth_token")
 	if oauthToken != "" {
@@ -43,7 +33,21 @@ func (a *API) loadFlowState(w http.ResponseWriter, r *http.Request) (context.Con
 	if oauthVerifier != "" {
 		ctx = withOAuthVerifier(ctx, oauthVerifier)
 	}
-	return a.loadExternalState(ctx, state)
+
+	var err error
+	ctx, err = a.loadExternalState(ctx, r)
+	if err != nil {
+		u, uerr := url.ParseRequestURI(a.config.SiteURL)
+		if uerr != nil {
+			return ctx, internalServerError("site url is improperly formatted").WithInternalError(uerr)
+		}
+
+		q := getErrorQueryString(err, utilities.GetRequestID(ctx), observability.GetLogEntry(r).Entry, u.Query())
+		u.RawQuery = q.Encode()
+
+		http.Redirect(w, r, u.String(), http.StatusFound)
+	}
+	return ctx, err
 }
 
 func (a *API) oAuthCallback(ctx context.Context, r *http.Request, providerType string) (*OAuthProviderData, error) {

--- a/internal/api/external_oauth.go
+++ b/internal/api/external_oauth.go
@@ -45,7 +45,7 @@ func (a *API) loadFlowState(w http.ResponseWriter, r *http.Request) (context.Con
 		q := getErrorQueryString(err, utilities.GetRequestID(ctx), observability.GetLogEntry(r).Entry, u.Query())
 		u.RawQuery = q.Encode()
 
-		http.Redirect(w, r, u.String(), http.StatusFound)
+		http.Redirect(w, r, u.String(), http.StatusSeeOther)
 	}
 	return ctx, err
 }

--- a/internal/api/external_test.go
+++ b/internal/api/external_test.go
@@ -235,7 +235,7 @@ func (ts *ExternalTestSuite) TestRedirectErrorsShouldPreserveParams() {
 		parsedURL, err := url.Parse(c.RedirectURL)
 		require.Equal(ts.T(), err, nil)
 
-		ts.API.redirectErrors(ts.API.internalExternalProviderCallback, w, req, parsedURL)
+		redirectErrors(ts.API.internalExternalProviderCallback, w, req, parsedURL)
 
 		parsedParams, err := url.ParseQuery(parsedURL.RawQuery)
 		require.Equal(ts.T(), err, nil)

--- a/internal/api/samlacs.go
+++ b/internal/api/samlacs.go
@@ -43,8 +43,8 @@ func IsSAMLMetadataStale(idpMetadata *saml.EntityDescriptor, samlProvider models
 	return hasValidityExpired || hasCacheDurationExceeded || needsForceUpdate
 }
 
-// SAMLACS implements the main Assertion Consumer Service endpoint behavior.
-func (a *API) SAMLACS(w http.ResponseWriter, r *http.Request) error {
+// SamlAcs implements the main Assertion Consumer Service endpoint behavior.
+func (a *API) SamlAcs(w http.ResponseWriter, r *http.Request) error {
 	ctx := r.Context()
 
 	db := a.db.WithContext(ctx)
@@ -61,7 +61,6 @@ func (a *API) SAMLACS(w http.ResponseWriter, r *http.Request) error {
 	var requestIds []string
 
 	var flowState *models.FlowState
-	flowState = nil
 	if relayStateUUID != uuid.Nil {
 		// relay state is a valid UUID, therefore this is likely a SP initiated flow
 


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Currently, invalid state errors on the oauth callback endpoint are returned as json responses - this makes error handling impossible for the client since the callback is invoked by the oauth provider and leaves users with an unfriendly error message.
* This PR aims to address this by redirecting errors to the Site URL. We can't redirect errors to the redirect url specified in the `state` because the `state` might not be verified yet, which may lead to malicious redirects.
* This changes the response for these type of errors to redirect to the site URL instead of failing at the `/callback` endpoint.

