### PR TITLE
updated regex for provider name

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -282,7 +282,7 @@ paths:
           required: true
           schema:
             type: string
-            pattern: "[^a-zA-Z0-9]+"
+            pattern: "^[a-zA-Z0-9]+$"
         - name: scopes
           in: query
           required: true


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

A valid provider name gets invalidated.

## What is the new behavior?

A possible valid provider name gets verified by regex correctly.

## Additional context

`[^a]+` -> This regex will match any char except character `a`
`^a$` -> This regex will match string have single char `a`
`^[a-zA-Z0-9]+$` -> This regex will match any alphanumeric string. `^` denotes start of string and `$` denotes end of string.

This pull request will address https://github.com/supabase/auth/issues/1719