### PR TITLE
fix: use signing jwk to sign oauth state

### DIFF
--- a/internal/api/jwks.go
+++ b/internal/api/jwks.go
@@ -3,8 +3,10 @@ package api
 import (
 	"net/http"
 
+	jwt "github.com/golang-jwt/jwt/v5"
 	"github.com/lestrrat-go/jwx/v2/jwa"
 	jwk "github.com/lestrrat-go/jwx/v2/jwk"
+	"github.com/supabase/auth/internal/conf"
 )
 
 type JwksResponse struct {
@@ -27,4 +29,33 @@ func (a *API) Jwks(w http.ResponseWriter, r *http.Request) error {
 
 	w.Header().Set("Cache-Control", "public, max-age=600")
 	return sendJSON(w, http.StatusOK, resp)
+}
+
+func signJwt(config *conf.JWTConfiguration, claims jwt.Claims) (string, error) {
+	signingJwk, err := conf.GetSigningJwk(config)
+	if err != nil {
+		return "", err
+	}
+	signingMethod := conf.GetSigningAlg(signingJwk)
+	token := jwt.NewWithClaims(signingMethod, claims)
+	if token.Header == nil {
+		token.Header = make(map[string]interface{})
+	}
+
+	if _, ok := token.Header["kid"]; !ok {
+		if kid := signingJwk.KeyID(); kid != "" {
+			token.Header["kid"] = kid
+		}
+	}
+	// this serializes the aud claim to a string
+	jwt.MarshalSingleStringAsArray = false
+	signingKey, err := conf.GetSigningKey(signingJwk)
+	if err != nil {
+		return "", err
+	}
+	signed, err := token.SignedString(signingKey)
+	if err != nil {
+		return "", err
+	}
+	return signed, nil
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?
* OAuth state is now signed with the same JWK that is used to sign the access tokens 

## What is the current behavior?
* currently, it's weird for the `GOTRUE_JWT_SECRET` to be set (other than it being a fallback option) just for the sake of signing the oauth state

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
