### PR TITLE
fix: return oauth identity when user is created

### DIFF
--- a/internal/api/external.go
+++ b/internal/api/external.go
@@ -338,7 +338,7 @@ func (a *API) createAccountFromExternalIdentity(tx *storage.Connection, r *http.
 		if identity, terr = a.createNewIdentity(tx, user, providerType, identityData); terr != nil {
 			return nil, terr
 		}
-
+		user.Identities = append(user.Identities, *identity)
 	case models.AccountExists:
 		user = decision.User
 		identity = decision.Identities[0]


### PR DESCRIPTION
## What kind of change does this PR introduce?
* When the oauth user is first created, the identity needs to be returned in the user object as well. 

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
