### PR TITLE
fix: allow anonymous user to update password

### DIFF
--- a/internal/api/user.go
+++ b/internal/api/user.go
@@ -102,11 +102,10 @@ func (a *API) UserUpdate(w http.ResponseWriter, r *http.Request) error {
 	}
 
 	if user.IsAnonymous {
-		updatingForbiddenFields := false
-		updatingForbiddenFields = updatingForbiddenFields || (params.Password != nil && *params.Password != "")
-		if updatingForbiddenFields {
-			// CHECK
-			return unprocessableEntityError(ErrorCodeUnknown, "Updating password of an anonymous user is not possible")
+		if params.Password != nil && *params.Password != "" {
+			if params.Email == "" && params.Phone == "" {
+				return unprocessableEntityError(ErrorCodeValidationFailed, "Updating password of an anonymous user without an email or phone is not allowed")
+			}
 		}
 	}
 


### PR DESCRIPTION
## What kind of change does this PR introduce?
* fixes https://github.com/supabase/auth/issues/1671
* allows an anonymous user to update their password when linking an email or phone identity (through update user)

## What is the current behavior?
* an anonymous cannot update their password unless they confirm their email first - this is not ideal since it requires the anonymous user to verify the email first before adding a password to their account

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context
* An anonymous user remains anonymous until they have confirmed the email / phone added

Add any other context or screenshots.
