### PR TITLE
fix: hide hook name

### DIFF
--- a/internal/conf/configuration.go
+++ b/internal/conf/configuration.go
@@ -552,9 +552,10 @@ func (h *HTTPHookSecrets) Decode(value string) error {
 }
 
 type ExtensibilityPointConfiguration struct {
-	URI      string `json:"uri"`
-	Enabled  bool   `json:"enabled"`
-	HookName string `json:"hook_name"`
+	URI     string `json:"uri"`
+	Enabled bool   `json:"enabled"`
+	// For internal use together with Postgres Hook. Not publicly exposed.
+	HookName string `json:"-"`
 	// We use | as a separator for keys and : as a separator for keys within a keypair. For instance: v1,whsec_test|v1a,whpk_myother:v1a,whsk_testkey|v1,whsec_secret3
 	HTTPHookSecrets HTTPHookSecrets `json:"secrets" envconfig:"secrets"`
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

The HookName is generated from the Postgres URI and used internally to invoke the hook.

Context: https://github.com/supabase/auth/issues/1734#issuecomment-2308342232

Since it's for internal use, we don't expose it similar to what we do with [encryption key](https://github.com/supabase/auth/compare/j0/hide_hook_name?expand=1#diff-4c28cb40881781a1067b3b3681c43f805dab629f31f3c7614b0f781ffa096505L457) and other similar fields.

This is fine since we don't marshal the extensibility point.

## Testing setup

We don't marshal the struct so it should be fine but for additional sanity check ran this locally:
```
GOTRUE_HOOK_CUSTOM_ACCESS_TOKEN_ENABLED="true"
GOTRUE_HOOK_CUSTOM_ACCESS_TOKEN_URI="pg-functions://postgres/public/custom_access_token_hook"
```

```
create or replace function public.custom_access_token_hook(event jsonb)
returns jsonb
language plpgsql
as $$
  declare
    claims jsonb;
  begin
   

    -- Proceed only if the user is an admin
      claims := event->'claims';

      -- Check if 'user_metadata' exists in claims
      if jsonb_typeof(claims->'user_metadata') is null then
        -- If 'user_metadata' does not exist, create an empty object
        claims := jsonb_set(claims, '{user_metadata}', '{}');
      end if;

      -- Set a claim of 'admin'
      claims := jsonb_set(claims, '{user_metadata, admin}', 'true');

      -- Update the 'claims' object in the original event
      event := jsonb_set(event, '{claims}', claims);

    -- Return the modified or original event
    return event;
  end;
$$;

grant execute
  on function public.custom_access_token_hook
  to supabase_auth_admin;

revoke execute
  on function public.custom_access_token_hook
  from authenticated, anon, public;

grant usage on schema public to supabase_auth_admin;
```

