### PR TITLE
fix: apply shared limiters before email / sms is sent

### DIFF
--- a/internal/api/context.go
+++ b/internal/api/context.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/url"
 
+	"github.com/didip/tollbooth/v5/limiter"
 	jwt "github.com/golang-jwt/jwt/v5"
 	"github.com/supabase/auth/internal/models"
 )
@@ -31,6 +32,7 @@ const (
 	ssoProviderKey          = contextKey("sso_provider")
 	externalHostKey         = contextKey("external_host")
 	flowStateKey            = contextKey("flow_state_id")
+	sharedLimiterKey        = contextKey("shared_limiter")
 )
 
 // withToken adds the JWT token to the context.
@@ -240,4 +242,21 @@ func getExternalHost(ctx context.Context) *url.URL {
 		return nil
 	}
 	return obj.(*url.URL)
+}
+
+type SharedLimiter struct {
+	EmailLimiter *limiter.Limiter
+	PhoneLimiter *limiter.Limiter
+}
+
+func withLimiter(ctx context.Context, limiter *SharedLimiter) context.Context {
+	return context.WithValue(ctx, sharedLimiterKey, limiter)
+}
+
+func getLimiter(ctx context.Context) *SharedLimiter {
+	obj := ctx.Value(sharedLimiterKey)
+	if obj == nil {
+		return nil
+	}
+	return obj.(*SharedLimiter)
 }

--- a/internal/api/external.go
+++ b/internal/api/external.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -383,10 +382,7 @@ func (a *API) createAccountFromExternalIdentity(tx *storage.Connection, r *http.
 			emailConfirmationSent := false
 			if decision.CandidateEmail.Email != "" {
 				if terr = a.sendConfirmation(r, tx, user, models.ImplicitFlow); terr != nil {
-					if errors.Is(terr, MaxFrequencyLimitError) {
-						return nil, tooManyRequestsError(ErrorCodeOverEmailSendRateLimit, "For security purposes, you can only request this once every minute")
-					}
-					return nil, internalServerError("Error sending confirmation mail").WithInternalError(terr)
+					return nil, terr
 				}
 				emailConfirmationSent = true
 			}

--- a/internal/api/identity.go
+++ b/internal/api/identity.go
@@ -7,7 +7,6 @@ import (
 	"github.com/fatih/structs"
 	"github.com/go-chi/chi/v5"
 	"github.com/gofrs/uuid"
-	"github.com/pkg/errors"
 	"github.com/supabase/auth/internal/api/provider"
 	"github.com/supabase/auth/internal/models"
 	"github.com/supabase/auth/internal/storage"
@@ -133,9 +132,7 @@ func (a *API) linkIdentityToUser(r *http.Request, ctx context.Context, tx *stora
 		}
 		if !userData.Metadata.EmailVerified {
 			if terr := a.sendConfirmation(r, tx, targetUser, models.ImplicitFlow); terr != nil {
-				if errors.Is(terr, MaxFrequencyLimitError) {
-					return nil, tooManyRequestsError(ErrorCodeOverSMSSendRateLimit, "For security purposes, you can only request this once every minute")
-				}
+				return nil, terr
 			}
 			return nil, storage.NewCommitWithError(unprocessableEntityError(ErrorCodeEmailNotConfirmed, "Unverified email with %v. A confirmation email has been sent to your %v email", providerType, providerType))
 		}

--- a/internal/api/invite.go
+++ b/internal/api/invite.go
@@ -80,7 +80,7 @@ func (a *API) Invite(w http.ResponseWriter, r *http.Request) error {
 		}
 
 		if err := a.sendInvite(r, tx, user); err != nil {
-			return internalServerError("Error inviting user").WithInternalError(err)
+			return err
 		}
 		return nil
 	})

--- a/internal/api/magic_link.go
+++ b/internal/api/magic_link.go
@@ -3,7 +3,6 @@ package api
 import (
 	"bytes"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -141,10 +140,7 @@ func (a *API) MagicLink(w http.ResponseWriter, r *http.Request) error {
 		return a.sendMagicLink(r, tx, user, flowType)
 	})
 	if err != nil {
-		if errors.Is(err, MaxFrequencyLimitError) {
-			return tooManyRequestsError(ErrorCodeOverEmailSendRateLimit, generateFrequencyLimitErrorMessage(user.RecoverySentAt, config.SMTP.MaxFrequency))
-		}
-		return internalServerError("Error sending magic link").WithInternalError(err)
+		return err
 	}
 
 	return sendJSON(w, http.StatusOK, make(map[string]string))

--- a/internal/api/phone.go
+++ b/internal/api/phone.go
@@ -90,11 +90,10 @@ func (a *API) sendPhoneConfirmation(r *http.Request, tx *storage.Connection, use
 	if otp == "" {
 		// apply rate limiting before the sms is sent out
 		limiter := getLimiter(ctx)
-		if limiter == nil {
-			return "", internalServerError("phone limiter not found in context")
-		}
-		if err := tollbooth.LimitByKeys(limiter.PhoneLimiter, []string{"phone_functions"}); err != nil {
-			return "", tooManyRequestsError(ErrorCodeOverSMSSendRateLimit, "SMS rate limit exceeded")
+		if limiter != nil {
+			if err := tollbooth.LimitByKeys(limiter.PhoneLimiter, []string{"phone_functions"}); err != nil {
+				return "", tooManyRequestsError(ErrorCodeOverSMSSendRateLimit, "SMS rate limit exceeded")
+			}
 		}
 		otp, err = crypto.GenerateOtp(config.Sms.OtpLength)
 		if err != nil {

--- a/internal/api/reauthenticate.go
+++ b/internal/api/reauthenticate.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"errors"
 	"net/http"
 
 	"github.com/supabase/auth/internal/api/sms_provider"
@@ -53,14 +52,6 @@ func (a *API) Reauthenticate(w http.ResponseWriter, r *http.Request) error {
 		return nil
 	})
 	if err != nil {
-		if errors.Is(err, MaxFrequencyLimitError) {
-			reason := ErrorCodeOverEmailSendRateLimit
-			if phone != "" {
-				reason = ErrorCodeOverSMSSendRateLimit
-			}
-
-			return tooManyRequestsError(reason, "For security purposes, you can only request this once every 60 seconds")
-		}
 		return err
 	}
 

--- a/internal/api/recover.go
+++ b/internal/api/recover.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"errors"
 	"net/http"
 
 	"github.com/supabase/auth/internal/models"
@@ -67,10 +66,7 @@ func (a *API) Recover(w http.ResponseWriter, r *http.Request) error {
 		return a.sendPasswordRecovery(r, tx, user, flowType)
 	})
 	if err != nil {
-		if errors.Is(err, MaxFrequencyLimitError) {
-			return tooManyRequestsError(ErrorCodeOverEmailSendRateLimit, "For security purposes, you can only request this once every 60 seconds")
-		}
-		return internalServerError("Unable to process request").WithInternalError(err)
+		return err
 	}
 
 	return sendJSON(w, http.StatusOK, map[string]string{})

--- a/internal/api/resend.go
+++ b/internal/api/resend.go
@@ -1,9 +1,7 @@
 package api
 
 import (
-	"errors"
 	"net/http"
-	"time"
 
 	"github.com/supabase/auth/internal/api/sms_provider"
 	"github.com/supabase/auth/internal/conf"
@@ -144,16 +142,7 @@ func (a *API) Resend(w http.ResponseWriter, r *http.Request) error {
 		return nil
 	})
 	if err != nil {
-		if errors.Is(err, MaxFrequencyLimitError) {
-			reason := ErrorCodeOverEmailSendRateLimit
-			if params.Type == smsVerification || params.Type == phoneChangeVerification {
-				reason = ErrorCodeOverSMSSendRateLimit
-			}
-
-			until := time.Until(user.ConfirmationSentAt.Add(config.SMTP.MaxFrequency)) / time.Second
-			return tooManyRequestsError(reason, "For security purposes, you can only request this once every %d seconds.", until)
-		}
-		return internalServerError("Unable to process request").WithInternalError(err)
+		return err
 	}
 
 	ret := map[string]any{}

--- a/internal/api/signup.go
+++ b/internal/api/signup.go
@@ -274,14 +274,7 @@ func (a *API) Signup(w http.ResponseWriter, r *http.Request) error {
 	})
 
 	if err != nil {
-		reason := ErrorCodeOverEmailSendRateLimit
-		if params.Provider == "phone" {
-			reason = ErrorCodeOverSMSSendRateLimit
-		}
-
-		if errors.Is(err, MaxFrequencyLimitError) {
-			return tooManyRequestsError(reason, "For security purposes, you can only request this once every minute")
-		} else if errors.Is(err, UserExistsError) {
+		if errors.Is(err, UserExistsError) {
 			err = db.Transaction(func(tx *storage.Connection) error {
 				if terr := models.NewAuditLogEntry(r, tx, user, models.UserRepeatedSignUpAction, "", map[string]interface{}{
 					"provider": params.Provider,

--- a/internal/api/signup.go
+++ b/internal/api/signup.go
@@ -244,10 +244,7 @@ func (a *API) Signup(w http.ResponseWriter, r *http.Request) error {
 					}
 				}
 				if terr = a.sendConfirmation(r, tx, user, flowType); terr != nil {
-					if errors.Is(terr, MaxFrequencyLimitError) {
-						return tooManyRequestsError(ErrorCodeOverEmailSendRateLimit, generateFrequencyLimitErrorMessage(user.ConfirmationSentAt, config.SMTP.MaxFrequency))
-					}
-					return internalServerError("Error sending confirmation mail").WithInternalError(terr)
+					return terr
 				}
 			}
 		} else if params.Provider == "phone" && !user.IsPhoneConfirmed() {

--- a/internal/api/user.go
+++ b/internal/api/user.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"context"
-	"errors"
 	"net/http"
 	"time"
 
@@ -226,10 +225,7 @@ func (a *API) UserUpdate(w http.ResponseWriter, r *http.Request) error {
 
 				}
 				if terr = a.sendEmailChange(r, tx, user, params.Email, flowType); terr != nil {
-					if errors.Is(terr, MaxFrequencyLimitError) {
-						return tooManyRequestsError(ErrorCodeOverEmailSendRateLimit, generateFrequencyLimitErrorMessage(user.EmailChangeSentAt, config.SMTP.MaxFrequency))
-					}
-					return internalServerError("Error sending change email").WithInternalError(terr)
+					return terr
 				}
 			}
 		}

--- a/internal/mailer/mailer.go
+++ b/internal/mailer/mailer.go
@@ -15,7 +15,6 @@ import (
 
 // Mailer defines the interface a mailer must implement.
 type Mailer interface {
-	Send(user *models.User, subject, body string, data map[string]interface{}) error
 	InviteMail(r *http.Request, user *models.User, otp, referrerURL string, externalURL *url.URL) error
 	ConfirmationMail(r *http.Request, user *models.User, otp, referrerURL string, externalURL *url.URL) error
 	RecoveryMail(r *http.Request, user *models.User, otp, referrerURL string, externalURL *url.URL) error


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Fixes https://github.com/supabase/auth/issues/1236
* Reduces the number of false positives arising from validation errors when counting rate limits for emails / sms sent
* This change applies the shared rate limiter for email and phone functions before the actual email / sms is being sent out rather than at the start of the request
* The `limitEmailOrPhoneSentHandler()` now initialises the rate limiters and sets it in the request context so we can subsequently retrieve it right before the email / sms is sent

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
