### PR TITLE
feat: add support for saml encrypted assertions

### DIFF
--- a/internal/api/saml.go
+++ b/internal/api/saml.go
@@ -80,16 +80,14 @@ func (a *API) SAMLMetadata(w http.ResponseWriter, r *http.Request) error {
 		}
 	}
 
-	// don't advertize the encryption keys as it makes it much difficult to debug
-	// requests / responses, and does not increase security since assertions are
-	// not "private" and not necessary to be hidden from the browser
 	for i := range metadata.SPSSODescriptors {
 		spd := &metadata.SPSSODescriptors[i]
 
 		var keyDescriptors []saml.KeyDescriptor
 
 		for _, kd := range spd.KeyDescriptors {
-			if kd.Use == "signing" {
+			// only advertize key as usable for encryption if allowed
+			if kd.Use == "signing" || (a.config.SAML.AllowEncryptedAssertions && kd.Use == "encryption") {
 				keyDescriptors = append(keyDescriptors, kd)
 			}
 		}

--- a/internal/conf/saml.go
+++ b/internal/conf/saml.go
@@ -17,6 +17,7 @@ import (
 type SAMLConfiguration struct {
 	Enabled                  bool          `json:"enabled"`
 	PrivateKey               string        `json:"-" split_words:"true"`
+	AllowEncryptedAssertions bool          `json:"allow_encrypted_assertions" split_words:"true"`
 	RelayStateValidityPeriod time.Duration `json:"relay_state_validity_period" split_words:"true"`
 
 	RSAPrivateKey *rsa.PrivateKey   `json:"-"`
@@ -109,6 +110,10 @@ func (c *SAMLConfiguration) PopulateFields(externalURL string) error {
 		Subject: pkix.Name{
 			CommonName: "SAML 2.0 Certificate for " + host,
 		},
+	}
+
+	if c.AllowEncryptedAssertions {
+		certTemplate.KeyUsage = certTemplate.KeyUsage | x509.KeyUsageDataEncipherment
 	}
 
 	certDer, err := x509.CreateCertificate(nil, certTemplate, certTemplate, c.RSAPublicKey, c.RSAPrivateKey)


### PR DESCRIPTION
By setting the `GOTRUE_SAML_ALLOW_ENCRYPTED_ASSERTIONS` to `true` the SAML private key will be advertised as usable with encryption too.

Encrypted assertions are fairly rare these days because:

- They make it very hard to debug what's going on.
- HTTPS is the default protocol on the web for over 10 years, including in intranets.

**Why not use a separate key?**

The underlying library [does not support it](https://pkg.go.dev/github.com/crewjam/saml@v0.4.14/samlsp#Options) and there are no significant cryptological issues using the same RSA key for signatures and encryption, especially in a limited setting like this.
