### PR TITLE
feat: add option to disable magic links

### DIFF
--- a/internal/api/magic_link.go
+++ b/internal/api/magic_link.go
@@ -46,6 +46,10 @@ func (a *API) MagicLink(w http.ResponseWriter, r *http.Request) error {
 		return unprocessableEntityError(ErrorCodeEmailProviderDisabled, "Email logins are disabled")
 	}
 
+	if !config.External.Email.MagicLinkEnabled {
+		return unprocessableEntityError(ErrorCodeEmailProviderDisabled, "Login with magic link is disabled")
+	}
+
 	params := &MagicLinkParams{}
 	jsonDecoder := json.NewDecoder(r.Body)
 	err := jsonDecoder.Decode(params)

--- a/internal/conf/configuration.go
+++ b/internal/conf/configuration.go
@@ -71,6 +71,8 @@ type AnonymousProviderConfiguration struct {
 
 type EmailProviderConfiguration struct {
 	Enabled bool `json:"enabled" default:"true"`
+
+	MagicLinkEnabled bool `json:"magic_link_enabled" default:"true" split_words:"true"`
 }
 
 // DBConfiguration holds all the database related configuration.


### PR DESCRIPTION
Adds an option to disable magic links, as they are more prone to email sending abuse than other email authentication methods.