### PR TITLE
feat: add authorized email address support

### DIFF
--- a/internal/api/admin.go
+++ b/internal/api/admin.go
@@ -150,7 +150,7 @@ func (a *API) adminUserUpdate(w http.ResponseWriter, r *http.Request) error {
 	}
 
 	if params.Email != "" {
-		params.Email, err = validateEmail(params.Email)
+		params.Email, err = a.validateEmail(params.Email)
 		if err != nil {
 			return err
 		}
@@ -343,7 +343,7 @@ func (a *API) adminUserCreate(w http.ResponseWriter, r *http.Request) error {
 
 	var providers []string
 	if params.Email != "" {
-		params.Email, err = validateEmail(params.Email)
+		params.Email, err = a.validateEmail(params.Email)
 		if err != nil {
 			return err
 		}

--- a/internal/api/errorcodes.go
+++ b/internal/api/errorcodes.go
@@ -83,5 +83,6 @@ const (
 	ErrorCodeMFATOTPVerifyDisabled             ErrorCode = "mfa_totp_verify_not_enabled"
 	ErrorCodeMFAVerifiedFactorExists           ErrorCode = "mfa_verified_factor_exists"
 	//#nosec G101 -- Not a secret value.
-	ErrorCodeInvalidCredentials ErrorCode = "invalid_credentials"
+	ErrorCodeInvalidCredentials        ErrorCode = "invalid_credentials"
+	ErrorCodeEmailAddressNotAuthorized ErrorCode = "email_address_not_authorized"
 )

--- a/internal/api/invite.go
+++ b/internal/api/invite.go
@@ -26,7 +26,7 @@ func (a *API) Invite(w http.ResponseWriter, r *http.Request) error {
 	}
 
 	var err error
-	params.Email, err = validateEmail(params.Email)
+	params.Email, err = a.validateEmail(params.Email)
 	if err != nil {
 		return err
 	}

--- a/internal/api/magic_link.go
+++ b/internal/api/magic_link.go
@@ -21,12 +21,12 @@ type MagicLinkParams struct {
 	CodeChallenge       string                 `json:"code_challenge"`
 }
 
-func (p *MagicLinkParams) Validate() error {
+func (p *MagicLinkParams) Validate(a *API) error {
 	if p.Email == "" {
 		return unprocessableEntityError(ErrorCodeValidationFailed, "Password recovery requires an email")
 	}
 	var err error
-	p.Email, err = validateEmail(p.Email)
+	p.Email, err = a.validateEmail(p.Email)
 	if err != nil {
 		return err
 	}
@@ -57,7 +57,7 @@ func (a *API) MagicLink(w http.ResponseWriter, r *http.Request) error {
 		return badRequestError(ErrorCodeBadJSON, "Could not read verification params: %v", err).WithInternalError(err)
 	}
 
-	if err := params.Validate(); err != nil {
+	if err := params.Validate(a); err != nil {
 		return err
 	}
 

--- a/internal/api/mail_test.go
+++ b/internal/api/mail_test.go
@@ -48,6 +48,41 @@ func (ts *MailTestSuite) SetupTest() {
 	require.NoError(ts.T(), ts.API.db.Create(u), "Error saving new user")
 }
 
+func (ts *MailTestSuite) TestValidateEmailAuthorizedAddresses() {
+	ts.Config.External.Email.AuthorizedAddresses = []string{"someone-a@example.com", "someone-b@example.com"}
+	defer func() {
+		ts.Config.External.Email.AuthorizedAddresses = nil
+	}()
+
+	positiveExamples := []string{
+		"someone-a@example.com",
+		"someone-b@example.com",
+		"someone-a+test-1@example.com",
+		"someone-b+test-2@example.com",
+		"someone-A@example.com",
+		"someone-B@example.com",
+		"someone-a@Example.com",
+		"someone-b@Example.com",
+	}
+
+	negativeExamples := []string{
+		"someone@example.com",
+		"s.omeone@example.com",
+		"someone-a+@example.com",
+		"someone+a@example.com",
+	}
+
+	for _, example := range positiveExamples {
+		_, err := ts.API.validateEmail(example)
+		require.NoError(ts.T(), err)
+	}
+
+	for _, example := range negativeExamples {
+		_, err := ts.API.validateEmail(example)
+		require.Error(ts.T(), err)
+	}
+}
+
 func (ts *MailTestSuite) TestGenerateLink() {
 	// create admin jwt
 	claims := &AccessTokenClaims{

--- a/internal/api/otp.go
+++ b/internal/api/otp.go
@@ -216,7 +216,7 @@ func (a *API) shouldCreateUser(r *http.Request, params *OtpParams) (bool, error)
 		aud := a.requestAud(ctx, r)
 		var err error
 		if params.Email != "" {
-			params.Email, err = validateEmail(params.Email)
+			params.Email, err = a.validateEmail(params.Email)
 			if err != nil {
 				return false, err
 			}

--- a/internal/api/recover.go
+++ b/internal/api/recover.go
@@ -14,12 +14,12 @@ type RecoverParams struct {
 	CodeChallengeMethod string `json:"code_challenge_method"`
 }
 
-func (p *RecoverParams) Validate() error {
+func (p *RecoverParams) Validate(a *API) error {
 	if p.Email == "" {
 		return badRequestError(ErrorCodeValidationFailed, "Password recovery requires an email")
 	}
 	var err error
-	if p.Email, err = validateEmail(p.Email); err != nil {
+	if p.Email, err = a.validateEmail(p.Email); err != nil {
 		return err
 	}
 	if err := validatePKCEParams(p.CodeChallengeMethod, p.CodeChallenge); err != nil {
@@ -38,7 +38,7 @@ func (a *API) Recover(w http.ResponseWriter, r *http.Request) error {
 	}
 
 	flowType := getFlowFromChallenge(params.CodeChallenge)
-	if err := params.Validate(); err != nil {
+	if err := params.Validate(a); err != nil {
 		return err
 	}
 

--- a/internal/api/signup.go
+++ b/internal/api/signup.go
@@ -141,7 +141,7 @@ func (a *API) Signup(w http.ResponseWriter, r *http.Request) error {
 		if !config.External.Email.Enabled {
 			return badRequestError(ErrorCodeEmailProviderDisabled, "Email signups are disabled")
 		}
-		params.Email, err = validateEmail(params.Email)
+		params.Email, err = a.validateEmail(params.Email)
 		if err != nil {
 			return err
 		}

--- a/internal/api/user.go
+++ b/internal/api/user.go
@@ -30,7 +30,7 @@ func (a *API) validateUserUpdateParams(ctx context.Context, p *UserUpdateParams)
 
 	var err error
 	if p.Email != "" {
-		p.Email, err = validateEmail(p.Email)
+		p.Email, err = a.validateEmail(p.Email)
 		if err != nil {
 			return err
 		}

--- a/internal/api/verify_test.go
+++ b/internal/api/verify_test.go
@@ -1248,7 +1248,7 @@ func (ts *VerifyTestSuite) TestVerifyValidateParams() {
 	for _, c := range cases {
 		ts.Run(c.desc, func() {
 			req := httptest.NewRequest(c.method, "http://localhost", nil)
-			err := c.params.Validate(req)
+			err := c.params.Validate(req, ts.API)
 			require.Equal(ts.T(), c.expected, err)
 		})
 	}

--- a/internal/conf/configuration.go
+++ b/internal/conf/configuration.go
@@ -72,6 +72,8 @@ type AnonymousProviderConfiguration struct {
 type EmailProviderConfiguration struct {
 	Enabled bool `json:"enabled" default:"true"`
 
+	AuthorizedAddresses []string `json:"authorized_addresses" split_words:"true"`
+
 	MagicLinkEnabled bool `json:"magic_link_enabled" default:"true" split_words:"true"`
 }
 


### PR DESCRIPTION
Adds support for authorized email addresses, useful when needing to restrict email sending to a handful of email addresses. In the Supabase platform use case, this can be used to allow sending of emails on new projects only to the project's owners or developers, reducing email abuse.

To enable it, specify `GOTRUE_EXTERNAL_EMAIL_AUTHORIZED_ADDRESSES` as a comma-delimited string of email addresses. The addresses should be lowercased and without labels.

Labels are supported so emails will be sent to `someone+test1@gmail.com` and `someone+test2@gmail.com` if and only if the `someone@gmail.com` address is added in the authorized list.

Not a substitute for blocklists!