### PR TITLE
fix: user sanitization should clean up email change info too

### DIFF
--- a/internal/api/signup.go
+++ b/internal/api/signup.go
@@ -336,9 +336,9 @@ func sanitizeUser(u *models.User, params *SignupParams) (*models.User, error) {
 
 	u.ID = uuid.Must(uuid.NewV4())
 
-	u.Role = ""
+	u.Role, u.EmailChange = "", ""
 	u.CreatedAt, u.UpdatedAt, u.ConfirmationSentAt = now, now, &now
-	u.LastSignInAt, u.ConfirmedAt, u.EmailConfirmedAt, u.PhoneConfirmedAt = nil, nil, nil, nil
+	u.LastSignInAt, u.ConfirmedAt, u.EmailChangeSentAt, u.EmailConfirmedAt, u.PhoneConfirmedAt = nil, nil, nil, nil, nil
 	u.Identities = make([]models.Identity, 0)
 	u.UserMetaData = params.Data
 	u.Aud = params.Aud


### PR DESCRIPTION
The `sanitizeUser` function did not cleanup the **EmailChange** and **EmailChangeSentAt** properties on a User. If a User had a pending email address change, the new address could be leaked via a crafted `signUp` request.