### PR TITLE
fix: add token to hook payload for non-secure email change

### DIFF
--- a/internal/api/mail.go
+++ b/internal/api/mail.go
@@ -588,6 +588,11 @@ func (a *API) sendEmail(r *http.Request, tx *storage.Connection, u *models.User,
 	}
 
 	if config.Hook.SendEmail.Enabled {
+		// When secure email change is disabled, we place the token for the new email on emailData.Token
+		if emailActionType == mail.EmailChangeVerification && !config.Mailer.SecureEmailChangeEnabled && u.GetEmail() != "" {
+			otp = otpNew
+		}
+
 		emailData := mail.EmailData{
 			Token:           otp,
 			EmailActionType: emailActionType,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fix #1744  by introducing the token to the Auth Hook payload for Send Email. The tokenHash seems to be already present.

Currently, it's passed into the function as `otpNew`. Though it is indeed the OTP needed to validate the new email address we place it in  the `token` field to maintain the convention that `token_hash_new` is only populated when secure email change is enabled

New output structure:

<img width="598" alt="image" src="https://github.com/user-attachments/assets/a8c44214-dcf2-4d2e-a653-b3953244ac69">
