### PR TITLE
fix: update aal requirements to update user

### DIFF
--- a/internal/api/user.go
+++ b/internal/api/user.go
@@ -89,8 +89,6 @@ func (a *API) UserUpdate(w http.ResponseWriter, r *http.Request) error {
 
 	user := getUser(ctx)
 	session := getSession(ctx)
-	// Change to check for verified
-	// Allow for metadata update
 
 	if err := a.validateUserUpdateParams(ctx, params); err != nil {
 		return err
@@ -102,14 +100,7 @@ func (a *API) UserUpdate(w http.ResponseWriter, r *http.Request) error {
 		}
 	}
 
-	numVerifiedFactors := 0
-	for _, factor := range user.Factors {
-		if factor.IsVerified() {
-			numVerifiedFactors++
-		}
-	}
-
-	if numVerifiedFactors > 0 && !session.IsAAL2() {
+	if user.HasMFAEnabled() && !session.IsAAL2() {
 		if (params.Password != nil && *params.Password != "") || params.Email != "" && user.GetEmail() != params.Email {
 			return httpError(http.StatusUnauthorized, ErrorCodeInsufficientAAL, "AAL2 session is required to update email or password when MFA is enabled.")
 		}

--- a/internal/api/user.go
+++ b/internal/api/user.go
@@ -101,7 +101,7 @@ func (a *API) UserUpdate(w http.ResponseWriter, r *http.Request) error {
 	}
 
 	if user.HasMFAEnabled() && !session.IsAAL2() {
-		if (params.Password != nil && *params.Password != "") || params.Email != "" && user.GetEmail() != params.Email {
+		if (params.Password != nil && *params.Password != "") || (params.Email != "" && user.GetEmail() != params.Email) || (params.Phone != "" && user.GetPhone() != params.Phone) {
 			return httpError(http.StatusUnauthorized, ErrorCodeInsufficientAAL, "AAL2 session is required to update email or password when MFA is enabled.")
 		}
 	}

--- a/internal/api/user.go
+++ b/internal/api/user.go
@@ -89,6 +89,11 @@ func (a *API) UserUpdate(w http.ResponseWriter, r *http.Request) error {
 
 	user := getUser(ctx)
 	session := getSession(ctx)
+	// Change to check for verified
+	// Allow for metadata update
+	if len(user.Factors) != 0 && session.AAL != models.AAL2 {
+		return unauthorizedError("need aal2")
+	}
 
 	if err := a.validateUserUpdateParams(ctx, params); err != nil {
 		return err

--- a/internal/models/user.go
+++ b/internal/models/user.go
@@ -773,7 +773,8 @@ func (u *User) IsBanned() bool {
 }
 
 func (u *User) HasMFAEnabled() bool {
-	for _, factor := range user.Factors {
+	numVerifiedFactors := 0
+	for _, factor := range u.Factors {
 		if factor.IsVerified() {
 			numVerifiedFactors++
 		}

--- a/internal/models/user.go
+++ b/internal/models/user.go
@@ -772,6 +772,16 @@ func (u *User) IsBanned() bool {
 	return time.Now().Before(*u.BannedUntil)
 }
 
+func (u *User) HasMFAEnabled() bool {
+	for _, factor := range user.Factors {
+		if factor.IsVerified() {
+			numVerifiedFactors++
+		}
+	}
+
+	return numVerifiedFactors > 0
+}
+
 func (u *User) UpdateBannedUntil(tx *storage.Connection) error {
 	return tx.UpdateOnly(u, "banned_until")
 }

--- a/internal/models/user.go
+++ b/internal/models/user.go
@@ -773,14 +773,13 @@ func (u *User) IsBanned() bool {
 }
 
 func (u *User) HasMFAEnabled() bool {
-	numVerifiedFactors := 0
 	for _, factor := range u.Factors {
 		if factor.IsVerified() {
-			numVerifiedFactors++
+			return true
 		}
 	}
 
-	return numVerifiedFactors > 0
+	return false
 }
 
 func (u *User) UpdateBannedUntil(tx *storage.Connection) error {


### PR DESCRIPTION
## What kind of change does this PR introduce?

If a user has verified factors (mfa enabled) we should require an AAL2 session in order to proceed with any operation

We restrict phone, email, and password from updates as we consider those as sensitive fields

Context: https://supabase.slack.com/archives/C02AK9166FR/p1725466764804889