### PR TITLE
fix: apply authorized email restriction to non-admin routes

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -128,6 +128,7 @@ func NewAPIWithVersion(globalConfig *conf.GlobalConfiguration, db *storage.Conne
 
 	r.Route("/", func(r *router) {
 		r.Use(api.isValidExternalHost)
+		r.Use(api.isValidAuthorizedEmail)
 
 		r.Get("/settings", api.Settings)
 

--- a/internal/api/helpers.go
+++ b/internal/api/helpers.go
@@ -86,6 +86,9 @@ type RequestParams interface {
 		struct {
 			Email string `json:"email"`
 			Phone string `json:"phone"`
+		} |
+		struct {
+			Email string `json:"email"`
 		}
 }
 

--- a/internal/api/mail.go
+++ b/internal/api/mail.go
@@ -2,8 +2,6 @@ package api
 
 import (
 	"net/http"
-	"regexp"
-	"strings"
 	"time"
 
 	"github.com/didip/tollbooth/v5"
@@ -550,8 +548,6 @@ func (a *API) sendEmailChange(r *http.Request, tx *storage.Connection, u *models
 	return nil
 }
 
-var emailLabelPattern = regexp.MustCompile("[+][^@]+@")
-
 func (a *API) validateEmail(email string) (string, error) {
 	if email == "" {
 		return "", badRequestError(ErrorCodeValidationFailed, "An email address is required")
@@ -561,21 +557,6 @@ func (a *API) validateEmail(email string) (string, error) {
 	}
 	if err := checkmail.ValidateFormat(email); err != nil {
 		return "", badRequestError(ErrorCodeValidationFailed, "Unable to validate email address: "+err.Error())
-	}
-
-	email = strings.ToLower(email)
-
-	if len(a.config.External.Email.AuthorizedAddresses) > 0 {
-		// allow labelled emails when authorization rules are in place
-		normalized := emailLabelPattern.ReplaceAllString(email, "@")
-
-		for _, authorizedAddress := range a.config.External.Email.AuthorizedAddresses {
-			if normalized == authorizedAddress {
-				return email, nil
-			}
-		}
-
-		return "", badRequestError(ErrorCodeEmailAddressNotAuthorized, "Email address %q cannot be used as it is not authorized", email)
 	}
 
 	return email, nil

--- a/internal/api/mail_test.go
+++ b/internal/api/mail_test.go
@@ -48,41 +48,6 @@ func (ts *MailTestSuite) SetupTest() {
 	require.NoError(ts.T(), ts.API.db.Create(u), "Error saving new user")
 }
 
-func (ts *MailTestSuite) TestValidateEmailAuthorizedAddresses() {
-	ts.Config.External.Email.AuthorizedAddresses = []string{"someone-a@example.com", "someone-b@example.com"}
-	defer func() {
-		ts.Config.External.Email.AuthorizedAddresses = nil
-	}()
-
-	positiveExamples := []string{
-		"someone-a@example.com",
-		"someone-b@example.com",
-		"someone-a+test-1@example.com",
-		"someone-b+test-2@example.com",
-		"someone-A@example.com",
-		"someone-B@example.com",
-		"someone-a@Example.com",
-		"someone-b@Example.com",
-	}
-
-	negativeExamples := []string{
-		"someone@example.com",
-		"s.omeone@example.com",
-		"someone-a+@example.com",
-		"someone+a@example.com",
-	}
-
-	for _, example := range positiveExamples {
-		_, err := ts.API.validateEmail(example)
-		require.NoError(ts.T(), err)
-	}
-
-	for _, example := range negativeExamples {
-		_, err := ts.API.validateEmail(example)
-		require.Error(ts.T(), err)
-	}
-}
-
 func (ts *MailTestSuite) TestGenerateLink() {
 	// create admin jwt
 	claims := &AccessTokenClaims{

--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -177,7 +177,7 @@ func (a *API) isValidAuthorizedEmail(w http.ResponseWriter, req *http.Request) (
 	ctx := req.Context()
 
 	// skip checking for authorized email addresses if it's an admin request
-	if strings.HasPrefix(req.URL.Path, "/admin") || req.Method == http.MethodGet {
+	if strings.HasPrefix(req.URL.Path, "/admin") || req.Method == http.MethodGet || req.Method == http.MethodDelete {
 		return ctx, nil
 	}
 

--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -186,7 +186,8 @@ func (a *API) isValidAuthorizedEmail(w http.ResponseWriter, req *http.Request) (
 	}
 
 	if err := retrieveRequestParams(req, &body); err != nil {
-		return ctx, err
+		// let downstream handlers handle the error
+		return ctx, nil
 	}
 	if body.Email == "" {
 		return ctx, nil

--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -177,7 +177,7 @@ func (a *API) isValidAuthorizedEmail(w http.ResponseWriter, req *http.Request) (
 	ctx := req.Context()
 
 	// skip checking for authorized email addresses if it's an admin request
-	if strings.HasPrefix(req.URL.Path, "/admin") {
+	if strings.HasPrefix(req.URL.Path, "/admin") || req.Method == http.MethodGet {
 		return ctx, nil
 	}
 


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Move the email restriction validation to the middleware rather than doing it in the `validateEmail` function
* Excludes requests made to the `/admin` endpoints and any `GET` and `DELETE` requests

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
