### PR TITLE
fix: `/generate_link` endpoint excluded from authorized email restriction

### DIFF
--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -181,6 +181,11 @@ func (a *API) isValidAuthorizedEmail(w http.ResponseWriter, req *http.Request) (
 		return ctx, nil
 	}
 
+	// skip checking for authorized email addresses if it's a POST request to /generate_link
+	if req.URL.Path == "/generate_link" && req.Method == http.MethodPost {
+		return ctx, nil
+	}
+
 	var body struct {
 		Email string `json:"email"`
 	}

--- a/internal/api/middleware_test.go
+++ b/internal/api/middleware_test.go
@@ -532,6 +532,13 @@ func (ts *MiddlewareTestSuite) TestIsValidAuthorizedEmail() {
 			},
 		},
 		{
+			desc:    "bypass check for generate_link endpoint",
+			reqPath: "/generate_link",
+			body: map[string]interface{}{
+				"email": "test@example.com",
+			},
+		},
+		{
 			desc:    "bypass check if no email in request body",
 			reqPath: "/signup",
 			body:    map[string]interface{}{},


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix. 

## What is the current behavior?

The `/generate_link` endpoint is currently failing with

```
Email address "someUser@gmail.com" cannot be used as it is not authorized
```

See: https://github.com/orgs/supabase/discussions/29370#discussioncomment-10781231

## What is the new behavior?

Users can use the [`generateLink` function](https://supabase.com/docs/reference/javascript/auth-admin-generatelink) even if they don't have a custom SMTP provider configured.
