### PR TITLE
fix: upgrade ci Go version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,10 +73,10 @@ jobs:
           echo "RELEASE_CANDIDATE=${RELEASE_CANDIDATE}" >> "${GITHUB_OUTPUT}"
           echo "RELEASE_NAME=${RELEASE_NAME}" >> "${GITHUB_OUTPUT}"
 
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v5
         if: ${{ steps.release.outputs.release_created == 'true' || steps.release.outputs.prs_created == 'true' }}
         with:
-          go-version: "^1.21.0" # The Go version to download (if necessary) and use.
+          go-version: "^1.22.0" # The Go version to download (if necessary) and use.
 
       - name: Build release artifacts
         if: ${{ steps.release.outputs.release_created == 'true' || steps.release.outputs.prs_created == 'true' }}


### PR DESCRIPTION
## What kind of change does this PR introduce?

[Support for Go 1.21 has ended](https://endoflife.date/go). Also for certainty that we don't have cases where the CI build passes (v1.21) but doesn't work with 1.22. 

Setup Go v4 and v3 [seem to use node16](https://github.com/actions/setup-go) and supported has ended for that so decided to upgrade