### PR TITLE
fix: bypass check for token & verify endpoints

### DIFF
--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -176,8 +176,11 @@ var emailLabelPattern = regexp.MustCompile("[+][^@]+@")
 func (a *API) isValidAuthorizedEmail(w http.ResponseWriter, req *http.Request) (context.Context, error) {
 	ctx := req.Context()
 
+	// we don't need to enforce the check on these endpoints since they don't send emails
+	containsNonEmailSendingPath := regexp.MustCompile(`^/(admin|token|verify)`)
+
 	// skip checking for authorized email addresses if it's an admin request
-	if strings.HasPrefix(req.URL.Path, "/admin") || req.Method == http.MethodGet || req.Method == http.MethodDelete {
+	if containsNonEmailSendingPath.MatchString(req.URL.Path) || req.Method == http.MethodGet || req.Method == http.MethodDelete {
 		return ctx, nil
 	}
 

--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -173,11 +173,11 @@ func isIgnoreCaptchaRoute(req *http.Request) bool {
 
 var emailLabelPattern = regexp.MustCompile("[+][^@]+@")
 
+// we don't need to enforce the check on these endpoints since they don't send emails
+var containsNonEmailSendingPath = regexp.MustCompile(`^/(admin|token|verify)`)
+
 func (a *API) isValidAuthorizedEmail(w http.ResponseWriter, req *http.Request) (context.Context, error) {
 	ctx := req.Context()
-
-	// we don't need to enforce the check on these endpoints since they don't send emails
-	containsNonEmailSendingPath := regexp.MustCompile(`^/(admin|token|verify)`)
 
 	// skip checking for authorized email addresses if it's an admin request
 	if containsNonEmailSendingPath.MatchString(req.URL.Path) || req.Method == http.MethodGet || req.Method == http.MethodDelete {

--- a/internal/api/middleware_test.go
+++ b/internal/api/middleware_test.go
@@ -532,6 +532,20 @@ func (ts *MiddlewareTestSuite) TestIsValidAuthorizedEmail() {
 			},
 		},
 		{
+			desc:    "bypass check for token endpoint",
+			reqPath: "/token",
+			body: map[string]interface{}{
+				"email": "valid@example.com",
+			},
+		},
+		{
+			desc:    "bypass check for verify endpoint",
+			reqPath: "/token",
+			body: map[string]interface{}{
+				"email": "valid@example.com",
+			},
+		},
+		{
 			desc:    "bypass check if no email in request body",
 			reqPath: "/signup",
 			body:    map[string]interface{}{},


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Allow requests to skip check for authorized email addresses for /token and /verify endpoints

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
