### PR TITLE
fix: fix `getExcludedColumns` slice allocation

### DIFF
--- a/internal/storage/dial.go
+++ b/internal/storage/dial.go
@@ -180,7 +180,7 @@ func getExcludedColumns(model interface{}, includeColumns ...string) ([]string, 
 		cols.Remove(f)
 	}
 
-	xcols := make([]string, len(cols.Cols))
+	xcols := make([]string, 0, len(cols.Cols))
 	for n := range cols.Cols {
 		// gobuffalo updates the updated_at column automatically
 		if n == "updated_at" {


### PR DESCRIPTION
`getExcludedColumns` allocates a slice of a particular length instead of capacity, which does not achieve the intended effect -- memory optimization.
