### PR TITLE
fix: Fix reqPath for bypass check for verify EP

### DIFF
--- a/internal/api/middleware_test.go
+++ b/internal/api/middleware_test.go
@@ -540,7 +540,7 @@ func (ts *MiddlewareTestSuite) TestIsValidAuthorizedEmail() {
 		},
 		{
 			desc:    "bypass check for verify endpoint",
-			reqPath: "/token",
+			reqPath: "/verify",
 			body: map[string]interface{}{
 				"email": "valid@example.com",
 			},


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fix reqPath for verify check bypass test

## What is the current behavior?

We are experiencing lot of 403 responses from /v1/verify EP. Supabase is returning "invalid or expired OTP". Correcting this test maybe will raise the cause of our problems. I did not setup the project on my machine, someone can run the test and check if it passes also on verify EP?

## What is the new behavior?

Test is correct.

## Additional context

Add any other context or screenshots.
