### PR TITLE
fix: validateEmail should normalise emails

### DIFF
--- a/internal/api/mail.go
+++ b/internal/api/mail.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/didip/tollbooth/v5"
@@ -559,7 +560,7 @@ func (a *API) validateEmail(email string) (string, error) {
 		return "", badRequestError(ErrorCodeValidationFailed, "Unable to validate email address: "+err.Error())
 	}
 
-	return email, nil
+	return strings.ToLower(email), nil
 }
 
 func validateSentWithinFrequencyLimit(sentAt *time.Time, frequency time.Duration) error {

--- a/internal/api/verify_test.go
+++ b/internal/api/verify_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strings"
 	"testing"
 	"time"
 
@@ -894,6 +895,19 @@ func (ts *VerifyTestSuite) TestVerifyValidOtp() {
 				"type":  mail.EmailOTPVerification,
 				"token": "123456",
 				"email": u.GetEmail(),
+			},
+			expected: expected{
+				code:      http.StatusOK,
+				tokenHash: crypto.GenerateTokenHash(u.GetEmail(), "123456"),
+			},
+		},
+		{
+			desc:     "Valid Email OTP (email casing shouldn't matter)",
+			sentTime: time.Now(),
+			body: map[string]interface{}{
+				"type":  mail.EmailOTPVerification,
+				"token": "123456",
+				"email": strings.ToUpper(u.GetEmail()),
 			},
 			expected: expected{
 				code:      http.StatusOK,


### PR DESCRIPTION
## What kind of change does this PR introduce?
* `validateEmail` should normalise emails

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
