### PR TITLE
feat: rate limiter persistence

### DIFF
--- a/cmd/serve_cmd.go
+++ b/cmd/serve_cmd.go
@@ -48,7 +48,10 @@ func serve(ctx context.Context) {
 	addr := net.JoinHostPort(config.API.Host, config.API.Port)
 	logrus.Infof("GoTrue API started on: %s", addr)
 
-	a := api.NewAPIWithVersion(config, db, utilities.Version)
+	opts := []api.Option{
+		api.NewLimiterOptions(config),
+	}
+	a := api.NewAPIWithVersion(config, db, utilities.Version, opts...)
 	ah := reloader.NewAtomicHandler(a)
 
 	baseCtx, baseCancel := context.WithCancel(context.Background())
@@ -74,7 +77,8 @@ func serve(ctx context.Context) {
 
 			fn := func(latestCfg *conf.GlobalConfiguration) {
 				log.Info("reloading api with new configuration")
-				latestAPI := api.NewAPIWithVersion(latestCfg, db, utilities.Version)
+				latestAPI := api.NewAPIWithVersion(
+					latestCfg, db, utilities.Version, opts...)
 				ah.Store(latestAPI)
 			}
 

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -45,7 +45,8 @@ func setupAPIForTestWithCallback(cb func(*conf.GlobalConfiguration, *storage.Con
 		cb(nil, conn)
 	}
 
-	return NewAPIWithVersion(config, conn, apiTestVersion), config, nil
+	limiterOpts := NewLimiterOptions(config)
+	return NewAPIWithVersion(config, conn, apiTestVersion, limiterOpts), config, nil
 }
 
 func TestEmailEnabledByDefault(t *testing.T) {

--- a/internal/api/middleware_test.go
+++ b/internal/api/middleware_test.go
@@ -212,7 +212,7 @@ func (ts *MiddlewareTestSuite) TestLimitEmailOrPhoneSentHandler() {
 		},
 	}
 
-	limiter := ts.API.limitEmailOrPhoneSentHandler()
+	limiter := ts.API.limitEmailOrPhoneSentHandler(NewLimiterOptions(ts.Config))
 	for _, c := range cases {
 		ts.Run(c.desc, func() {
 			var buffer bytes.Buffer
@@ -484,7 +484,7 @@ func (ts *MiddlewareTestSuite) TestLimitHandlerWithSharedLimiter() {
 			ts.Config.RateLimitEmailSent = c.sharedLimiterConfig.RateLimitEmailSent
 			ts.Config.RateLimitSmsSent = c.sharedLimiterConfig.RateLimitSmsSent
 			lmt := ts.API.limitHandler(ipBasedLimiter(c.ipBasedLimiterConfig))
-			sharedLimiter := ts.API.limitEmailOrPhoneSentHandler()
+			sharedLimiter := ts.API.limitEmailOrPhoneSentHandler(NewLimiterOptions(ts.Config))
 
 			// get the minimum amount to reach the threshold just before the rate limit is exceeded
 			threshold := min(c.sharedLimiterConfig.RateLimitEmailSent, c.sharedLimiterConfig.RateLimitSmsSent, c.ipBasedLimiterConfig)

--- a/internal/api/options.go
+++ b/internal/api/options.go
@@ -1,0 +1,111 @@
+package api
+
+import (
+	"time"
+
+	"github.com/didip/tollbooth/v5"
+	"github.com/didip/tollbooth/v5/limiter"
+	"github.com/supabase/auth/internal/conf"
+)
+
+type Option interface {
+	apply(*API)
+}
+
+type optionFunc func(*API)
+
+func (fn optionFunc) apply(a *API) { fn(a) }
+
+type LimiterOptions struct {
+	Email            *limiter.Limiter
+	Phone            *limiter.Limiter
+	Signups          *limiter.Limiter
+	AnonymousSignIns *limiter.Limiter
+	Recover          *limiter.Limiter
+	Resend           *limiter.Limiter
+	MagicLink        *limiter.Limiter
+	Otp              *limiter.Limiter
+	Token            *limiter.Limiter
+	Verify           *limiter.Limiter
+	User             *limiter.Limiter
+	FactorVerify     *limiter.Limiter
+	FactorChallenge  *limiter.Limiter
+	SSO              *limiter.Limiter
+	SAMLAssertion    *limiter.Limiter
+}
+
+func (lo *LimiterOptions) apply(a *API) { a.limiterOpts = lo }
+
+func NewLimiterOptions(gc *conf.GlobalConfiguration) *LimiterOptions {
+	o := &LimiterOptions{}
+
+	o.Email = tollbooth.NewLimiter(gc.RateLimitEmailSent/(60*60),
+		&limiter.ExpirableOptions{
+			DefaultExpirationTTL: time.Hour,
+		}).SetBurst(int(gc.RateLimitEmailSent)).SetMethods([]string{"PUT", "POST"})
+
+	o.Phone = tollbooth.NewLimiter(gc.RateLimitSmsSent/(60*60),
+		&limiter.ExpirableOptions{
+			DefaultExpirationTTL: time.Hour,
+		}).SetBurst(int(gc.RateLimitSmsSent)).SetMethods([]string{"PUT", "POST"})
+
+	o.AnonymousSignIns = tollbooth.NewLimiter(gc.RateLimitAnonymousUsers/(60*60),
+		&limiter.ExpirableOptions{
+			DefaultExpirationTTL: time.Hour,
+		}).SetBurst(int(gc.RateLimitAnonymousUsers)).SetMethods([]string{"POST"})
+
+	o.Token = tollbooth.NewLimiter(gc.RateLimitTokenRefresh/(60*5),
+		&limiter.ExpirableOptions{
+			DefaultExpirationTTL: time.Hour,
+		}).SetBurst(30)
+
+	o.Verify = tollbooth.NewLimiter(gc.RateLimitVerify/(60*5),
+		&limiter.ExpirableOptions{
+			DefaultExpirationTTL: time.Hour,
+		}).SetBurst(30)
+
+	o.User = tollbooth.NewLimiter(gc.RateLimitOtp/(60*5),
+		&limiter.ExpirableOptions{
+			DefaultExpirationTTL: time.Hour,
+		}).SetBurst(30)
+
+	o.FactorVerify = tollbooth.NewLimiter(gc.MFA.RateLimitChallengeAndVerify/60,
+		&limiter.ExpirableOptions{
+			DefaultExpirationTTL: time.Minute,
+		}).SetBurst(30)
+
+	o.FactorChallenge = tollbooth.NewLimiter(gc.MFA.RateLimitChallengeAndVerify/60,
+		&limiter.ExpirableOptions{
+			DefaultExpirationTTL: time.Minute,
+		}).SetBurst(30)
+
+	o.SSO = tollbooth.NewLimiter(gc.RateLimitSso/(60*5),
+		&limiter.ExpirableOptions{
+			DefaultExpirationTTL: time.Hour,
+		}).SetBurst(30)
+
+	o.SAMLAssertion = tollbooth.NewLimiter(gc.SAML.RateLimitAssertion/(60*5),
+		&limiter.ExpirableOptions{
+			DefaultExpirationTTL: time.Hour,
+		}).SetBurst(30)
+
+	o.Signups = tollbooth.NewLimiter(gc.RateLimitOtp/(60*5),
+		&limiter.ExpirableOptions{
+			DefaultExpirationTTL: time.Hour,
+		}).SetBurst(30)
+
+	// These all use the OTP limit per 5 min with 1hour ttl and burst of 30.
+	o.Recover = newLimiterPer5mOver1h(gc.RateLimitOtp)
+	o.Resend = newLimiterPer5mOver1h(gc.RateLimitOtp)
+	o.MagicLink = newLimiterPer5mOver1h(gc.RateLimitOtp)
+	o.Otp = newLimiterPer5mOver1h(gc.RateLimitOtp)
+	return o
+}
+
+func newLimiterPer5mOver1h(rate float64) *limiter.Limiter {
+	freq := rate / (60 * 5)
+	lim := tollbooth.NewLimiter(freq, &limiter.ExpirableOptions{
+		DefaultExpirationTTL: time.Hour,
+	}).SetBurst(30)
+	return lim
+}


### PR DESCRIPTION
The goal with this change is to persist the rate limiters across reloads with the least invasive changes possible. To do this I first added a LimiterOptions structure to hold the current set of rate limiters. I then identified each call of tollbooth.New and moved the construction of the limiter without modifications to options.go. I assigned each limiter a distinct field to be referenced during the API object creation.

Next I needed to add an optional parameter to the NewAPI methods so I could store the new LimiterOptions onto the API object for reference during route construction. To do this without breaking all existing calls to NewAPI I used the options pattern. This makes the method accept a parametric set of values implementing a common interface, so future problems of similar nature can also be added as options.

I then replaced all the local anonymous limiter.Limiters made inline within the API route construction with each corresponding newly added field within the LimiterOptions struct.

## What kind of change does this PR introduce?

Feature

## What is the current behavior?

Currently we do not persist rate limiters when the config is reloaded.

## What is the new behavior?

We persist rate limiters in memory across configuration reloads.