### PR TITLE
fix: email header setting no longer misleading

### DIFF
--- a/internal/conf/configuration.go
+++ b/internal/conf/configuration.go
@@ -18,6 +18,7 @@ import (
 	"github.com/joho/godotenv"
 	"github.com/kelseyhightower/envconfig"
 	"github.com/lestrrat-go/jwx/v2/jwk"
+	"gopkg.in/gomail.v2"
 )
 
 const defaultMinPasswordLength int = 6
@@ -351,6 +352,12 @@ type SMTPConfiguration struct {
 
 func (c *SMTPConfiguration) Validate() error {
 	return nil
+}
+
+func (c *SMTPConfiguration) FromAddress() string {
+	mail := gomail.NewMessage()
+
+	return mail.FormatAddress(c.AdminEmail, c.SenderName)
 }
 
 type MailerConfiguration struct {

--- a/internal/mailer/mailer.go
+++ b/internal/mailer/mailer.go
@@ -5,11 +5,9 @@ import (
 	"net/http"
 	"net/url"
 
-	"github.com/gofrs/uuid"
 	"github.com/sirupsen/logrus"
 	"github.com/supabase/auth/internal/conf"
 	"github.com/supabase/auth/internal/models"
-	"gopkg.in/gomail.v2"
 )
 
 // Mailer defines the interface a mailer must implement.
@@ -42,16 +40,7 @@ type EmailData struct {
 
 // NewMailer returns a new gotrue mailer
 func NewMailer(globalConfig *conf.GlobalConfiguration) Mailer {
-	mail := gomail.NewMessage()
-
-	mail.SetHeaders(map[string][]string{
-		// Make the emails explicitly set to be HTML formatted (to cover older email clients)
-		"Content-Type": {"text/html; charset=utf-8"},
-		// so that messages are not grouped under each other
-		"Message-ID": {fmt.Sprintf("<%s@gotrue-mailer>", uuid.Must(uuid.NewV4()).String())},
-	})
-
-	from := mail.FormatAddress(globalConfig.SMTP.AdminEmail, globalConfig.SMTP.SenderName)
+	from := globalConfig.SMTP.FromAddress()
 	u, _ := url.ParseRequestURI(globalConfig.API.ExternalURL)
 
 	var mailClient MailClient


### PR DESCRIPTION
The code here is misleading. The `mail` variable is only used to format a From address, not used at all after that.