### PR TITLE
feat: add mail header support via `GOTRUE_SMTP_HEADERS` with `$messageType`

### DIFF
--- a/internal/mailer/mailme.go
+++ b/internal/mailer/mailme.go
@@ -38,7 +38,7 @@ type MailmeMailer struct {
 
 // Mail sends a templated mail. It will try to load the template from a URL, and
 // otherwise fall back to the default
-func (m *MailmeMailer) Mail(to, subjectTemplate, templateURL, defaultTemplate string, templateData map[string]interface{}) error {
+func (m *MailmeMailer) Mail(to, subjectTemplate, templateURL, defaultTemplate string, templateData map[string]interface{}, headers map[string][]string) error {
 	if m.FuncMap == nil {
 		m.FuncMap = map[string]interface{}{}
 	}
@@ -69,6 +69,13 @@ func (m *MailmeMailer) Mail(to, subjectTemplate, templateURL, defaultTemplate st
 	mail.SetHeader("From", m.From)
 	mail.SetHeader("To", to)
 	mail.SetHeader("Subject", subject.String())
+
+	for k, v := range headers {
+		if v != nil {
+			mail.SetHeader(k, v...)
+		}
+	}
+
 	mail.SetBody("text/html", body)
 
 	dial := gomail.NewDialer(m.Host, m.Port, m.User, m.Pass)

--- a/internal/mailer/noop.go
+++ b/internal/mailer/noop.go
@@ -6,7 +6,7 @@ import (
 
 type noopMailClient struct{}
 
-func (m *noopMailClient) Mail(to, subjectTemplate, templateURL, defaultTemplate string, templateData map[string]interface{}) error {
+func (m *noopMailClient) Mail(to, subjectTemplate, templateURL, defaultTemplate string, templateData map[string]interface{}, headers map[string][]string) error {
 	if to == "" {
 		return errors.New("to field cannot be empty")
 	}

--- a/internal/mailer/template_test.go
+++ b/internal/mailer/template_test.go
@@ -1,0 +1,30 @@
+package mailer
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/supabase/auth/internal/conf"
+)
+
+func TestTemplateHeaders(t *testing.T) {
+	mailer := TemplateMailer{
+		Config: &conf.GlobalConfiguration{
+			SMTP: conf.SMTPConfiguration{
+				Headers: `{"X-Test-A": ["test-a", "test-b"], "X-Test-B": ["test-c", "abc $messageType"]}`,
+			},
+		},
+	}
+
+	require.NoError(t, mailer.Config.SMTP.Validate())
+
+	require.Equal(t, mailer.Headers("TEST-MESSAGE-TYPE"), map[string][]string{
+		"X-Test-A": {"test-a", "test-b"},
+		"X-Test-B": {"test-c", "abc TEST-MESSAGE-TYPE"},
+	})
+
+	require.Equal(t, mailer.Headers("OTHER-TYPE"), map[string][]string{
+		"X-Test-A": {"test-a", "test-b"},
+		"X-Test-B": {"test-c", "abc OTHER-TYPE"},
+	})
+}


### PR DESCRIPTION
Adds support for additional and configurable email message headers. Set the `GOTRUE_SMTP_HEADERS` value to a JSON object of the shape (TypeScript notation) 

```
{ [header: string]: string[] }
```

Use the special string `$messageType` in the value portion to identify the message type being sent (for now: `invite`, `confirm`, `reauthenticate`, `email_change`, `recovery`, `magiclink`, `other`).

To use this with [AWS SES Feedback-ID](https://aws.amazon.com/about-aws/whats-new/2024/06/amazon-ses-custom-values-feedback-header/) one way to do it would be to [set SES SMTP message tags](https://docs.aws.amazon.com/ses/latest/dg/event-publishing-send-email.html#event-publishing-using-ses-headers):

```
GOTRUE_SMTP_HEADERS={"x-ses-message-tags": ["ses:feedback-id-a=<project-ref>,ses:feedback-id-b=$messageType"]}
```