### PR TITLE
fix: external host validation

### DIFF
--- a/internal/api/mail_test.go
+++ b/internal/api/mail_test.go
@@ -206,6 +206,11 @@ func (ts *MailTestSuite) TestGenerateLink() {
 	customDomainUrl, err := url.ParseRequestURI("https://example.gotrue.com")
 	require.NoError(ts.T(), err)
 
+	originalHosts := ts.API.config.Mailer.ExternalHosts
+	ts.API.config.Mailer.ExternalHosts = []string{
+		"example.gotrue.com",
+	}
+
 	for _, c := range cases {
 		ts.Run(c.Desc, func() {
 			var buffer bytes.Buffer
@@ -239,6 +244,8 @@ func (ts *MailTestSuite) TestGenerateLink() {
 			require.Equal(ts.T(), req.Host, u.Host)
 		})
 	}
+
+	ts.API.config.Mailer.ExternalHosts = originalHosts
 }
 
 func (ts *MailTestSuite) setURIAllowListMap(uris ...string) {

--- a/internal/conf/configuration.go
+++ b/internal/conf/configuration.go
@@ -397,6 +397,8 @@ type MailerConfiguration struct {
 
 	OtpExp    uint `json:"otp_exp" split_words:"true"`
 	OtpLength int  `json:"otp_length" split_words:"true"`
+
+	ExternalHosts []string `json:"external_hosts" split_words:"true"`
 }
 
 type PhoneProviderConfiguration struct {


### PR DESCRIPTION
Adds a new config option `GOTRUE_MAILER_EXTERNAL_HOSTS` that serves as an allowlist to all the acceptable hosts provided to the APIs.

Fixes #1228 