### PR TITLE
fix: ignore rate limits for autoconfirm

### DIFF
--- a/internal/api/mail.go
+++ b/internal/api/mail.go
@@ -627,14 +627,17 @@ func (a *API) sendEmail(r *http.Request, tx *storage.Connection, u *models.User,
 		}
 	}
 
-	// apply rate limiting before the email is sent out
-	if ok := a.limiterOpts.Email.Allow(); !ok {
-		emailRateLimitCounter.Add(
-			ctx,
-			1,
-			metric.WithAttributeSet(attribute.NewSet(attribute.String("path", r.URL.Path))),
-		)
-		return EmailRateLimitExceeded
+	// TODO(km): Deprecate this behaviour - rate limits should still be applied to autoconfirm
+	if !config.Mailer.Autoconfirm {
+		// apply rate limiting before the email is sent out
+		if ok := a.limiterOpts.Email.Allow(); !ok {
+			emailRateLimitCounter.Add(
+				ctx,
+				1,
+				metric.WithAttributeSet(attribute.NewSet(attribute.String("path", r.URL.Path))),
+			)
+			return EmailRateLimitExceeded
+		}
 	}
 
 	if config.Hook.SendEmail.Enabled {

--- a/internal/api/phone.go
+++ b/internal/api/phone.go
@@ -86,9 +86,12 @@ func (a *API) sendPhoneConfirmation(r *http.Request, tx *storage.Connection, use
 
 	// not using test OTPs
 	if otp == "" {
-		// apply rate limiting before the sms is sent out
-		if ok := a.limiterOpts.Phone.Allow(); !ok {
-			return "", tooManyRequestsError(ErrorCodeOverSMSSendRateLimit, "SMS rate limit exceeded")
+		// TODO(km): Deprecate this behaviour - rate limits should still be applied to autoconfirm
+		if !config.Sms.Autoconfirm {
+			// apply rate limiting before the sms is sent out
+			if ok := a.limiterOpts.Phone.Allow(); !ok {
+				return "", tooManyRequestsError(ErrorCodeOverSMSSendRateLimit, "SMS rate limit exceeded")
+			}
 		}
 		otp, err = crypto.GenerateOtp(config.Sms.OtpLength)
 		if err != nil {


### PR DESCRIPTION
## What kind of change does this PR introduce?
* https://github.com/supabase/auth/pull/1800 introduced a bug which applied the rate limiting setting even if `AUTOCONFIRM` was enabled. Although this is unintended, it is a breaking change so we need to give users time to update their rate limit settings before applying it

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
