### PR TITLE
feat: return validation failed error if captcha request was not json

### DIFF
--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -118,6 +118,10 @@ func (a *API) verifyCaptcha(w http.ResponseWriter, req *http.Request) (context.C
 
 	verificationResult, err := security.VerifyRequest(req, strings.TrimSpace(config.Security.Captcha.Secret), config.Security.Captcha.Provider)
 	if err != nil {
+		if strings.Contains(err.Error(), "request body was not JSON") {
+			return nil, badRequestError(ErrorCodeValidationFailed, "Request body for CAPTCHA verification was not a valid JSON object")
+		}
+
 		return nil, internalServerError("captcha verification process failed").WithInternalError(err)
 	}
 


### PR DESCRIPTION
Returns HTTP 400 with the validation failed error code if the request body sent to the server when CAPTCHA verification is enabled was not JSON or couldn't be parsed into JSON.