### PR TITLE
fix: make drop_uniqueness_constraint_on_phone idempotent

### DIFF
--- a/migrations/20240806073726_drop_uniqueness_constraint_on_phone.up.sql
+++ b/migrations/20240806073726_drop_uniqueness_constraint_on_phone.up.sql
@@ -1,6 +1,16 @@
 alter table {{ index .Options "Namespace" }}.mfa_factors drop constraint if exists mfa_factors_phone_key;
 do $$
 begin
+    -- if both indexes exist, it means that the schema_migrations table was truncated and the migrations had to be rerun
+    if (
+        select count(*) = 2
+        from pg_indexes 
+        where indexname in ('unique_verified_phone_factor', 'unique_phone_factor_per_user')
+        and schemaname = '{{ index .Options "Namespace" }}'
+    ) then
+        execute 'drop index {{ index .Options "Namespace" }}.unique_verified_phone_factor';
+    end if;
+
     if exists (
          select 1
          from pg_indexes


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Fixes an issue where `20240806073726_drop_uniqueness_constraint_on_phone.up.sql` is not idempotent when the `schema_migrations` table is truncated because `20240729123726_add_mfa_phone_config.up.sql` would have recreated the `unique_verified_phone_factor` index. This causes both indexes (`unique_verified_phone_factor` and `unique_phone_factor_per_user`) to be present resulting in the later migration (which renames the index) to fail.

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
