### PR TITLE
chore: use retrieveRequestParams where possible

### DIFF
--- a/internal/api/admin.go
+++ b/internal/api/admin.go
@@ -14,6 +14,7 @@ import (
 	"github.com/supabase/auth/internal/models"
 	"github.com/supabase/auth/internal/observability"
 	"github.com/supabase/auth/internal/storage"
+	"github.com/supabase/auth/internal/utilities"
 	"golang.org/x/crypto/bcrypt"
 )
 
@@ -513,11 +514,10 @@ func (a *API) adminUserDelete(w http.ResponseWriter, r *http.Request) error {
 
 	// ShouldSoftDelete defaults to false
 	params := &adminUserDeleteParams{}
-	if err := retrieveRequestParams(r, params); err != nil {
-		if err.(*HTTPError).ErrorCode == ErrorCodeBadJSON {
-			// request body is empty so the default behavior should be to hard delete the user
-			params.ShouldSoftDelete = false
-		} else {
+	if body, _ := utilities.GetBodyBytes(r); len(body) != 0 {
+		// we only want to parse the body if it's not empty
+		// retrieveRequestParams will handle any errors with stream
+		if err := retrieveRequestParams(r, params); err != nil {
 			return err
 		}
 	}

--- a/internal/api/helpers.go
+++ b/internal/api/helpers.go
@@ -57,11 +57,6 @@ func isStringInSlice(checkValue string, list []string) bool {
 	return false
 }
 
-// getBodyBytes returns a byte array of the request's Body.
-func getBodyBytes(req *http.Request) ([]byte, error) {
-	return utilities.GetBodyBytes(req)
-}
-
 type RequestParams interface {
 	AdminUserParams |
 		CreateSSOProviderParams |
@@ -82,6 +77,7 @@ type RequestParams interface {
 		VerifyFactorParams |
 		VerifyParams |
 		adminUserUpdateFactorParams |
+		adminUserDeleteParams |
 		ChallengeFactorParams |
 		struct {
 			Email string `json:"email"`
@@ -94,7 +90,7 @@ type RequestParams interface {
 
 // retrieveRequestParams is a generic method that unmarshals the request body into the params struct provided
 func retrieveRequestParams[A RequestParams](r *http.Request, params *A) error {
-	body, err := getBodyBytes(r)
+	body, err := utilities.GetBodyBytes(r)
 	if err != nil {
 		return internalServerError("Could not read body into byte slice").WithInternalError(err)
 	}

--- a/internal/api/helpers.go
+++ b/internal/api/helpers.go
@@ -9,6 +9,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/supabase/auth/internal/conf"
 	"github.com/supabase/auth/internal/models"
+	"github.com/supabase/auth/internal/security"
 	"github.com/supabase/auth/internal/utilities"
 )
 
@@ -78,6 +79,7 @@ type RequestParams interface {
 		VerifyParams |
 		adminUserUpdateFactorParams |
 		adminUserDeleteParams |
+		security.GotrueRequest |
 		ChallengeFactorParams |
 		struct {
 			Email string `json:"email"`

--- a/internal/security/captcha.go
+++ b/internal/security/captcha.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"fmt"
+
 	"github.com/pkg/errors"
 	"github.com/supabase/auth/internal/utilities"
 )
@@ -45,25 +46,13 @@ func init() {
 	Client = &http.Client{Timeout: defaultTimeout}
 }
 
-func VerifyRequest(r *http.Request, secretKey, captchaProvider string) (VerificationResponse, error) {
-	bodyBytes, err := utilities.GetBodyBytes(r)
-	if err != nil {
-		return VerificationResponse{}, err
-	}
-
-	var requestBody GotrueRequest
-
-	if err := json.Unmarshal(bodyBytes, &requestBody); err != nil {
-		return VerificationResponse{}, errors.Wrap(err, "request body was not JSON")
-	}
-
+func VerifyRequest(requestBody *GotrueRequest, clientIP, secretKey, captchaProvider string) (VerificationResponse, error) {
 	captchaResponse := strings.TrimSpace(requestBody.Security.Token)
 
 	if captchaResponse == "" {
 		return VerificationResponse{}, errors.New("no captcha response (captcha_token) found in request")
 	}
 
-	clientIP := utilities.GetIPAddress(r)
 	captchaURL, err := GetCaptchaURL(captchaProvider)
 	if err != nil {
 		return VerificationResponse{}, err


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Move the reading the requestBody into the captcha middleware, which is in the api package so it can use `retrieveRequestParams` 
* Use `retrieveRequestParams` in the admin delete route

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
