### PR TITLE
fix: check for phone identity on Phone Change

### DIFF
--- a/internal/api/user.go
+++ b/internal/api/user.go
@@ -136,7 +136,7 @@ func (a *API) UserUpdate(w http.ResponseWriter, r *http.Request) error {
 	}
 
 	if params.Phone != "" && user.GetPhone() != params.Phone {
-		if exists, err := models.IsDuplicatedPhone(db, params.Phone, aud); err != nil {
+		if exists, err := models.HasPhoneIdentity(db, params.Phone, aud); err != nil {
 			return internalServerError("Database error checking phone").WithInternalError(err)
 		} else if exists {
 			return unprocessableEntityError(ErrorCodePhoneExists, DuplicatePhoneMsg)

--- a/internal/api/user_test.go
+++ b/internal/api/user_test.go
@@ -205,6 +205,12 @@ func (ts *UserTestSuite) TestUserUpdatePhoneAutoconfirmEnabled() {
 	require.NoError(ts.T(), err)
 	require.NoError(ts.T(), ts.API.db.Create(existingUser))
 
+	idPhone, err := models.NewIdentity(existingUser, "phone", map[string]interface{}{
+		"sub": "+29382983298",
+	})
+	require.NoError(ts.T(), err)
+	require.NoError(ts.T(), ts.API.db.Create(idPhone))
+
 	cases := []struct {
 		desc         string
 		userData     map[string]string

--- a/internal/models/user.go
+++ b/internal/models/user.go
@@ -759,6 +759,26 @@ func IsDuplicatedPhone(tx *storage.Connection, phone, aud string) (bool, error) 
 	return true, nil
 }
 
+// TODO: Simplify this, check if it is safe to do this in admin create user too
+// HasPhoneIdentity checks if the phone number already exists in the identities table
+func HasPhoneIdentity(tx *storage.Connection, phone, aud string) (bool, error) {
+	user, err := FindUserByPhoneAndAudience(tx, phone, aud)
+	if err != nil {
+		if IsNotFoundError(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	_, err = FindIdentityByIdAndProvider(tx, user.ID.String(), "phone")
+	if err != nil {
+		if IsNotFoundError(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
+}
+
 // Ban a user for a given duration.
 func (u *User) Ban(tx *storage.Connection, duration time.Duration) error {
 	if duration == time.Duration(0) {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Allows user to change phone number to that of another unconfirmed phone number in they system


## What is the current behavior?

Currently, it is not possible to use a phone number which exists in the system but is unconfirmed. Consider the following scenario:

>User A signs up with phone number PN but doesn't confirm the number.
>User B signs up with phone number PN2 and confirms it.
>User B tries to update their phone number to PN -> this fails because User A has signed up with it already.

## What is the new behavior?

 It is possible to change phone number to one that is tagged to another user but unconfirmed.

>User A signs up with phone number PN but doesn't confirm the number.
>User B signs up with phone number PN2 and confirms it.
>User B tries to update their phone number to PN -> this succeeds.

Check is done via phone identity,

## Additional context
- [x] Add a test