### PR TITLE
fix: improve error messaging for http hooks

### DIFF
--- a/internal/api/hooks.go
+++ b/internal/api/hooks.go
@@ -179,7 +179,7 @@ func (a *API) runHTTPHook(r *http.Request, hookConfig conf.ExtensibilityPointCon
 		case http.StatusUnauthorized:
 			return nil, internalServerError("Hook requires authorization token")
 		default:
-			return nil, internalServerError("Error executing Hook")
+			return nil, internalServerError("Unexpected status code returned from hook: %d", rsp.StatusCode)
 		}
 	}
 	return nil, nil


### PR DESCRIPTION
## What kind of change does this PR introduce?
* HTTP hooks that return status codes outside of the accepted status codes will cause Auth to return an obscure error message that is hard to debug: `Error executing Hook` - this change is an attempt to improve the error messaging to reflect the status code being rejected

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
