### PR TITLE
fix: possible panic if refresh token has a null session_id

### DIFF
--- a/internal/api/token_refresh.go
+++ b/internal/api/token_refresh.go
@@ -56,19 +56,25 @@ func (a *API) RefreshTokenGrant(ctx context.Context, w http.ResponseWriter, r *h
 			return oauthError("invalid_grant", "Invalid Refresh Token: User Banned")
 		}
 
-		if session != nil {
-			result := session.CheckValidity(retryStart, &token.UpdatedAt, config.Sessions.Timebox, config.Sessions.InactivityTimeout)
-
-			switch result {
-			case models.SessionValid:
-				// do nothing
-
-			case models.SessionTimedOut:
-				return oauthError("invalid_grant", "Invalid Refresh Token: Session Expired (Inactivity)")
-
-			default:
-				return oauthError("invalid_grant", "Invalid Refresh Token: Session Expired")
+		if session == nil {
+			// a refresh token won't have a session if it's created prior to the sessions table introduced
+			if err := db.Destroy(token); err != nil {
+				return internalServerError("Error deleting refresh token with missing session").WithInternalError(err)
 			}
+			return badRequestError(ErrorCodeSessionNotFound, "Invalid Refresh Token: No Valid Session Found")
+		}
+
+		result := session.CheckValidity(retryStart, &token.UpdatedAt, config.Sessions.Timebox, config.Sessions.InactivityTimeout)
+
+		switch result {
+		case models.SessionValid:
+			// do nothing
+
+		case models.SessionTimedOut:
+			return oauthError("invalid_grant", "Invalid Refresh Token: Session Expired (Inactivity)")
+
+		default:
+			return oauthError("invalid_grant", "Invalid Refresh Token: Session Expired")
 		}
 
 		// Basic checks above passed, now we need to serialize access

--- a/internal/models/user.go
+++ b/internal/models/user.go
@@ -667,24 +667,6 @@ func FindUserWithRefreshToken(tx *storage.Connection, token string, forUpdate bo
 		}
 	}
 
-	if session == nil {
-		// the refresh token doesn't have a session so we just create one for it
-		// this is to accomodate refresh tokens that were created prior to the creation of the sessions table
-		session, err = NewSession(user.ID, nil)
-		if err != nil {
-			return nil, nil, nil, errors.Wrap(err, "error instantiating new session for refresh token")
-		}
-		if err := tx.Create(session); err != nil {
-			return nil, nil, nil, errors.Wrap(err, "error creating new session for refresh token")
-		}
-
-		// backfill the existing token with the session id
-		refreshToken.SessionId = &session.ID
-		if err := tx.UpdateOnly(refreshToken, "session_id"); err != nil {
-			return nil, nil, nil, errors.Wrap(err, "error updating refresh token with session id")
-		}
-	}
-
 	return user, refreshToken, session, nil
 }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Prior to the `auth.sessions` table being created, some refresh tokens can contain a null `session_id`. In those cases, attempting to use those refresh tokens to obtain a new session will result in a panic. 
* This PR creates a new session for those refresh tokens that do not have a `session_id` to prevent panics from happening.

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
