### PR TITLE
feat: add claim to JWT to indicate if there are verified MFA factors for user

### DIFF
--- a/internal/api/token.go
+++ b/internal/api/token.go
@@ -309,6 +309,15 @@ func (a *API) generateAccessToken(r *http.Request, tx *storage.Connection, user 
 	issuedAt := time.Now().UTC()
 	expiresAt := issuedAt.Add(time.Second * time.Duration(config.JWT.Exp)).Unix()
 
+	atLeastOneVerifiedFactor := false
+	for i := 0; i < len(user.Factors); i++ {
+		factor := user.Factors[i]
+		if factor.IsVerified() {
+			atLeastOneVerifiedFactor = true
+			break
+		}
+	}
+
 	claims := &hooks.AccessTokenClaims{
 		StandardClaims: jwt.StandardClaims{
 			Subject:   user.ID.String(),
@@ -324,6 +333,7 @@ func (a *API) generateAccessToken(r *http.Request, tx *storage.Connection, user 
 		Role:                          user.Role,
 		SessionId:                     sid,
 		AuthenticatorAssuranceLevel:   aal.String(),
+		AtLeastOneVerifiedFactor:      atLeastOneVerifiedFactor,
 		AuthenticationMethodReference: amr,
 		IsAnonymous:                   user.IsAnonymous,
 	}

--- a/internal/hooks/auth_hooks.go
+++ b/internal/hooks/auth_hooks.go
@@ -104,6 +104,7 @@ type AccessTokenClaims struct {
 	AppMetaData                   map[string]interface{} `json:"app_metadata"`
 	UserMetaData                  map[string]interface{} `json:"user_metadata"`
 	Role                          string                 `json:"role"`
+	AtLeastOneVerifiedFactor      bool                   `json:"has_factor,omitempty"`
 	AuthenticatorAssuranceLevel   string                 `json:"aal,omitempty"`
 	AuthenticationMethodReference []models.AMREntry      `json:"amr,omitempty"`
 	SessionId                     string                 `json:"session_id,omitempty"`


### PR DESCRIPTION
Hi Supabase team,

This is to satisfy setup in which `supabase/auth` genereated JWT can be passed to external API which validates JWT validity on its own. With this change the external API can determine whether to enforce `aal2` level or not, based on `has_factor` boolean which determines if user has at least one verified factor.

Commit description:
> Add field which can be used to determine if 2FA is enabled.
> That way the JWT consumer (e.g. if JWT is passed to some other API which verifies its authenticity) can only enforce 2FA AAL levels once 2FA is enabled. This allows to enforce 2FA only when at least one factor is used making 2FA roll-out optional.

Please let me know if you would be happy to merge that into your codebase.