### PR TITLE
fix: correct web authn aaguid column naming

### DIFF
--- a/internal/models/factor.go
+++ b/internal/models/factor.go
@@ -251,7 +251,7 @@ func (f *Factor) SaveWebAuthnCredential(tx *storage.Connection, credential *weba
 		f.WebAuthnAAGUID = nil
 	}
 
-	return tx.UpdateOnly(f, "web_authn_credential", "aaguid", "updated_at")
+	return tx.UpdateOnly(f, "web_authn_credential", "web_authn_aaguid", "updated_at")
 }
 
 func FindFactorByFactorID(conn *storage.Connection, factorID uuid.UUID) (*Factor, error) {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Use appropriate column name for Web Authn verification - it's fine to change this as it's currently behind the feature flags `MFA_WEB_AUTHN_*_ENABLED` and should have never been used.