### PR TITLE
fix: don't return `session_not_found` on logout, make it idempotent

### DIFF
--- a/internal/api/auth_test.go
+++ b/internal/api/auth_test.go
@@ -271,7 +271,7 @@ func (ts *AuthTestSuite) TestMaybeLoadUserOrSession() {
 
 			ctx, err := ts.API.parseJWTClaims(userJwt, req)
 			require.NoError(ts.T(), err)
-			ctx, err = ts.API.maybeLoadUserOrSession(ctx)
+			ctx, err = ts.API.maybeLoadUserOrSession(ctx, false)
 			if c.ExpectedError != nil {
 				require.Equal(ts.T(), c.ExpectedError.Error(), err.Error())
 			} else {

--- a/internal/api/mfa_test.go
+++ b/internal/api/mfa_test.go
@@ -676,7 +676,7 @@ func (ts *MFATestSuite) TestSessionsMaintainAALOnRefresh() {
 
 	ctx, err := ts.API.parseJWTClaims(data.Token, req)
 	require.NoError(ts.T(), err)
-	ctx, err = ts.API.maybeLoadUserOrSession(ctx)
+	ctx, err = ts.API.maybeLoadUserOrSession(ctx, false)
 	require.NoError(ts.T(), err)
 	require.True(ts.T(), getSession(ctx).IsAAL2())
 }


### PR DESCRIPTION
If you call `POST /logout` with a JWT whose session cannot be found in the database, it means that one of these cases occurred:

- The API call was retried, such as by the user clicking the button multiple times too fast.
- The user signed out from device A and then proceeds to sign out from device B within the JWT expiry period.
- The session was deleted outside of the logout flow, such as by manually running a `DELETE FROM sessions` query.

If this was done, the logout request failed with a `session_not_found` error code. With this change, the logout request succeeds.