### PR TITLE
fix: add test coverage for rate limits with 0 permitted events

### DIFF
--- a/internal/api/ratelimits_test.go
+++ b/internal/api/ratelimits_test.go
@@ -83,6 +83,32 @@ func TestNewRateLimiter(t *testing.T) {
 				{true, now.Add(time.Hour * 25), 0},
 			},
 		},
+		{
+			cfg: conf.Rate{Events: 0, OverTime: time.Hour},
+			now: now,
+			evts: []event{
+				{false, now.Add(-time.Hour), 0},
+				{false, now, 0},
+				{false, now.Add(time.Minute), 0},
+				{false, now.Add(time.Hour), 0},
+				{false, now.Add(time.Hour), 12},
+				{false, now.Add(time.Hour * 24), 0},
+				{false, now.Add(time.Hour * 24 * 2), 0},
+			},
+		},
+		{
+			cfg: conf.Rate{Events: 0, OverTime: time.Hour * 24},
+			now: now,
+			evts: []event{
+				{false, now.Add(-time.Hour), 0},
+				{false, now, 0},
+				{false, now.Add(time.Minute), 0},
+				{false, now.Add(time.Hour), 0},
+				{false, now.Add(time.Hour), 12},
+				{false, now.Add(time.Hour * 24), 0},
+				{false, now.Add(time.Hour * 24 * 2), 0},
+			},
+		},
 	}
 	for _, tc := range cases {
 		rl := newRateLimiter(tc.cfg)

--- a/internal/conf/rate_test.go
+++ b/internal/conf/rate_test.go
@@ -20,7 +20,6 @@ func TestRateDecode(t *testing.T) {
 		{str: "100/24h",
 			eps: 0.0011574074074074073,
 			exp: Rate{Events: 100, OverTime: time.Hour * 24}},
-
 		{str: "", eps: 1, exp: Rate{},
 			err: `rate: value does not match`},
 		{str: "1h", eps: 1, exp: Rate{},
@@ -35,6 +34,10 @@ func TestRateDecode(t *testing.T) {
 			err: `rate: over-time part of rate value`},
 		{str: "100/1", eps: 1, exp: Rate{},
 			err: `rate: over-time part of rate value`},
+
+		// zero events
+		{str: "0/1h", eps: 0.0, exp: Rate{Events: 0, OverTime: time.Hour}},
+		{str: "0/24h", eps: 0.0, exp: Rate{Events: 0, OverTime: time.Hour * 24}},
 	}
 	for idx, tc := range cases {
 		var r Rate


### PR DESCRIPTION
Verify that rate limits such as "0/1h", "0/24h" work as intended. This is a tests only change to ensure this behavior is preserved in the future.