### PR TITLE
feat: use embedded migrations for `migrate` command

### DIFF
--- a/cmd/migrate_cmd.go
+++ b/cmd/migrate_cmd.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"embed"
 	"fmt"
 	"net/url"
 	"os"
@@ -11,6 +12,8 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
+
+var EmbeddedMigrations embed.FS
 
 var migrateCmd = cobra.Command{
 	Use:  "migrate",
@@ -76,11 +79,14 @@ func migrate(cmd *cobra.Command, args []string) {
 		log.Fatalf("%+v", errors.Wrap(err, "checking database connection"))
 	}
 
-	log.Debugf("Reading migrations from %s", globalConfig.DB.MigrationsPath)
-	mig, err := pop.NewFileMigrator(globalConfig.DB.MigrationsPath, db)
+	log.Debugf("Reading migrations from executable")
+	box, err := pop.NewMigrationBox(EmbeddedMigrations, db)
 	if err != nil {
 		log.Fatalf("%+v", errors.Wrap(err, "creating db migrator"))
 	}
+
+	mig := box.Migrator
+
 	log.Debugf("before status")
 
 	if log.Level == logrus.DebugLevel {

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"embed"
 	"os/signal"
 	"sync"
 	"syscall"
@@ -12,11 +13,16 @@ import (
 	"github.com/supabase/auth/internal/observability"
 )
 
+//go:embed migrations/*
+var embeddedMigrations embed.FS
+
 func init() {
 	logrus.SetFormatter(&logrus.JSONFormatter{})
 }
 
 func main() {
+	cmd.EmbeddedMigrations = embeddedMigrations
+
 	execCtx, execCancel := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGHUP, syscall.SIGINT)
 	defer execCancel()
 


### PR DESCRIPTION
Embeds the DB migrations in the executable. Instead of a tarball only a single file can be used to start Supabase Auth.

This has added benefits in the Supabase platform for upgrades. See internal discussion.