### PR TITLE
fix(migrations): update types that are not set on the schema

### DIFF
--- a/migrations/20221003041400_add_aal_and_factor_id_to_sessions.up.sql
+++ b/migrations/20221003041400_add_aal_and_factor_id_to_sessions.up.sql
@@ -1,3 +1,3 @@
 -- add factor_id to sessions
  alter table {{ index .Options "Namespace" }}.sessions add column if not exists factor_id uuid null;
- alter table {{ index .Options "Namespace" }}.sessions add column if not exists aal aal_level null;
+ alter table {{ index .Options "Namespace" }}.sessions add column if not exists aal {{ index .Options "Namespace" }}.aal_level null;

--- a/migrations/20230322519590_add_flow_state_table.up.sql
+++ b/migrations/20230322519590_add_flow_state_table.up.sql
@@ -1,6 +1,6 @@
 -- see: https://stackoverflow.com/questions/7624919/check-if-a-user-defined-type-already-exists-in-postgresql/48382296#48382296
 do $$ begin
-    create type code_challenge_method as enum('s256', 'plain');
+    create type {{ index .Options "Namespace" }}.code_challenge_method as enum('s256', 'plain');
 exception
     when duplicate_object then null;
 end $$;
@@ -8,7 +8,7 @@ create table if not exists {{ index .Options "Namespace" }}.flow_state(
        id uuid primary key,
        user_id uuid null,
        auth_code text not null,
-       code_challenge_method code_challenge_method not null,
+       code_challenge_method {{ index .Options "Namespace" }}.code_challenge_method not null,
        code_challenge text not null,
        provider_type text not null,
        provider_access_token text null,

--- a/migrations/20240427152123_add_one_time_tokens_table.up.sql
+++ b/migrations/20240427152123_add_one_time_tokens_table.up.sql
@@ -1,5 +1,5 @@
 do $$ begin
-  create type one_time_token_type as enum (
+  create type {{ index .Options "Namespace" }}.one_time_token_type as enum (
     'confirmation_token',
     'reauthentication_token',
     'recovery_token',
@@ -16,7 +16,7 @@ do $$ begin
   create table if not exists {{ index .Options "Namespace" }}.one_time_tokens (
     id uuid primary key,
     user_id uuid not null references {{ index .Options "Namespace" }}.users on delete cascade,
-    token_type one_time_token_type not null,
+    token_type {{ index .Options "Namespace" }}.one_time_token_type not null,
     token_hash text not null,
     relates_to text not null,
     created_at timestamp without time zone not null default now(),


### PR DESCRIPTION
## What kind of change does this PR introduce?

This changeset updates the migrations schema that's causing trouble on new supabase/auth installations whether it's using docker or not. The types are not set on the schema which causes the migrations to fail. And it adds residual types to public schema.

## What is the current behavior?

Issue #1729 was closed despite not resolving the problem.

## What is the new behavior?

Add the relevant types to the proper schema.

## Additional context

![image](https://github.com/user-attachments/assets/bea26eca-e061-4086-97c7-6acf7e3e554d)
![image](https://github.com/user-attachments/assets/47ab01a0-3b48-44f6-833d-c635af23f612)

