### PR TITLE
fix: return the error code instead of status code

### DIFF
--- a/internal/api/external.go
+++ b/internal/api/external.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
-	"strconv"
 	"strings"
 	"time"
 
@@ -635,7 +634,7 @@ func getErrorQueryString(err error, errorID string, log logrus.FieldLogger, q ur
 			log.WithError(e.Cause()).Info(e.Error())
 		}
 		q.Set("error_description", e.Message)
-		q.Set("error_code", strconv.Itoa(e.HTTPStatus))
+		q.Set("error_code", e.ErrorCode)
 	case *OAuthError:
 		q.Set("error", e.Err)
 		q.Set("error_description", e.Description)

--- a/internal/api/verify.go
+++ b/internal/api/verify.go
@@ -439,10 +439,10 @@ func (a *API) prepErrorRedirectURL(err *HTTPError, r *http.Request, rurl string,
 		hq.Set("error", str)
 		q.Set("error", str)
 	}
-	hq.Set("error_code", strconv.Itoa(err.HTTPStatus))
+	hq.Set("error_code", err.ErrorCode)
 	hq.Set("error_description", err.Message)
 
-	q.Set("error_code", strconv.Itoa(err.HTTPStatus))
+	q.Set("error_code", err.ErrorCode)
 	q.Set("error_description", err.Message)
 	if flowType == models.PKCEFlow {
 		// Additionally, may override existing error query param if set to PKCE.

--- a/internal/api/verify_test.go
+++ b/internal/api/verify_test.go
@@ -305,7 +305,7 @@ func (ts *VerifyTestSuite) TestExpiredConfirmationToken() {
 
 	f, err := url.ParseQuery(rurl.Fragment)
 	require.NoError(ts.T(), err)
-	assert.Equal(ts.T(), "403", f.Get("error_code"))
+	assert.Equal(ts.T(), ErrorCodeOTPExpired, f.Get("error_code"))
 	assert.Equal(ts.T(), "Email link is invalid or has expired", f.Get("error_description"))
 	assert.Equal(ts.T(), "access_denied", f.Get("error"))
 }
@@ -824,7 +824,7 @@ func (ts *VerifyTestSuite) TestVerifyBannedUser() {
 
 			f, err := url.ParseQuery(rurl.Fragment)
 			require.NoError(ts.T(), err)
-			assert.Equal(ts.T(), "403", f.Get("error_code"))
+			assert.Equal(ts.T(), ErrorCodeUserBanned, f.Get("error_code"))
 		})
 	}
 }
@@ -1145,7 +1145,7 @@ func (ts *VerifyTestSuite) TestPrepRedirectURL() {
 
 func (ts *VerifyTestSuite) TestPrepErrorRedirectURL() {
 	const DefaultError = "Invalid redirect URL"
-	redirectError := fmt.Sprintf("error=invalid_request&error_code=400&error_description=%s", url.QueryEscape(DefaultError))
+	redirectError := fmt.Sprintf("error=invalid_request&error_code=validation_failed&error_description=%s", url.QueryEscape(DefaultError))
 
 	cases := []struct {
 		desc     string


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Return the error code for in the redirect URL instead of the status code 