### PR TITLE
fix: fallback on btree indexes when hash is unavailable

### DIFF
--- a/migrations/20240427152123_add_one_time_tokens_table.up.sql
+++ b/migrations/20240427152123_add_one_time_tokens_table.up.sql
@@ -24,7 +24,14 @@ do $$ begin
     check (char_length(token_hash) > 0)
   );
 
-  create index if not exists one_time_tokens_token_hash_hash_idx on {{ index .Options "Namespace" }}.one_time_tokens using hash (token_hash);
-  create index if not exists one_time_tokens_relates_to_hash_idx on {{ index .Options "Namespace" }}.one_time_tokens using hash (relates_to);
+  begin
+    create index if not exists one_time_tokens_token_hash_hash_idx on {{ index .Options "Namespace" }}.one_time_tokens using hash (token_hash);
+    create index if not exists one_time_tokens_relates_to_hash_idx on {{ index .Options "Namespace" }}.one_time_tokens using hash (relates_to);
+  exception when others then
+    -- Fallback to btree indexes if hash creation fails
+    create index if not exists one_time_tokens_token_hash_hash_idx on {{ index .Options "Namespace" }}.one_time_tokens using btree (token_hash);
+    create index if not exists one_time_tokens_relates_to_hash_idx on {{ index .Options "Namespace" }}.one_time_tokens using btree (relates_to);
+  end;
+
   create unique index if not exists one_time_tokens_user_id_token_type_key on {{ index .Options "Namespace" }}.one_time_tokens (user_id, token_type);
 end $$;


### PR DESCRIPTION
## What kind of change does this PR introduce?
Edits an existing migration to fallback onto btree indexes when hash indexes are unavailable.

This change allows auth to be compatible with the orioledb storage engine. At time of writing orioledb only support btree indexes. That issue is expected to be addressed by the end of Q1 - 2025. Once that support is added, both heap and orioledb projects will both use the code path for hash indexes. hash indexes are preferred because they are [safer from timing attacks](https://dba.stackexchange.com/questions/285739/prevent-timing-attacks-in-postgres)

A reminder has been set for May 1st for us to
- remove the fork in this migration
- identify and update the index type (from btree to hash) on any orioledb-alpha projects that are still in existence