### PR TITLE
fix: revert fallback on btree indexes when hash is unavailable

### DIFF
--- a/migrations/20240427152123_add_one_time_tokens_table.up.sql
+++ b/migrations/20240427152123_add_one_time_tokens_table.up.sql
@@ -24,14 +24,7 @@ do $$ begin
     check (char_length(token_hash) > 0)
   );
 
-  begin
-    create index if not exists one_time_tokens_token_hash_hash_idx on {{ index .Options "Namespace" }}.one_time_tokens using hash (token_hash);
-    create index if not exists one_time_tokens_relates_to_hash_idx on {{ index .Options "Namespace" }}.one_time_tokens using hash (relates_to);
-  exception when others then
-    -- Fallback to btree indexes if hash creation fails
-    create index if not exists one_time_tokens_token_hash_hash_idx on {{ index .Options "Namespace" }}.one_time_tokens using btree (token_hash);
-    create index if not exists one_time_tokens_relates_to_hash_idx on {{ index .Options "Namespace" }}.one_time_tokens using btree (relates_to);
-  end;
-
+  create index if not exists one_time_tokens_token_hash_hash_idx on {{ index .Options "Namespace" }}.one_time_tokens using hash (token_hash);
+  create index if not exists one_time_tokens_relates_to_hash_idx on {{ index .Options "Namespace" }}.one_time_tokens using hash (relates_to);
   create unique index if not exists one_time_tokens_user_id_token_type_key on {{ index .Options "Namespace" }}.one_time_tokens (user_id, token_type);
 end $$;


### PR DESCRIPTION
Reverts supabase/auth#1856. We plan to roll this out in the next version (v2.166.0)