### PR TITLE
fix: allow setting the mailer service headers as strings (#1861)

### DIFF
--- a/internal/conf/configuration.go
+++ b/internal/conf/configuration.go
@@ -403,7 +403,7 @@ type MailerConfiguration struct {
 	// EXPERIMENTAL: May be removed in a future release.
 	EmailValidationExtended       bool   `json:"email_validation_extended" split_words:"true" default:"false"`
 	EmailValidationServiceURL     string `json:"email_validation_service_url" split_words:"true"`
-	EmailValidationServiceHeaders string `json:"email_validation_service_key" split_words:"true"`
+	EmailValidationServiceHeaders string `json:"email_validation_service_headers" split_words:"true"`
 
 	serviceHeaders map[string][]string `json:"-"`
 }
@@ -414,7 +414,7 @@ func (c *MailerConfiguration) Validate() error {
 	if c.EmailValidationServiceHeaders != "" {
 		err := json.Unmarshal([]byte(c.EmailValidationServiceHeaders), &headers)
 		if err != nil {
-			return fmt.Errorf("conf: SMTP headers not a map[string][]string format: %w", err)
+			return fmt.Errorf("conf: mailer validation headers not a map[string][]string format: %w", err)
 		}
 	}
 

--- a/internal/mailer/validate.go
+++ b/internal/mailer/validate.go
@@ -197,7 +197,7 @@ func (ev *EmailValidator) validateService(ctx context.Context, email string) err
 	}
 
 	rdr := bytes.NewReader(reqData)
-	req, err := http.NewRequestWithContext(ctx, "GET", ev.serviceURL, rdr)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, ev.serviceURL, rdr)
 	if err != nil {
 		return nil
 	}
@@ -218,7 +218,8 @@ func (ev *EmailValidator) validateService(ctx context.Context, email string) err
 		Valid *bool `json:"valid"`
 	}{}
 
-	if res.StatusCode != http.StatusOK {
+	if res.StatusCode/100 != 2 {
+		// we ignore the error here just in case the service is down
 		return nil
 	}
 


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Request made to email validation service should be a `POST`
* Update error message when config validation fails

## What kind of change does this PR introduce?

Bug fix, feature, docs update, ...

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
