### PR TITLE
fix: set hook for email change when only phone identity present

### DIFF
--- a/internal/api/mail.go
+++ b/internal/api/mail.go
@@ -660,10 +660,11 @@ func (a *API) sendEmail(r *http.Request, tx *storage.Connection, u *models.User,
 		if emailActionType == mail.EmailChangeVerification {
 			// When secure email change is disabled, we place the token for the new email on emailData.Token
 			if !config.Mailer.SecureEmailChangeEnabled {
+				// Token Hash should already be set above
 				emailData.Token = otpNew
 			} else {
 				emailData.TokenNew = otpNew
-				emailData.TokenHashNew = u.EmailChangeTokenCurrent
+				emailData.TokenHashNew = tokenHashWithPrefix
 			}
 		}
 		input := hooks.SendEmailInput{

--- a/internal/api/mail.go
+++ b/internal/api/mail.go
@@ -662,7 +662,7 @@ func (a *API) sendEmail(r *http.Request, tx *storage.Connection, u *models.User,
 			SiteURL:         externalURL.String(),
 			TokenHash:       tokenHashWithPrefix,
 		}
-		if emailActionType == mail.EmailChangeVerification && config.Mailer.SecureEmailChangeEnabled && u.GetEmail() != "" {
+		if emailActionType == mail.EmailChangeVerification && config.Mailer.SecureEmailChangeEnabled {
 			emailData.TokenNew = otpNew
 			emailData.TokenHashNew = u.EmailChangeTokenCurrent
 		}

--- a/internal/api/mail.go
+++ b/internal/api/mail.go
@@ -664,7 +664,7 @@ func (a *API) sendEmail(r *http.Request, tx *storage.Connection, u *models.User,
 				emailData.Token = otpNew
 			} else {
 				emailData.TokenNew = otpNew
-				emailData.TokenHashNew = tokenHashWithPrefix
+				emailData.TokenHashNew = u.EmailChangeTokenCurrent
 			}
 		}
 		input := hooks.SendEmailInput{


### PR DESCRIPTION
## What kind of change does this PR introduce?

Currently, there is no token passed in into the email hook when an email change is attempted right after a phone sign up. 