### PR TITLE
fix: Add openid scope by default for Keycloak

### DIFF
--- a/internal/api/provider/keycloak.go
+++ b/internal/api/provider/keycloak.go
@@ -31,6 +31,7 @@ func NewKeycloakProvider(ext conf.OAuthProviderConfiguration, scopes string) (OA
 	oauthScopes := []string{
 		"profile",
 		"email",
+		"openid",
 	}
 
 	if scopes != "" {


### PR DESCRIPTION

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Since Keycloak 19, this is required for the userinfo endpoint to work.

If you try to use Supabase with modern Keycloak, authentication fails with "Error getting user profile from external provider".

## What is the new behavior?

Login with Keycloak works.

## Additional context

