### PR TITLE
fix: idempotent logout

### DIFF
--- a/internal/api/logout.go
+++ b/internal/api/logout.go
@@ -41,6 +41,13 @@ func (a *API) Logout(w http.ResponseWriter, r *http.Request) error {
 	s := getSession(ctx)
 	u := getUser(ctx)
 
+	if u == nil || s == nil {
+		// Neither session or user actually exist, meaning the user is already logged out.
+		w.WriteHeader(http.StatusNoContent)
+
+		return nil
+	}
+
 	err := db.Transaction(func(tx *storage.Connection) error {
 		if terr := models.NewAuditLogEntry(r, tx, u, models.LogoutAction, "", nil); terr != nil {
 			return terr


### PR DESCRIPTION
If there's no user or session when calling logout, the action should be successful.