### PR TITLE
Create sendsms.ro

### DIFF
--- a/internal/api/sms_provider/sendsms.ro
+++ b/internal/api/sms_provider/sendsms.ro
@@ -1,0 +1,122 @@
+package sms_provider
+
+import (
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/supabase/auth/internal/conf"
+	"github.com/supabase/auth/internal/utilities"
+)
+
+const (
+	defaultSendsmsApiBase = "https://api.sendsms.ro/json"
+)
+
+type SendsmsProvider struct {
+	Config *conf.SendsmsProviderConfiguration
+}
+
+// SendsmsResponse represents the response structure from the sendsms.ro API for sending OTP.
+type SendsmsResponse struct {
+	Status  int    `json:"status"`
+	Message string `json:"message"`
+	Salt    string `json:"salt,omitempty"`
+	Expire  string `json:"expire,omitempty"`
+	UID     string `json:"uid,omitempty"`
+}
+
+// SendsmsCheckResponse represents the response structure from the sendsms.ro API for checking OTP.
+type SendsmsCheckResponse struct {
+	Status  int    `json:"status"`
+	Message string `json:"message"`
+	UID     string `json:"uid,omitempty"`
+}
+
+// Creates a SmsProvider with the Sendsms Config
+func NewSendsmsProvider(config conf.SendsmsProviderConfiguration) (SmsProvider, error) {
+	if err := config.Validate(); err != nil {
+		return nil, err
+	}
+
+	return &SendsmsProvider{
+		Config: &config,
+	}, nil
+}
+
+// SendMessage sends an OTP to the specified phone number.
+func (s *SendsmsProvider) SendMessage(phone, message, channel, otp string) (string, error) {
+	return s.SendSms(phone, otp)
+}
+
+// SendSms sends an OTP using the sendsms.ro API.
+func (s *SendsmsProvider) SendSms(phone, otp string) (string, error) {
+	// Prepare the request URL
+	reqURL := fmt.Sprintf("%s?action=otp_send&username=%s&password=%s&from=%s&to=%s&template=%s",
+		defaultSendsmsApiBase, s.Config.Username, s.Config.Password, s.Config.From, phone, url.QueryEscape("Your OTP is: ****"))
+
+	// Send the request
+	resp, err := http.Get(reqURL)
+	if err != nil {
+		return "", err
+	}
+	defer utilities.SafeClose(resp.Body)
+
+	// Decode the response
+	var sendsmsResp SendsmsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&sendsmsResp); err != nil {
+		return "", err
+	}
+
+	if sendsmsResp.Status != 1 {
+		return "", fmt.Errorf("failed to send OTP: %s", sendsmsResp.Message)
+	}
+
+	// Generate the hash using the salt and the OTP
+	hash := GenerateHash(sendsmsResp.Salt, otp)
+
+	// Return the UID and the hash for tracking the OTP
+	return sendsmsResp.UID + ":" + hash, nil
+}
+
+// VerifyOTP checks the OTP using the sendsms.ro API.
+func (s *SendsmsProvider) VerifyOTP(phone, hash string) error {
+	// Split the UID and hash
+	parts := strings.Split(hash, ":")
+	if len(parts) != 2 {
+		return fmt.Errorf("invalid hash format")
+	}
+	uid := parts[0]
+	otpHash := parts[1]
+
+	reqURL := fmt.Sprintf("%s?action=otp_check&username=%s&password=%s&to=%s&hash=%s",
+		defaultSendsmsApiBase, s.Config.Username, s.Config.Password, phone, otpHash)
+
+	// Send the request
+	resp, err := http.Get(reqURL)
+	if err != nil {
+		return err
+	}
+	defer utilities.SafeClose(resp.Body)
+
+	// Decode the response
+	var checkResp SendsmsCheckResponse
+	if err := json.NewDecoder(resp.Body).Decode(&checkResp); err != nil {
+		return err
+	}
+
+	if checkResp.Status != 1 {
+		return fmt.Errorf("OTP check failed: %s", checkResp.Message)
+	}
+
+	return nil
+}
+
+// GenerateHash generates a SHA256 hash using the salt and OTP.
+func GenerateHash(salt, otp string) string {
+	hash := sha256.Sum256([]byte(salt + otp))
+	return fmt.Sprintf("%x", hash)
+}


### PR DESCRIPTION
## What kind of change does this PR introduce?

- [ ] Bug fix
- [x] Feature
- [ ] Documentation update
- [ ] Other (please specify)

## What is the current behavior?

Currently, the OTP sending mechanism does not comply with the zero-knowledge approach. The OTP is sent in clear text, and there is no mechanism to hash the OTP before sending or to replace it in logs. This can lead to security vulnerabilities as the OTP may be exposed in logs or message histories.

Please link any relevant issues here:
- Issue # (if applicable)

## What is the new behavior?

This PR introduces a new implementation for the OTP sending mechanism using the `sendsms.ro` API that adheres to the zero-knowledge approach. Key changes include:

- The OTP is replaced with `****` in the message template sent to the user.
- The OTP is hashed using a salt provided in the response from the `otp_send` API call before being sent for verification.
- The implementation ensures that no clear text OTPs are stored or logged.

### Implementation Details of `sendsms.ro`

[sendsms.ro Documentation](https://www.sendsms.ro/api/#otp-send)

1. **SendsmsProvider Struct**: This struct holds the configuration for the `sendsms.ro` API, including the username, password, and sender label.

2. **SendsmsResponse and SendsmsCheckResponse Structs**: These structs represent the JSON response from the `sendsms.ro` API for sending and checking OTPs, respectively.

3. **NewSendsmsProvider Function**: Initializes a new `SendsmsProvider` instance and validates the configuration.

4. **SendMessage Method**: Responsible for sending an OTP. It calls the `SendSms` method with the phone number and OTP.

5. **SendSms Method**: 
   - Constructs the request URL with the necessary parameters for sending an OTP.
   - Sends a GET request to the `otp_send` endpoint.
   - Replaces the OTP in the message with `****` to ensure it is not exposed.
   - Decodes the response and checks for success.
   - Generates a hash using the salt provided in the response and the OTP, returning the UID and hash for tracking.

6. **VerifyOTP Method**: 
   - Constructs the request URL for the `otp_check` endpoint.
   - Sends a GET request to verify the OTP using the provided hash.
   - Returns whether the OTP is valid or an error message.

## Additional context

- This change enhances the security of the OTP mechanism by ensuring that sensitive information is not exposed.
- The implementation is consistent with the existing SMS providers (Twilio and Textlocal) in terms of structure and error handling.

Add any other context or screenshots.
