### PR TITLE
chore: release as 2.165.2, switch to googleapis/release-please-action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
       RELEASE_CANDIDATE: ${{ steps.versions.outputs.RELEASE_CANDIDATE }}
       RELEASE_NAME: ${{ steps.versions.outputs.RELEASE_NAME }}
     steps:
-      - uses: google-github-actions/release-please-action@v4
+      - uses: googleapis/release-please-action@v4
         id: release
         with:
           release-type: go


### PR DESCRIPTION
Because 2.165.1 was incorrectly made over the release/2.165.0 branch (should have just been a PR to master as 2.165.0 was the latest version) that version number is taken. Now master needs an explicit `Release-As` directive.

Release-As: 2.165.2
