### PR TITLE
feat: fix argon2 parsing and comparison

### DIFF
--- a/internal/crypto/password_test.go
+++ b/internal/crypto/password_test.go
@@ -19,6 +19,10 @@ func TestArgon2(t *testing.T) {
 	for _, example := range examples {
 		assert.NoError(t, CompareHashAndPassword(context.Background(), example, "test"))
 	}
+
+	for _, example := range examples {
+		assert.Error(t, CompareHashAndPassword(context.Background(), example, "test1"))
+	}
 }
 
 func TestGeneratePassword(t *testing.T) {


### PR DESCRIPTION
Argon2 parsing and comparison is broken in multiple ways:

1. Incorrect comparison being done using `ConstantTimeCompare`. This Go API is awful as it returns 1 on _equality_ (unlike all other comparison APIs that return 0) so it was missed.
2. All Argon2 comparisons were producing incorrect derived keys due to the multiplication by 1024. The `argon2.Key` and `IDKey` accept *KiB* as arguments (not bytes!) which caused all hashes to always be incorrect.

Tests didn't catch this as they only tested for the positive case (which passed with flying colors).