### PR TITLE
ci: fix coverage metering by removing files not under test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,6 +65,19 @@ jobs:
         run: make migrate_dev
       - name: Lint and test
         run: make test
+      - name: Cleanup coverage
+        run: |
+          set -x
+
+          # since Go 1.20 these source files need to be deleted from the
+          # coverage profile as they contain legacy or untestable code (like
+          # `main` package)
+
+          sed -i '/^github.com\/supabase\/auth\/client/d' coverage.out
+          sed -i '/^github.com\/supabase\/auth\/cmd/d' coverage.out
+          sed -i '/^github.com\/supabase\/auth\/docs/d' coverage.out
+          sed -i '/^github.com\/supabase\/auth\/main/d' coverage.out
+
       - uses: shogo82148/actions-goveralls@v1
         with:
           path-to-profile: coverage.out


### PR DESCRIPTION
The `-coverpkg` option changed in Go 1.20 and now includes files not under test, which skew the actual coverage.

Files not under test:

- `/cmd` The commands, these run as part of the executable.
- `/client` A non-official admin client that should be removed from the repo in the next major version.
- `/docs` Will be removed in a follow up PR.
- `/main.go` Main file.