### PR TITLE
ci: use `alpine:3` as base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,8 @@ COPY . /go/src/github.com/supabase/auth
 # Make sure you change the RELEASE_VERSION value before publishing an image.
 RUN RELEASE_VERSION=unspecified make build
 
-FROM alpine:3.20
+# Always use alpine:3 so the latest version is used. This will keep CA certs more up to date.
+FROM alpine:3
 RUN adduser -D -u 1000 supabase
 
 RUN apk add --no-cache ca-certificates


### PR DESCRIPTION
Using `alpine:3` means we don't have to worry about updating the base image often, it'll just use whatever latest.