### PR TITLE
docs: correct casing of API key authentication in OpenAPI

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -949,7 +949,7 @@ paths:
       tags:
         - saml
       security:
-        - ApiKeyAuth: []
+        - APIKeyAuth: []
       parameters:
         - name: download
           in: query


### PR DESCRIPTION
## What kind of change does this PR introduce?

fix: correct casing of API key authentication in openapi.yaml
