### PR TITLE
docs: update OpenAPI schema to use 'minimum' instead of 'min' for integer validation

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1146,13 +1146,13 @@ paths:
           in: query
           schema:
             type: integer
-            min: 1
+            minimum: 1
             default: 1
         - name: per_page
           in: query
           schema:
             type: integer
-            min: 1
+            minimum: 1
             default: 50
       responses:
         200:
@@ -1241,13 +1241,13 @@ paths:
           in: query
           schema:
             type: integer
-            min: 1
+            minimum: 1
             default: 1
         - name: per_page
           in: query
           schema:
             type: integer
-            min: 1
+            minimum: 1
             default: 50
       responses:
         200:


### PR DESCRIPTION
## What kind of change does this PR introduce?

fix: update OpenAPI schema to use 'minimum' instead of 'min' for integer validation
ref:https://swagger.io/docs/specification/v3_0/data-models/data-types/#numbers:~:text=2-,minimum,-%3A%201