### PR TITLE
ci: fix unspecified version at runtime in docker images

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -89,6 +89,7 @@ jobs:
 
       - uses: docker/build-push-action@v3
         with:
+          context: . # IMPORTANT: Dockerfile is modified above to include the release version. Don't remove this line: https://github.com/docker/build-push-action?tab=readme-ov-file#git-context
           push: true
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
Docker images are built with the `vunspecified` version, which comes because the release step does not use the current [Git context of the buildx action](https://github.com/docker/build-push-action?tab=readme-ov-file#git-context):

> Be careful because any file mutation in the steps that precede the build step will be ignored, including processing of the .dockerignore file since the context is based on the Git reference. However, you can use the [Path context](https://github.com/docker/build-push-action?tab=readme-ov-file#path-context) using the [context input](https://github.com/docker/build-push-action?tab=readme-ov-file#inputs) alongside the [actions/checkout](https://github.com/actions/checkout/) action to remove this restriction.