### PR TITLE
fix: improve invalid channel error message returned

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [2.168.0](https://github.com/supabase/auth/compare/v2.167.0...v2.168.0) (2025-01-06)
+
+
+### Features
+
+* set `email_verified` to true on all identities with the verified email ([#1902](https://github.com/supabase/auth/issues/1902)) ([307892f](https://github.com/supabase/auth/commit/307892f85b39150074fbb80b9c8f45ac3312aae2))
+
 ## [2.167.0](https://github.com/supabase/auth/compare/v2.166.0...v2.167.0) (2024-12-24)
 
 

--- a/internal/api/errors.go
+++ b/internal/api/errors.go
@@ -20,7 +20,7 @@ var (
 	UserExistsError   error = errors.New("user already exists")
 )
 
-const InvalidChannelError = "Invalid channel, supported values are 'sms' or 'whatsapp'"
+const InvalidChannelError = "Invalid channel, supported values are 'sms' or 'whatsapp'. 'whatsapp' is only supported if twilio or twilio verify is used as the provider."
 
 var oauthErrorMap = map[int]string{
 	http.StatusBadRequest:          "invalid_request",


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Improve error message around invalid channel error for phone auth. Only twilio and twilio verify support whatsapp as a valid channel.