### PR TITLE
ci: fix dogfooding check to identify current latest rc not future rc

### DIFF
--- a/.github/workflows/dogfooding.yml
+++ b/.github/workflows/dogfooding.yml
@@ -17,15 +17,15 @@ jobs:
       - uses: actions/checkout@v4
         if: github.event.pull_request.base.ref == 'master' && github.event.pull_request.head.ref == 'release-please--branches--master'
         with:
-          ref: master # used to identify the current RC version via git describe --tags --exclude rc*
+          ref: master # used to identify the latest RC version via git describe --tags --match rc*
           fetch-depth: 0
 
       - if: github.event.pull_request.base.ref == 'master' && github.event.pull_request.head.ref == 'release-please--branches--master'
         run: |
           set -ex
 
-          MAIN_RELEASE_VERSION=$(node -e "console.log('${{ github.event.pull_request.title }}'.split(' ').reverse().find(x => x.match(/[0-9]+[.][0-9]+[.][0-9]+/)))")
-          RELEASE_VERSION=$MAIN_RELEASE_VERSION-rc.$(node -e "console.log('$(git describe --tags --exclude rc*)'.split('-')[1])")
+          # finds the latest RC version on master
+          RELEASE_VERSION=$(node -e "const a = '$(git describe --tags --match rc*)'.replace(/^rc/, 'v').split('-'); console.log(a[0] + '-' + a[1]);")
 
           PROD_VERSION=$(curl 'https://auth.supabase.io/auth/v1/health' | jq -r .version)
           STAGING_VERSION=$(curl 'https://alt.supabase.green/auth/v1/health' | jq -r .version)


### PR DESCRIPTION
Previously it identified the next RC version, not the currently published one.