### PR TITLE
docs: update `api.go` reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -468,7 +468,7 @@ The base URL used for constructing the URLs to request authorization and access 
 To try out external authentication with Apple locally, you will need to do the following:
 
 1. Remap localhost to \<my_custom_dns \> in your `/etc/hosts` config.
-2. Configure auth to serve HTTPS traffic over localhost by replacing `ListenAndServe` in [api.go](api/api.go) with:
+2. Configure auth to serve HTTPS traffic over localhost by replacing `ListenAndServe` in [api.go](internal/api/api.go) with:
 
    ```
       func (a *API) ListenAndServe(hostAndPort string) {


### PR DESCRIPTION
## What kind of change does this PR introduce?

docs

## What is the current behavior?

Commit 1a52eb6e3aaa5a2331bab2cf233856fa6f6015d8 moved `api.go` to `internal`, without updating all references.

## What is the new behavior?

This PR adjusts sources to changes. 

## Additional context