### PR TITLE
fix: adjust required claims in custom access token hook

### DIFF
--- a/internal/hooks/auth_hooks.go
+++ b/internal/hooks/auth_hooks.go
@@ -94,16 +94,16 @@ const MinimumViableTokenSchema = `{
       "type": "string"
     }
   },
-  "required": ["aud", "exp", "iat", "sub", "email", "phone", "role", "aal", "session_id", "is_anonymous"]
+  "required": ["aud", "exp", "iat", "sub", "role", "aal", "session_id"]
 }`
 
 // AccessTokenClaims is a struct thats used for JWT claims
 type AccessTokenClaims struct {
 	jwt.RegisteredClaims
-	Email                         string                 `json:"email"`
-	Phone                         string                 `json:"phone"`
-	AppMetaData                   map[string]interface{} `json:"app_metadata"`
-	UserMetaData                  map[string]interface{} `json:"user_metadata"`
+	Email                         string                 `json:"email,omitempty"`
+	Phone                         string                 `json:"phone,omitempty"`
+	AppMetaData                   map[string]interface{} `json:"app_metadata,omitempty"`
+	UserMetaData                  map[string]interface{} `json:"user_metadata,omitempty"`
 	Role                          string                 `json:"role"`
 	AuthenticatorAssuranceLevel   string                 `json:"aal,omitempty"`
 	AuthenticationMethodReference []models.AMREntry      `json:"amr,omitempty"`


### PR DESCRIPTION
`email` and `phone` should not be required as they are not used by Supabase Auth for anything meaningful. They also don't have to exist (but are probably set as `""` today) if using just email provider, or just phone provider, or anonymous sign-ins, etc.

`is_anonymous` also is not required as it depends on whether it's used in RLS policies.

`iss` _should be_ added but it's not as it only makes sense with asymmetric JWTs. Additional validation on this will follow.
