### PR TITLE
fix: convert refreshed_at to UTC before updating

### DIFF
--- a/internal/models/sessions.go
+++ b/internal/models/sessions.go
@@ -103,6 +103,10 @@ func (s *Session) LastRefreshedAt(refreshTokenTime *time.Time) time.Time {
 }
 
 func (s *Session) UpdateOnlyRefreshInfo(tx *storage.Connection) error {
+	// TODO(kangmingtay): The underlying database type uses timestamp without timezone,
+	// so we need to convert the value to UTC before updating it.
+	// In the future, we should add a migration to update the type to contain the timezone.
+	*s.RefreshedAt = s.RefreshedAt.UTC()
 	return tx.UpdateOnly(s, "refreshed_at", "user_agent", "ip")
 }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Fixes an issue with session inactivity timeout where the session's `refreshed_at` time is being saved without the timezone since the underlying postgres type uses `timestamp without time zone`. This means that when the timestamp is later queried from the database, go assumes that the timestamp is in UTC (since there's no timezone information stored). 