### PR TITLE
feat: Add custom claims from Keycloak user token

### DIFF
--- a/internal/api/provider/keycloak.go
+++ b/internal/api/provider/keycloak.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"strings"
 
@@ -16,10 +17,33 @@ type keycloakProvider struct {
 }
 
 type keycloakUser struct {
-	Name          string `json:"name"`
-	Sub           string `json:"sub"`
-	Email         string `json:"email"`
-	EmailVerified bool   `json:"email_verified"`
+	Name          string                 `json:"name"`
+	Sub           string                 `json:"sub"`
+	Email         string                 `json:"email"`
+	EmailVerified bool                   `json:"email_verified"`
+	RawClaims     map[string]interface{} `json:"-"`
+}
+
+func (u *keycloakUser) UnmarshalJSON(data []byte) error {
+	if err := json.Unmarshal(data, &u.RawClaims); err != nil {
+		return err
+	}
+
+	// Extract known fields
+	if v, ok := u.RawClaims["name"].(string); ok {
+		u.Name = v
+	}
+	if v, ok := u.RawClaims["sub"].(string); ok {
+		u.Sub = v
+	}
+	if v, ok := u.RawClaims["email"].(string); ok {
+		u.Email = v
+	}
+	if v, ok := u.RawClaims["email_verified"].(bool); ok {
+		u.EmailVerified = v
+	}
+
+	return nil
 }
 
 // NewKeycloakProvider creates a Keycloak account provider.
@@ -72,6 +96,17 @@ func (g keycloakProvider) GetUserData(ctx context.Context, tok *oauth2.Token) (*
 		return nil, err
 	}
 
+	customClaims := make(map[string]interface{})
+	standardClaims := map[string]bool{
+		"name": true, "sub": true, "email": true, "email_verified": true,
+	}
+
+	for k, v := range u.RawClaims {
+		if !standardClaims[k] {
+			customClaims[k] = v
+		}
+	}
+
 	data := &UserProvidedData{}
 	if u.Email != "" {
 		data.Emails = []Email{{
@@ -87,6 +122,7 @@ func (g keycloakProvider) GetUserData(ctx context.Context, tok *oauth2.Token) (*
 		Name:          u.Name,
 		Email:         u.Email,
 		EmailVerified: u.EmailVerified,
+		CustomClaims:  customClaims,
 
 		// To be deprecated
 		FullName:   u.Name,


### PR DESCRIPTION
## What kind of change does this PR introduce?

This change will populate the `CustomClaims` field from the `Claims` struct with 'other' claims from the Keycloak user token.

## What is the current behavior?

Currently only `Name`, `Sub`, `Email`, and `EmailVerified` are taken from the Keycloak user token.

## What is the new behavior?

The "custom_claims" field in the retrieved JWT is populated. 

## Additional context

* https://github.com/orgs/supabase/discussions/18909
