### PR TITLE
feat: allow minimising the jwt size by omitting additional claims

### DIFF
--- a/example.env
+++ b/example.env
@@ -6,6 +6,7 @@ GOTRUE_JWT_EXP="3600"
 GOTRUE_JWT_AUD="authenticated"
 GOTRUE_JWT_DEFAULT_GROUP_NAME="authenticated"
 GOTRUE_JWT_ADMIN_ROLES="supabase_admin,service_role"
+GOTRUE_JWT_ADDITIONAL_CLAIMS="email,phone,app_metadata,user_metadata,amr,is_anonymous"
 
 # Database & API connection details
 GOTRUE_DB_DRIVER="postgres"

--- a/internal/api/token.go
+++ b/internal/api/token.go
@@ -31,7 +31,7 @@ type AccessTokenClaims struct {
 	AuthenticatorAssuranceLevel   string                 `json:"aal,omitempty"`
 	AuthenticationMethodReference []models.AMREntry      `json:"amr,omitempty"`
 	SessionId                     string                 `json:"session_id,omitempty"`
-	IsAnonymous                   bool                   `json:"is_anonymous"`
+	IsAnonymous                   bool                   `json:"is_anonymous,omitempty"`
 }
 
 // AccessTokenResponse represents an OAuth2 success response
@@ -339,8 +339,8 @@ func (a *API) generateAccessToken(r *http.Request, tx *storage.Connection, user 
 	}
 
 	// add additional claims that are optional
-	for _, rc := range config.JWT.AdditionalClaims {
-		switch rc {
+	for _, ac := range config.JWT.AdditionalClaims {
+		switch ac {
 		case "email":
 			claims.Email = user.GetEmail()
 		case "phone":

--- a/internal/api/token.go
+++ b/internal/api/token.go
@@ -31,7 +31,7 @@ type AccessTokenClaims struct {
 	AuthenticatorAssuranceLevel   string                 `json:"aal,omitempty"`
 	AuthenticationMethodReference []models.AMREntry      `json:"amr,omitempty"`
 	SessionId                     string                 `json:"session_id,omitempty"`
-	IsAnonymous                   bool                   `json:"is_anonymous,omitempty"`
+	IsAnonymous                   bool                   `json:"is_anonymous"`
 }
 
 // AccessTokenResponse represents an OAuth2 success response
@@ -336,6 +336,7 @@ func (a *API) generateAccessToken(r *http.Request, tx *storage.Connection, user 
 		AuthenticatorAssuranceLevel: aal.String(),
 		SessionId:                   sid,
 		Role:                        user.Role,
+		IsAnonymous:                 user.IsAnonymous,
 	}
 
 	// add additional claims that are optional
@@ -351,8 +352,6 @@ func (a *API) generateAccessToken(r *http.Request, tx *storage.Connection, user 
 			claims.UserMetaData = user.UserMetaData
 		case "amr":
 			claims.AuthenticationMethodReference = amr
-		case "is_anonymous":
-			claims.IsAnonymous = user.IsAnonymous
 		}
 	}
 

--- a/internal/api/token.go
+++ b/internal/api/token.go
@@ -23,9 +23,9 @@ import (
 // AccessTokenClaims is a struct thats used for JWT claims
 type AccessTokenClaims struct {
 	jwt.RegisteredClaims
-	Email                         string                 `json:"email"`
-	Phone                         string                 `json:"phone"`
-	AppMetaData                   map[string]interface{} `json:"app_metadata"`
+	Email                         string                 `json:"email,omitempty"`
+	Phone                         string                 `json:"phone,omitempty"`
+	AppMetaData                   map[string]interface{} `json:"app_metadata,omitempty"`
 	UserMetaData                  map[string]interface{} `json:"user_metadata"`
 	Role                          string                 `json:"role"`
 	AuthenticatorAssuranceLevel   string                 `json:"aal,omitempty"`
@@ -333,15 +333,27 @@ func (a *API) generateAccessToken(r *http.Request, tx *storage.Connection, user 
 			ExpiresAt: jwt.NewNumericDate(expiresAt),
 			Issuer:    config.JWT.Issuer,
 		},
-		Email:                         user.GetEmail(),
-		Phone:                         user.GetPhone(),
-		AppMetaData:                   user.AppMetaData,
-		UserMetaData:                  user.UserMetaData,
-		Role:                          user.Role,
-		SessionId:                     sid,
-		AuthenticatorAssuranceLevel:   aal.String(),
-		AuthenticationMethodReference: amr,
-		IsAnonymous:                   user.IsAnonymous,
+		AuthenticatorAssuranceLevel: aal.String(),
+		SessionId:                   sid,
+		Role:                        user.Role,
+	}
+
+	// add additional claims that are optional
+	for _, rc := range config.JWT.AdditionalClaims {
+		switch rc {
+		case "email":
+			claims.Email = user.GetEmail()
+		case "phone":
+			claims.Phone = user.GetPhone()
+		case "app_metadata":
+			claims.AppMetaData = user.AppMetaData
+		case "user_metadata":
+			claims.UserMetaData = user.UserMetaData
+		case "amr":
+			claims.AuthenticationMethodReference = amr
+		case "is_anonymous":
+			claims.IsAnonymous = user.IsAnonymous
+		}
 	}
 
 	var gotrueClaims jwt.Claims = claims

--- a/internal/api/token_test.go
+++ b/internal/api/token_test.go
@@ -862,7 +862,7 @@ func (ts *TokenTestSuite) TestConfigureAccessToken() {
 		additionalClaimsConfig []string
 		expectedClaims         []string
 	}
-	requiredClaims := []string{"aud", "exp", "iat", "sub", "role", "aal", "session_id", "user_metadata"}
+	requiredClaims := []string{"aud", "exp", "iat", "sub", "role", "aal", "session_id", "user_metadata", "is_anonymous"}
 	cases := []customAccessTokenTestcase{
 
 		{

--- a/internal/api/token_test.go
+++ b/internal/api/token_test.go
@@ -855,3 +855,67 @@ $$;`
 		})
 	}
 }
+
+func (ts *TokenTestSuite) TestConfigureAccessToken() {
+	type customAccessTokenTestcase struct {
+		desc                   string
+		additionalClaimsConfig []string
+		expectedClaims         []string
+	}
+	requiredClaims := []string{"aud", "exp", "iat", "sub", "role", "aal", "session_id", "user_metadata"}
+	cases := []customAccessTokenTestcase{
+
+		{
+			desc:                   "Default claims all present",
+			additionalClaimsConfig: []string{"empty"},
+			expectedClaims:         requiredClaims,
+		}, {
+			desc:                   "Minimal set of claims is returned",
+			additionalClaimsConfig: []string{},
+			expectedClaims:         requiredClaims,
+		},
+		{
+			desc:                   "Selected additional claims are returned",
+			additionalClaimsConfig: []string{"email"},
+			expectedClaims:         append(requiredClaims, []string{"email"}...),
+		},
+	}
+	for _, c := range cases {
+		ts.T().Run(c.desc, func(t *testing.T) {
+			ts.Config.JWT.AdditionalClaims = c.additionalClaimsConfig
+
+			var buffer bytes.Buffer
+			require.NoError(t, json.NewEncoder(&buffer).Encode(map[string]interface{}{
+				"refresh_token": ts.RefreshToken.Token,
+			}))
+
+			req := httptest.NewRequest(http.MethodPost, "http://localhost/token?grant_type=refresh_token", &buffer)
+			req.Header.Set("Content-Type", "application/json")
+
+			w := httptest.NewRecorder()
+			ts.API.handler.ServeHTTP(w, req)
+
+			var tokenResponse struct {
+				AccessToken string `json:"access_token"`
+			}
+			require.NoError(t, json.NewDecoder(w.Result().Body).Decode(&tokenResponse))
+			parts := strings.Split(tokenResponse.AccessToken, ".")
+			require.Equal(t, 3, len(parts), "Token should have 3 parts")
+
+			payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+			require.NoError(t, err)
+
+			var responseClaims map[string]interface{}
+			require.NoError(t, json.Unmarshal(payload, &responseClaims))
+
+			assert.Len(t, responseClaims, len(c.expectedClaims), "More or less claims in the response than expected")
+			for _, expectedClaim := range c.expectedClaims {
+				_, exists := responseClaims[expectedClaim]
+				assert.True(t, exists, "Claim should exist {%s}", expectedClaim)
+			}
+
+			// reset
+			ts.Config.JWT.AdditionalClaims = []string{"email", "phone", "app_metadata", "user_metadata", "amr", "is_anonymous"}
+		})
+	}
+}

--- a/internal/conf/configuration.go
+++ b/internal/conf/configuration.go
@@ -887,6 +887,15 @@ func (config *GlobalConfiguration) ApplyDefaults() error {
 		config.JWT.AdminRoles = []string{"service_role", "supabase_admin"}
 	}
 
+	// default to all claims that were / are available at the time of this change
+	// to ensure backwards compatibility. To exclude all these claims, the value
+	// of jwt.additional_claims can be set to an invalid claim, such as "none", "empty", "null"
+	// also allow setting to default claims using the "default" keyword, making it possible to use
+	// this config as a binary flag "none" == use_mimimal_jwt == true, "default" == use_mimimal_jwt == false
+	if len(config.JWT.AdditionalClaims) == 0 || (len(config.JWT.AdditionalClaims) == 1 && config.JWT.AdditionalClaims[0] == "default") {
+		config.JWT.AdditionalClaims = []string{"email", "phone", "app_metadata", "user_metadata", "amr", "is_anonymous"}
+	}
+
 	if config.JWT.Exp == 0 {
 		config.JWT.Exp = 3600
 	}

--- a/internal/conf/configuration.go
+++ b/internal/conf/configuration.go
@@ -893,7 +893,7 @@ func (config *GlobalConfiguration) ApplyDefaults() error {
 	// also allow setting to default claims using the "default" keyword, making it possible to use
 	// this config as a binary flag "none" == use_mimimal_jwt == true, "default" == use_mimimal_jwt == false
 	if len(config.JWT.AdditionalClaims) == 0 || (len(config.JWT.AdditionalClaims) == 1 && config.JWT.AdditionalClaims[0] == "default") {
-		config.JWT.AdditionalClaims = []string{"email", "phone", "app_metadata", "user_metadata", "amr", "is_anonymous"}
+		config.JWT.AdditionalClaims = []string{"email", "phone", "app_metadata", "user_metadata", "amr"}
 	}
 
 	if config.JWT.Exp == 0 {

--- a/internal/conf/configuration.go
+++ b/internal/conf/configuration.go
@@ -111,6 +111,7 @@ type JWTConfiguration struct {
 	KeyID            string         `json:"key_id" split_words:"true"`
 	Keys             JwtKeysDecoder `json:"keys"`
 	ValidMethods     []string       `json:"-"`
+	AdditionalClaims []string       `json:"additional_claims" split_words:"true"`
 }
 
 type MFAFactorTypeConfiguration struct {

--- a/internal/hooks/auth_hooks.go
+++ b/internal/hooks/auth_hooks.go
@@ -100,15 +100,15 @@ const MinimumViableTokenSchema = `{
 // AccessTokenClaims is a struct thats used for JWT claims
 type AccessTokenClaims struct {
 	jwt.RegisteredClaims
-	Email                         string                 `json:"email"`
-	Phone                         string                 `json:"phone"`
-	AppMetaData                   map[string]interface{} `json:"app_metadata"`
+	Email                         string                 `json:"email,omitempty"`
+	Phone                         string                 `json:"phone,omitempty"`
+	AppMetaData                   map[string]interface{} `json:"app_metadata,omitempty"`
 	UserMetaData                  map[string]interface{} `json:"user_metadata"`
 	Role                          string                 `json:"role"`
 	AuthenticatorAssuranceLevel   string                 `json:"aal,omitempty"`
 	AuthenticationMethodReference []models.AMREntry      `json:"amr,omitempty"`
 	SessionId                     string                 `json:"session_id,omitempty"`
-	IsAnonymous                   bool                   `json:"is_anonymous"`
+	IsAnonymous                   bool                   `json:"is_anonymous,omitempty"`
 }
 
 type MFAVerificationAttemptInput struct {

--- a/internal/hooks/auth_hooks.go
+++ b/internal/hooks/auth_hooks.go
@@ -94,7 +94,7 @@ const MinimumViableTokenSchema = `{
       "type": "string"
     }
   },
-  "required": ["aud", "exp", "iat", "sub", "email", "phone", "role", "aal", "session_id", "is_anonymous"]
+  "required": ["aud", "exp", "iat", "sub", "role", "aal", "session_id"]
 }`
 
 // AccessTokenClaims is a struct thats used for JWT claims
@@ -108,7 +108,7 @@ type AccessTokenClaims struct {
 	AuthenticatorAssuranceLevel   string                 `json:"aal,omitempty"`
 	AuthenticationMethodReference []models.AMREntry      `json:"amr,omitempty"`
 	SessionId                     string                 `json:"session_id,omitempty"`
-	IsAnonymous                   bool                   `json:"is_anonymous,omitempty"`
+	IsAnonymous                   bool                   `json:"is_anonymous"`
 }
 
 type MFAVerificationAttemptInput struct {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

## What is the current behavior?

JWT claims are not controllable, other than using a custom access hook. This can lead to large JWTs containing claims that might not be needed.

## What is the new behavior?

Adds a configuration to control which claims outside of the required claims can be added to the JWT automatically.

## Additional context

To be backward compatible, the default is to include all supported claims in the generated JWT. To have fewer claims, the config option `jwt.additional_claims` can be modified with the claims to include. Because the currently deployed (hosted and self-hosted) version does not have this config option, the decision to apply this default is based on the config value being empty. And empty value could also mean "don't include any additional claims", which would immediately break backwards compatibility as JWTs would suddenly not contain the optional claims. To simulate an empty set, it is possible to simply include an unknown claim, which would get ignored. It could make sense to standardise on a reserved word for this configuration.

Slightly depends on https://github.com/supabase/auth/pull/1913 to determine if some fields that are not yet `omitempty` should be set to a default value.
