### PR TITLE
fix: ignore not found error to check for pkce prefix later

### DIFF
--- a/internal/models/one_time_token.go
+++ b/internal/models/one_time_token.go
@@ -218,7 +218,7 @@ func FindUserByEmailChangeToken(tx *storage.Connection, token string) (*User, er
 // FindUserByEmailChangeCurrentAndAudience finds a user with the matching email change and audience.
 func FindUserByEmailChangeCurrentAndAudience(tx *storage.Connection, email, token, aud string) (*User, error) {
 	ott, err := FindOneTimeToken(tx, token, EmailChangeTokenCurrent)
-	if err != nil {
+	if err != nil && !IsNotFoundError(err) {
 		return nil, err
 	}
 


### PR DESCRIPTION
## What kind of change does this PR introduce?
* `POST /verify` fails for email change when PKCE is used and `GOTRUE_MAILER_SECURE_EMAIL_CHANGE_ENABLED` is enabled because the query to retrieve the token returns an error if the token is not found instead of trying again with the `pkce_` prefix
