### PR TITLE
fix: enable SO_REUSEPORT in listener config

### DIFF
--- a/cmd/serve_cmd.go
+++ b/cmd/serve_cmd.go
@@ -5,6 +5,7 @@ import (
 	"net"
 	"net/http"
 	"sync"
+	"syscall"
 	"time"
 
 	"github.com/pkg/errors"
@@ -105,7 +106,23 @@ func serve(ctx context.Context) {
 		}
 	}()
 
-	if err := httpSrv.ListenAndServe(); err != http.ErrServerClosed {
+	lc := net.ListenConfig{
+		Control: func(network, address string, c syscall.RawConn) error {
+			var serr error
+			if err := c.Control(func(fd uintptr) {
+				// hard-coded syscall.SO_REUSEPORT since it doesn't seem to be defined in different environments
+				serr = syscall.SetsockoptInt(int(fd), syscall.SOL_SOCKET, 0x200, 1)
+			}); err != nil {
+				return err
+			}
+			return serr
+		},
+	}
+	listener, err := lc.Listen(ctx, "tcp", addr)
+	if err != nil {
 		log.WithError(err).Fatal("http server listen failed")
+	}
+	if err := httpSrv.Serve(listener); err != nil {
+		log.WithError(err).Fatal("http server serve failed")
 	}
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Enables `SO_REUSEPORT` which allows multiple sockets to bind to the same address and port - this is useful when the auth service needs to be restarted and the port is still being held by a reverse proxy (i.e. envoy) until all the connections are drained
