### PR TITLE
fix: propagate error when when confirming phone

### DIFF
--- a/internal/models/user.go
+++ b/internal/models/user.go
@@ -468,7 +468,7 @@ func (u *User) ConfirmPhone(tx *storage.Connection) error {
 	now := time.Now()
 	u.PhoneConfirmedAt = &now
 	if err := tx.UpdateOnly(u, "confirmation_token", "phone_confirmed_at"); err != nil {
-		return nil
+		return err
 	}
 
 	return ClearAllOneTimeTokensForUser(tx, u.ID)


### PR DESCRIPTION
Propagate errors that occur when calling tx.UpdateOnly in internal/models/user.go:ConfirmPhone.

Previously this line returned nil:
https://github.com/supabase/auth/blob/097f01f39fa79d5e8e4e9c399a14e14405e3a142/internal/models/user.go#L471

Meaning that the next call to ClearAllOneTimeTokensForUser was ran even when the confirmation token could not be updated.
https://github.com/supabase/auth/blob/master/internal/models/one_time_token.go#L119