### PR TITLE
fix error described in issue #1940 by making all tokens DEFAULT ''

### DIFF
--- a/migrations/20250210211800_users_tokens_default_empty.sql
+++ b/migrations/20250210211800_users_tokens_default_empty.sql
@@ -1,0 +1,12 @@
+BEGIN;
+
+ALTER TABLE auth.users
+  ALTER COLUMN confirmation_token SET DEFAULT '';
+ALTER TABLE auth.users
+  ALTER COLUMN recovery_token SET DEFAULT '';
+ALTER TABLE auth.users
+  ALTER COLUMN email_change_token_new SET DEFAULT '';
+ALTER TABLE auth.users
+  ALTER COLUMN email_change SET DEFAULT '';
+
+COMMIT;


### PR DESCRIPTION
fix: make all auth.users tokens fields default empty

fix error authenticating users created via sql functions. the issue causes token generation to fail during the user lookup due to an sql error

https://github.com/supabase/auth/issues/1940