### PR TITLE
feat: allow alphanumeric and alphabetic (lower, upper and mixed case) as configuration options for the characters used by the OTP

### DIFF
--- a/internal/api/mail.go
+++ b/internal/api/mail.go
@@ -87,7 +87,7 @@ func (a *API) adminGenerateLink(w http.ResponseWriter, r *http.Request) error {
 
 	var url string
 	now := time.Now()
-	otp := crypto.GenerateOtp(config.Mailer.OtpLength)
+	otp := crypto.GenerateOtp(config.Mailer.OtpLength, config.Mailer.OtpCharset)
 
 	hashedToken := crypto.GenerateTokenHash(params.Email, otp)
 
@@ -301,12 +301,13 @@ func (a *API) sendConfirmation(r *http.Request, tx *storage.Connection, u *model
 	config := a.config
 	maxFrequency := config.SMTP.MaxFrequency
 	otpLength := config.Mailer.OtpLength
+	otpCharset := config.Mailer.OtpCharset
 
 	if err = validateSentWithinFrequencyLimit(u.ConfirmationSentAt, maxFrequency); err != nil {
 		return err
 	}
 	oldToken := u.ConfirmationToken
-	otp := crypto.GenerateOtp(otpLength)
+	otp := crypto.GenerateOtp(otpLength, otpCharset)
 
 	token := crypto.GenerateTokenHash(u.GetEmail(), otp)
 	u.ConfirmationToken = addFlowPrefixToToken(token, flowType)
@@ -335,9 +336,10 @@ func (a *API) sendConfirmation(r *http.Request, tx *storage.Connection, u *model
 func (a *API) sendInvite(r *http.Request, tx *storage.Connection, u *models.User) error {
 	config := a.config
 	otpLength := config.Mailer.OtpLength
+	otpCharset := config.Mailer.OtpCharset
 	var err error
 	oldToken := u.ConfirmationToken
-	otp := crypto.GenerateOtp(otpLength)
+	otp := crypto.GenerateOtp(otpLength, otpCharset)
 
 	u.ConfirmationToken = crypto.GenerateTokenHash(u.GetEmail(), otp)
 	now := time.Now()
@@ -368,13 +370,14 @@ func (a *API) sendInvite(r *http.Request, tx *storage.Connection, u *models.User
 func (a *API) sendPasswordRecovery(r *http.Request, tx *storage.Connection, u *models.User, flowType models.FlowType) error {
 	config := a.config
 	otpLength := config.Mailer.OtpLength
+	otpCharset := config.Mailer.OtpCharset
 
 	if err := validateSentWithinFrequencyLimit(u.RecoverySentAt, config.SMTP.MaxFrequency); err != nil {
 		return err
 	}
 
 	oldToken := u.RecoveryToken
-	otp := crypto.GenerateOtp(otpLength)
+	otp := crypto.GenerateOtp(otpLength, otpCharset)
 
 	token := crypto.GenerateTokenHash(u.GetEmail(), otp)
 	u.RecoveryToken = addFlowPrefixToToken(token, flowType)
@@ -405,13 +408,14 @@ func (a *API) sendReauthenticationOtp(r *http.Request, tx *storage.Connection, u
 	config := a.config
 	maxFrequency := config.SMTP.MaxFrequency
 	otpLength := config.Mailer.OtpLength
+	otpCharset := config.Mailer.OtpCharset
 
 	if err := validateSentWithinFrequencyLimit(u.ReauthenticationSentAt, maxFrequency); err != nil {
 		return err
 	}
 
 	oldToken := u.ReauthenticationToken
-	otp := crypto.GenerateOtp(otpLength)
+	otp := crypto.GenerateOtp(otpLength, otpCharset)
 
 	u.ReauthenticationToken = crypto.GenerateTokenHash(u.GetEmail(), otp)
 	now := time.Now()
@@ -441,6 +445,7 @@ func (a *API) sendMagicLink(r *http.Request, tx *storage.Connection, u *models.U
 	var err error
 	config := a.config
 	otpLength := config.Mailer.OtpLength
+	otpCharset := config.Mailer.OtpCharset
 
 	// since Magic Link is just a recovery with a different template and behaviour
 	// around new users we will reuse the recovery db timer to prevent potential abuse
@@ -449,7 +454,7 @@ func (a *API) sendMagicLink(r *http.Request, tx *storage.Connection, u *models.U
 	}
 
 	oldToken := u.RecoveryToken
-	otp := crypto.GenerateOtp(otpLength)
+	otp := crypto.GenerateOtp(otpLength, otpCharset)
 
 	token := crypto.GenerateTokenHash(u.GetEmail(), otp)
 	u.RecoveryToken = addFlowPrefixToToken(token, flowType)
@@ -480,12 +485,13 @@ func (a *API) sendMagicLink(r *http.Request, tx *storage.Connection, u *models.U
 func (a *API) sendEmailChange(r *http.Request, tx *storage.Connection, u *models.User, email string, flowType models.FlowType) error {
 	config := a.config
 	otpLength := config.Mailer.OtpLength
+	otpCharset := config.Mailer.OtpCharset
 
 	if err := validateSentWithinFrequencyLimit(u.EmailChangeSentAt, config.SMTP.MaxFrequency); err != nil {
 		return err
 	}
 
-	otpNew := crypto.GenerateOtp(otpLength)
+	otpNew := crypto.GenerateOtp(otpLength, otpCharset)
 
 	u.EmailChange = email
 	token := crypto.GenerateTokenHash(u.EmailChange, otpNew)
@@ -493,7 +499,7 @@ func (a *API) sendEmailChange(r *http.Request, tx *storage.Connection, u *models
 
 	otpCurrent := ""
 	if config.Mailer.SecureEmailChangeEnabled && u.GetEmail() != "" {
-		otpCurrent = crypto.GenerateOtp(otpLength)
+		otpCurrent = crypto.GenerateOtp(otpLength, otpCharset)
 
 		currentToken := crypto.GenerateTokenHash(u.GetEmail(), otpCurrent)
 		u.EmailChangeTokenCurrent = addFlowPrefixToToken(currentToken, flowType)

--- a/internal/api/mfa.go
+++ b/internal/api/mfa.go
@@ -394,7 +394,7 @@ func (a *API) challengePhoneFactor(w http.ResponseWriter, r *http.Request) error
 		}
 	}
 
-	otp := crypto.GenerateOtp(config.MFA.Phone.OtpLength)
+	otp := crypto.GenerateOtp(config.MFA.Phone.OtpLength, config.MFA.Phone.OtpCharset)
 
 	challenge, err := factor.CreatePhoneChallenge(ipAddress, otp, config.Security.DBEncryption.Encrypt, config.Security.DBEncryption.EncryptionKeyID, config.Security.DBEncryption.EncryptionKey)
 	if err != nil {

--- a/internal/api/mfa_test.go
+++ b/internal/api/mfa_test.go
@@ -525,7 +525,7 @@ func (ts *MFATestSuite) TestMFAVerifyFactor() {
 			} else if v.factorType == models.Phone {
 				friendlyName := uuid.Must(uuid.NewV4()).String()
 				numDigits := 10
-				otp := crypto.GenerateOtp(numDigits)
+				otp := crypto.GenerateOtp(numDigits, "numeric")
 				require.NoError(ts.T(), err)
 				phone := fmt.Sprintf("+%s", otp)
 				f = models.NewPhoneFactor(ts.TestUser, phone, friendlyName)

--- a/internal/api/phone.go
+++ b/internal/api/phone.go
@@ -92,7 +92,7 @@ func (a *API) sendPhoneConfirmation(r *http.Request, tx *storage.Connection, use
 				return "", tooManyRequestsError(ErrorCodeOverSMSSendRateLimit, "SMS rate limit exceeded")
 			}
 		}
-		otp = crypto.GenerateOtp(config.Sms.OtpLength)
+		otp = crypto.GenerateOtp(config.Sms.OtpLength, config.Sms.OtpCharset)
 
 		if config.Hook.SendSMS.Enabled {
 			input := hooks.SendSMSInput{

--- a/internal/conf/configuration.go
+++ b/internal/conf/configuration.go
@@ -127,6 +127,7 @@ type PhoneFactorTypeConfiguration struct {
 	// Default to false in order to ensure Phone MFA is opt-in
 	MFAFactorTypeConfiguration
 	OtpLength    int                `json:"otp_length" split_words:"true"`
+	OtpCharset   OtpCharset         `json:"otp_charset" split_words:"true"`
 	SMSTemplate  *template.Template `json:"-"`
 	MaxFrequency time.Duration      `json:"max_frequency" split_words:"true"`
 	Template     string             `json:"template"`
@@ -385,6 +386,43 @@ func (c *SMTPConfiguration) NormalizedHeaders() map[string][]string {
 	return c.normalizedHeaders
 }
 
+type OtpCharset string
+
+const (
+	Numeric           OtpCharset = "numeric"
+	LowerAlphanumeric OtpCharset = "lower_alphanumeric"
+	UpperAlphanumeric OtpCharset = "upper_alphanumeric"
+	MixedAlphanumeric OtpCharset = "mixed_alphanumeric"
+	LowerAlphabetic   OtpCharset = "lower_alphabetic"
+	UpperAlphabetic   OtpCharset = "upper_alphabetic"
+	MixedAlphabetic   OtpCharset = "mixed_alphabetic"
+)
+
+const digits = "0123456789"
+const lowercaseLetters = "abcdefghijklmnopqrstuvwxyz"
+const uppercaseLetters = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+
+func GetCharactersForCharset(charset OtpCharset) (string, error) {
+	switch charset {
+	case Numeric:
+		return digits, nil
+	case LowerAlphanumeric:
+		return digits + lowercaseLetters, nil
+	case UpperAlphanumeric:
+		return digits + uppercaseLetters, nil
+	case MixedAlphanumeric:
+		return digits + lowercaseLetters + uppercaseLetters, nil
+	case LowerAlphabetic:
+		return lowercaseLetters, nil
+	case UpperAlphabetic:
+		return uppercaseLetters, nil
+	case MixedAlphabetic:
+		return lowercaseLetters + uppercaseLetters, nil
+	default:
+		return "", fmt.Errorf("invalid OtpCharset option: %s", charset)
+	}
+}
+
 type MailerConfiguration struct {
 	Autoconfirm                 bool `json:"autoconfirm"`
 	AllowUnverifiedEmailSignIns bool `json:"allow_unverified_email_sign_ins" split_words:"true" default:"false"`
@@ -395,8 +433,9 @@ type MailerConfiguration struct {
 
 	SecureEmailChangeEnabled bool `json:"secure_email_change_enabled" split_words:"true" default:"true"`
 
-	OtpExp    uint `json:"otp_exp" split_words:"true"`
-	OtpLength int  `json:"otp_length" split_words:"true"`
+	OtpExp     uint       `json:"otp_exp" split_words:"true"`
+	OtpLength  int        `json:"otp_length" split_words:"true"`
+	OtpCharset OtpCharset `json:"otp_charset" split_words:"true"`
 
 	ExternalHosts []string `json:"external_hosts" split_words:"true"`
 
@@ -437,6 +476,7 @@ type SmsProviderConfiguration struct {
 	MaxFrequency      time.Duration      `json:"max_frequency" split_words:"true"`
 	OtpExp            uint               `json:"otp_exp" split_words:"true"`
 	OtpLength         int                `json:"otp_length" split_words:"true"`
+	OtpCharset        OtpCharset         `json:"otp_charset" split_words:"true"`
 	Provider          string             `json:"provider"`
 	Template          string             `json:"template"`
 	TestOTP           map[string]string  `json:"test_otp" split_words:"true"`

--- a/internal/conf/configuration.go
+++ b/internal/conf/configuration.go
@@ -985,6 +985,10 @@ func (config *GlobalConfiguration) ApplyDefaults() error {
 		config.Mailer.OtpLength = 6
 	}
 
+	if config.Mailer.OtpCharset == "" {
+		config.Mailer.OtpCharset = "numeric"
+	}
+
 	if config.SMTP.MaxFrequency == 0 {
 		config.SMTP.MaxFrequency = 1 * time.Minute
 	}
@@ -1000,6 +1004,10 @@ func (config *GlobalConfiguration) ApplyDefaults() error {
 	if config.Sms.OtpLength == 0 || config.Sms.OtpLength < 6 || config.Sms.OtpLength > 10 {
 		// 6-digit otp by default
 		config.Sms.OtpLength = 6
+	}
+
+	if config.Sms.OtpCharset == "" {
+		config.Sms.OtpCharset = "numeric"
 	}
 
 	if config.Sms.TestOTP != nil {
@@ -1046,6 +1054,10 @@ func (config *GlobalConfiguration) ApplyDefaults() error {
 	if config.MFA.Phone.OtpLength < 6 || config.MFA.Phone.OtpLength > 10 {
 		// 6-digit otp by default
 		config.MFA.Phone.OtpLength = 6
+	}
+
+	if config.MFA.Phone.OtpCharset == "" {
+		config.MFA.Phone.OtpCharset = "numeric"
 	}
 
 	if config.External.FlowStateExpiryDuration < defaultFlowStateExpiryDuration {

--- a/internal/crypto/crypto.go
+++ b/internal/crypto/crypto.go
@@ -8,10 +8,9 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"github.com/supabase/auth/internal/conf"
 	"io"
-	"math"
 	"math/big"
-	"strconv"
 	"strings"
 
 	"golang.org/x/crypto/hkdf"
@@ -26,15 +25,18 @@ func SecureToken() string {
 }
 
 // GenerateOtp generates a random n digit otp
-func GenerateOtp(digits int) string {
-	upper := math.Pow10(digits)
-	val := must(rand.Int(rand.Reader, big.NewInt(int64(upper))))
+func GenerateOtp(digits int, charset conf.OtpCharset) string {
+	characters := must(conf.GetCharactersForCharset(charset))
 
-	// adds a variable zero-padding to the left to ensure otp is uniformly random
-	expr := "%0" + strconv.Itoa(digits) + "v"
-	otp := fmt.Sprintf(expr, val.String())
+	charactersLength := big.NewInt(int64(len(characters)))
 
-	return otp
+	var otp strings.Builder
+	for i := 0; i < digits; i++ {
+		index := must(rand.Int(rand.Reader, charactersLength))
+		otp.WriteByte(characters[index.Int64()])
+	}
+
+	return otp.String()
 }
 func GenerateTokenHash(emailOrPhone, otp string) string {
 	return fmt.Sprintf("%x", sha256.Sum224([]byte(emailOrPhone+otp)))


### PR DESCRIPTION
## What kind of change does this PR introduce?

Adds support for alphanumeric and alphabetic (lower, upper and mixed case) characters as configuration options for generating OTPs.

## What is the current behavior?

OTPs can only be generated using digits.

## What is the new behavior?

Users can configure whether OTPs should be generated using other characters than just digits.

## Additional context

Background of this feature in this discussion: https://github.com/orgs/supabase/discussions/33744

I would love to get this feature (in this or a similar way) merged, so if there is anything I can do to support you with the review of this PR, feel free to poke me!
