### PR TITLE
fix: use sys/unix instead of syscall

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.23.x]
+        go-version: [1.23.7]
     runs-on: ubuntu-20.04
     services:
       postgres:
@@ -29,7 +29,7 @@ jobs:
           --health-retries 5
     steps:
       - name: Install Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go-version }}
       - name: Checkout code

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.22.x]
+        go-version: [1.23.x]
     runs-on: ubuntu-20.04
     services:
       postgres:
@@ -34,8 +34,6 @@ jobs:
           go-version: ${{ matrix.go-version }}
       - name: Checkout code
         uses: actions/checkout@v2
-        with:
-          skip-unshallow: "true"
       - name: Check gofmt
         run: |
           set -x

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22.3-alpine3.20 as build
+FROM golang:1.23.7-alpine3.20 as build
 ENV GO111MODULE=on
 ENV CGO_ENABLED=0
 ENV GOOS=linux

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM golang:1.22.3-alpine3.20
+FROM golang:1.23.7-alpine3.20
 ENV GO111MODULE=on
 ENV CGO_ENABLED=0
 ENV GOOS=linux

--- a/cmd/serve_cmd.go
+++ b/cmd/serve_cmd.go
@@ -8,6 +8,8 @@ import (
 	"syscall"
 	"time"
 
+	"golang.org/x/sys/unix"
+
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -110,8 +112,7 @@ func serve(ctx context.Context) {
 		Control: func(network, address string, c syscall.RawConn) error {
 			var serr error
 			if err := c.Control(func(fd uintptr) {
-				// hard-coded syscall.SO_REUSEPORT since it doesn't seem to be defined in different environments
-				serr = syscall.SetsockoptInt(int(fd), syscall.SOL_SOCKET, 0x200, 1)
+				serr = unix.SetsockoptInt(int(fd), unix.SOL_SOCKET, unix.SO_REUSEPORT, 1)
 			}); err != nil {
 				return err
 			}

--- a/go.mod
+++ b/go.mod
@@ -162,7 +162,7 @@ require (
 	golang.org/x/exp v0.0.0-20230811145659-89c5cff77bcb
 	golang.org/x/net v0.25.0 // indirect
 	golang.org/x/sync v0.10.0
-	golang.org/x/sys v0.28.0 // indirect
+	golang.org/x/sys v0.28.0
 	golang.org/x/text v0.21.0 // indirect
 	golang.org/x/time v0.5.0
 	google.golang.org/appengine v1.6.8 // indirect

--- a/go.mod
+++ b/go.mod
@@ -173,4 +173,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-go 1.22.3
+go 1.23.7


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Use `syscall.SO_REUSEPORT` instead of hardcoding the syscall to deal with cases where it's not supported
* Upgrade go to version 1.23.7 