### PR TITLE
chore: use go 1.23.7

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,7 +76,7 @@ jobs:
       - uses: actions/setup-go@v5
         if: ${{ steps.release.outputs.release_created == 'true' || steps.release.outputs.prs_created == 'true' }}
         with:
-          go-version: "^1.22.0" # The Go version to download (if necessary) and use.
+          go-version: "1.23.7" # The Go version to download (if necessary) and use.
 
       - name: Build release artifacts
         if: ${{ steps.release.outputs.release_created == 'true' || steps.release.outputs.prs_created == 'true' }}


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Force the release ci to use 1.23.7 - for some reason, the gh runner cache only contains 1.23.6