### PR TITLE
Fix issue where if the headers contain From it overrides the Custom SMTP From

### DIFF
--- a/internal/mailer/mailme.go
+++ b/internal/mailer/mailme.go
@@ -83,19 +83,17 @@ func (m *MailmeMailer) Mail(
 
 	mail := gomail.NewMessage()
 	
-	// Apply headers first
+	mail := gomail.NewMessage()
+	mail.SetHeader("From", m.From)
+	mail.SetHeader("To", to)
+	mail.SetHeader("Subject", subject.String())
+	
 	for k, v := range headers {
 		if v != nil && k != "From" { // Skip From header from headers
 			mail.SetHeader(k, v...)
 		}
 	}
 	
-	// Set From, To, Subject headers after other headers
-	// This ensures From from configuration takes precedence
-	mail.SetHeader("From", m.From)
-	mail.SetHeader("To", to)
-	mail.SetHeader("Subject", subject.String())
-
 	mail.SetBody("text/html", body)
 
 	dial := gomail.NewDialer(m.Host, m.Port, m.User, m.Pass)


### PR DESCRIPTION
## What kind of change does this PR introduce?

Under some circumstances headers may be passed that override the From field. This can cause emails to come from application users instead of from the Custom SMTP Sender details and will often result in email delivery failures since most SMTPs only accept emails from approved senders.

## What is the current behavior?

https://github.com/supabase/auth/issues/1957

## What is the new behavior?

Updates via headers to From are ignored, the correct Custom SMTP Sender details are preserved.
