### PR TITLE
Feat: Block emails based on mx server

### DIFF
--- a/internal/api/mail.go
+++ b/internal/api/mail.go
@@ -551,7 +551,7 @@ func (a *API) validateEmail(email string) (string, error) {
 		return "", badRequestError(ErrorCodeValidationFailed, "Unable to validate email address: "+err.Error())
 	}
 
-	if err := validateMX(email, a.config.Mailer.Denylist); err != nil {
+	if err := validateMX(email, a.config.Mailer.MXBlocklist); err != nil {
 		return "", badRequestError(ErrorCodeValidationFailed, "Unauthorised email address: "+err.Error())
 	}
 
@@ -569,7 +569,7 @@ func validateMX(email string, denylist []string) error {
 	for _, mx := range mxRecords {
 		for _, deniedHost := range denylist {
 			if strings.Contains(mx.Host, deniedHost) {
-				return fmt.Errorf("host is in the denylist")
+				return fmt.Errorf("host is in the blocklist")
 			}
 		}
 	}

--- a/internal/conf/configuration.go
+++ b/internal/conf/configuration.go
@@ -406,6 +406,8 @@ type MailerConfiguration struct {
 	EmailValidationServiceHeaders string `json:"email_validation_service_headers" split_words:"true"`
 
 	serviceHeaders map[string][]string `json:"-"`
+
+	MXBlocklist []string `json:"mx_blocklist" split_words:"true"`
 }
 
 func (c *MailerConfiguration) Validate() error {
@@ -420,6 +422,13 @@ func (c *MailerConfiguration) Validate() error {
 
 	if len(headers) > 0 {
 		c.serviceHeaders = headers
+	}
+	if len(c.MXBlocklist) > 0 {
+		for _, domain := range c.MXBlocklist {
+			if strings.TrimSpace(domain) == "" {
+				return fmt.Errorf("conf: Blocklist contains an empty domain")
+			}
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature that gives configuration option to block an email address event if the mx server of the domain is on a blocklist

## What is the current behavior?

There is no existing feature for this.

## What is the new behavior?

Anytime validateEmail is invoked (i.e. signup, magiclink), the mx server of the email addresses domain is queried and checked against a configurable blocklist 

## Additional context

Functionality to allow for the long term blocking of bot and spam behavior.