### PR TITLE
feat: allow invalid config directories

### DIFF
--- a/cmd/serve_cmd.go
+++ b/cmd/serve_cmd.go
@@ -34,7 +34,7 @@ func serve(ctx context.Context) {
 	}
 
 	if err := conf.LoadDirectory(watchDir); err != nil {
-		logrus.WithError(err).Fatal("unable to load config from watch dir")
+		logrus.WithError(err).Error("unable to load config from watch dir")
 	}
 
 	config, err := conf.LoadGlobalFromEnv()


### PR DESCRIPTION
This change will prevent an invalid config directory from shutting down the auth server. To prevent spamming the logs we wait for the reloadInterval between each attempt to check the config dir.