### PR TITLE
feat: Block specific outgoing mail servers

### DIFF
--- a/internal/conf/configuration.go
+++ b/internal/conf/configuration.go
@@ -433,6 +433,12 @@ func (c *MailerConfiguration) Validate() error {
 	}
 
 	if len(blockedMXRecords) > 0 {
+		// MX records end with a period, so we add it here if it's missing.
+		for i, record := range blockedMXRecords {
+			if !strings.HasSuffix(record, ".") {
+				blockedMXRecords[i] = record + "."
+			}
+		}
 		c.blockedMXRecords = blockedMXRecords
 	}
 
@@ -962,16 +968,6 @@ func (config *GlobalConfiguration) ApplyDefaults() error {
 	if config.Mailer.OtpLength == 0 || config.Mailer.OtpLength < 6 || config.Mailer.OtpLength > 10 {
 		// 6-digit otp by default
 		config.Mailer.OtpLength = 6
-	}
-
-	if config.Mailer.EmailValidationBlockedMX == "" {
-		config.Mailer.EmailValidationBlockedMX = `[
-			"mail.wallywatts.com",
-			"mail.wabblywabble.com",
-			"mail.gufum.com",
-			"mail.vvatxiy.com",
-			"mail.qacmjeq.com"
-		]`
 	}
 
 	if config.SMTP.MaxFrequency == 0 {

--- a/internal/mailer/validate_test.go
+++ b/internal/mailer/validate_test.go
@@ -260,7 +260,18 @@ func TestValidateEmailExtended(t *testing.T) {
 		EmailValidationExtended:       true,
 		EmailValidationServiceURL:     "",
 		EmailValidationServiceHeaders: "",
+		EmailValidationBlockedMX: `[
+			"mail.gufum.com",
+			"mail.vvatxiy.com",
+			"mail.qacmjeq.com"
+		]`,
 	}
+
+	// Ensure the BlockedMX transformation occurs by calling Validate
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("failed to validate MailerConfiguration: %v", err)
+	}
+
 	ev := newEmailValidator(cfg)
 
 	for idx, tc := range cases {

--- a/internal/mailer/validate_test.go
+++ b/internal/mailer/validate_test.go
@@ -258,9 +258,7 @@ func TestValidateEmailExtended(t *testing.T) {
 		EmailValidationExtended:       true,
 		EmailValidationServiceURL:     "",
 		EmailValidationServiceHeaders: "",
-		EmailValidationBlockedMX: `[
-			"hotmail-com.olc.protection.outlook.com"
-		]`,
+		EmailValidationBlockedMX:      `["hotmail-com.olc.protection.outlook.com"]`,
 	}
 
 	// Ensure the BlockedMX transformation occurs by calling Validate

--- a/internal/mailer/validate_test.go
+++ b/internal/mailer/validate_test.go
@@ -242,6 +242,11 @@ func TestValidateEmailExtended(t *testing.T) {
 		{email: "test@invalid.example.com", err: "invalid_email_dns"},
 		{email: "test@no.such.email.host.supabase.io", err: "invalid_email_dns"},
 
+		// various invalid mx records
+		{email: "user@gufum.com", err: "invalid_email_mx"},
+		{email: "user@vvatxiy.com", err: "invalid_email_mx"},
+		{email: "user@qacmjeq.com", err: "invalid_email_mx"},
+
 		// this low timeout should simulate a dns timeout, which should
 		// not be treated as an invalid email.
 		{email: "validemail@probablyaaaaaaaanotarealdomain.com",

--- a/internal/mailer/validate_test.go
+++ b/internal/mailer/validate_test.go
@@ -242,10 +242,8 @@ func TestValidateEmailExtended(t *testing.T) {
 		{email: "test@invalid.example.com", err: "invalid_email_dns"},
 		{email: "test@no.such.email.host.supabase.io", err: "invalid_email_dns"},
 
-		// various invalid mx records
-		{email: "user@gufum.com", err: "invalid_email_mx"},
-		{email: "user@vvatxiy.com", err: "invalid_email_mx"},
-		{email: "user@qacmjeq.com", err: "invalid_email_mx"},
+		// test blocked mx records
+		{email: "test@hotmail.com", err: "invalid_email_mx"},
 
 		// this low timeout should simulate a dns timeout, which should
 		// not be treated as an invalid email.
@@ -261,9 +259,7 @@ func TestValidateEmailExtended(t *testing.T) {
 		EmailValidationServiceURL:     "",
 		EmailValidationServiceHeaders: "",
 		EmailValidationBlockedMX: `[
-			"mail.gufum.com",
-			"mail.vvatxiy.com",
-			"mail.qacmjeq.com"
+			"hotmail-com.olc.protection.outlook.com"
 		]`,
 	}
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature that gives configuration option to block an email address event if the mx server of the domain is on a blocklist

## What is the current behavior?

Existing behavior only checks for syntax issues and single email addresses against a message stream.

## What is the new behavior?

This is called on every sent email event, the mx server of the email addresses domain is queried and checked against a hard-coded blocklist

## Additional context

Functionality to allow for the long term blocking of bot and spam behavior.

Resolves SEC-245
