### PR TITLE
fix: sanitize redirect URL (remove fragment, query) before pattern matching

### DIFF
--- a/internal/utilities/request.go
+++ b/internal/utilities/request.go
@@ -92,9 +92,13 @@ func IsRedirectURLValid(config *conf.GlobalConfiguration, redirectURL string) bo
 		return true
 	}
 
+	// Clean up the referrer URL to avoid pattern matching an invalid URL
+	refurl.Fragment = ""
+	refurl.RawQuery = ""
+
 	// For case when user came from mobile app or other permitted resource - redirect back
 	for _, pattern := range config.URIAllowListMap {
-		if pattern.Match(redirectURL) {
+		if pattern.Match(refurl.String()) {
 			return true
 		}
 	}

--- a/internal/utilities/request_test.go
+++ b/internal/utilities/request_test.go
@@ -91,7 +91,7 @@ func TestGetIPAddress(t *tst.T) {
 func TestGetReferrer(t *tst.T) {
 	config := conf.GlobalConfiguration{
 		SiteURL:      "https://example.com",
-		URIAllowList: []string{"http://localhost:8000/*"},
+		URIAllowList: []string{"http://localhost:8000/*", "http://*.localhost:8000/*"},
 		JWT: conf.JWTConfiguration{
 			Secret: "testsecret",
 		},
@@ -120,6 +120,16 @@ func TestGetReferrer(t *tst.T) {
 		{
 			desc:        "* respects separator",
 			redirectURL: "http://localhost:8000/path/to/page",
+			expected:    config.SiteURL,
+		},
+		{
+			desc:        "* respects parameters",
+			redirectURL: "http://localhost:8000/path?param=1",
+			expected:    "http://localhost:8000/path?param=1",
+		},
+		{
+			desc:        "invalid redirect url via query smurfing",
+			redirectURL: "http://123?.localhost:8000/path",
 			expected:    config.SiteURL,
 		},
 	}


### PR DESCRIPTION
Redirect URL was not being sanitized (query and fragment not being stripped) before being pattern matched on the allowed URL globs. This made it possible in some cases to produce an insecure redirect.