### PR TITLE
fix: explicit permisions on actions

### DIFF
--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -6,7 +6,7 @@ on:
       - master
       - release/*
 
-  pull_request_target:
+  pull_request:
     branches:
       - master
       - release/*
@@ -31,7 +31,7 @@ jobs:
           sparse-checkout: |
             .github
 
-      - if: ${{ github.event_name == 'pull_request_target' }}
+      - if: ${{ github.event_name == 'pull_request' }}
         run: |
           set -ex
 

--- a/.github/workflows/dogfooding.yml
+++ b/.github/workflows/dogfooding.yml
@@ -4,11 +4,14 @@ on:
   pull_request_review:
     types: [submitted, edited]
 
-  pull_request_target:
+  pull_request:
     types:
       - opened
     branches:
       - '*'
+
+permissions:
+  contents: read
 
 jobs:
   check_dogfooding:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,6 +7,9 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,9 @@ on:
       - master
       - release/*
 
+permissions:
+  contents: read
+
 jobs:
   release_please:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,9 @@ on:
       - master
     tags: ["*"]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     strategy:


### PR DESCRIPTION
Found nothing vulnerable found in actions, just tightening up the permissions across all our publicly facing repos.

Not clear why pull_request_target is being used. Ready to revert if needed
