### PR TITLE
fix: Migration error with different auth schema

### DIFF
--- a/migrations/20240729123726_add_mfa_phone_config.up.sql
+++ b/migrations/20240729123726_add_mfa_phone_config.up.sql
@@ -1,5 +1,5 @@
 do $$ begin
-    alter type {{ index .Options "Namespace" }}.factor_type add value 'phone';
+    alter type factor_type add value 'phone';
 exception
     when duplicate_object then null;
 end $$;


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fixes #1729 

## What is the current behavior?

Doesn't nicely play if default schema is other than "auth"

## What is the new behavior?

Migration will be fine

## Additional context

Add any other context or screenshots.

![image](https://github.com/user-attachments/assets/41f5f685-4831-4b85-8793-03d6f133c832)

