### PR TITLE
feat: separate web3 rate limits from other `/token?grant_type=...`

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -184,8 +184,8 @@ func NewAPIWithVersion(globalConfig *conf.GlobalConfiguration, db *storage.Conne
 		r.With(api.limitHandler(api.limiterOpts.Otp)).
 			With(api.verifyCaptcha).Post("/otp", api.Otp)
 
-		r.With(api.limitHandler(api.limiterOpts.Token)).
-			With(api.verifyCaptcha).Post("/token", api.Token)
+		// rate limiting applied in handler
+		r.With(api.verifyCaptcha).Post("/token", api.Token)
 
 		r.With(api.limitHandler(api.limiterOpts.Verify)).Route("/verify", func(r *router) {
 			r.Get("/", api.Verify)

--- a/internal/api/options.go
+++ b/internal/api/options.go
@@ -30,6 +30,7 @@ type LimiterOptions struct {
 	FactorChallenge  *limiter.Limiter
 	SSO              *limiter.Limiter
 	SAMLAssertion    *limiter.Limiter
+	Web3             *limiter.Limiter
 }
 
 func (lo *LimiterOptions) apply(a *API) { a.limiterOpts = lo }
@@ -81,6 +82,11 @@ func NewLimiterOptions(gc *conf.GlobalConfiguration) *LimiterOptions {
 		}).SetBurst(30)
 
 	o.Signups = tollbooth.NewLimiter(gc.RateLimitOtp/(60*5),
+		&limiter.ExpirableOptions{
+			DefaultExpirationTTL: time.Hour,
+		}).SetBurst(30)
+
+	o.Web3 = tollbooth.NewLimiter(gc.RateLimitWeb3/(60*5),
 		&limiter.ExpirableOptions{
 			DefaultExpirationTTL: time.Hour,
 		}).SetBurst(30)

--- a/internal/api/token_test.go
+++ b/internal/api/token_test.go
@@ -225,7 +225,7 @@ func (ts *TokenTestSuite) TestSingleSessionPerUserNoTags() {
 
 func (ts *TokenTestSuite) TestRateLimitTokenRefresh() {
 	var buffer bytes.Buffer
-	req := httptest.NewRequest(http.MethodPost, "http://localhost/token", &buffer)
+	req := httptest.NewRequest(http.MethodPost, "http://localhost/token?grant_type=refresh_token", &buffer)
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("My-Custom-Header", "1.2.3.4")
 
@@ -246,7 +246,38 @@ func (ts *TokenTestSuite) TestRateLimitTokenRefresh() {
 	assert.Equal(ts.T(), http.StatusTooManyRequests, w.Code)
 
 	// It doesn't rate limit a new value for the limited header
-	req = httptest.NewRequest(http.MethodPost, "http://localhost/token", &buffer)
+	req = httptest.NewRequest(http.MethodPost, "http://localhost/token?grant_type=refresh_token", &buffer)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("My-Custom-Header", "5.6.7.8")
+	w = httptest.NewRecorder()
+	ts.API.handler.ServeHTTP(w, req)
+	assert.Equal(ts.T(), http.StatusBadRequest, w.Code)
+}
+
+func (ts *TokenTestSuite) TestRateLimitWeb3() {
+	var buffer bytes.Buffer
+	req := httptest.NewRequest(http.MethodPost, "http://localhost/token?grant_type=web3", &buffer)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("My-Custom-Header", "1.2.3.4")
+
+	// It rate limits after 30 requests
+	for i := 0; i < 30; i++ {
+		w := httptest.NewRecorder()
+		ts.API.handler.ServeHTTP(w, req)
+		assert.Equal(ts.T(), http.StatusBadRequest, w.Code)
+	}
+	w := httptest.NewRecorder()
+	ts.API.handler.ServeHTTP(w, req)
+	assert.Equal(ts.T(), http.StatusTooManyRequests, w.Code)
+
+	// It ignores X-Forwarded-For by default
+	req.Header.Set("X-Forwarded-For", "1.1.1.1")
+	w = httptest.NewRecorder()
+	ts.API.handler.ServeHTTP(w, req)
+	assert.Equal(ts.T(), http.StatusTooManyRequests, w.Code)
+
+	// It doesn't rate limit a new value for the limited header
+	req = httptest.NewRequest(http.MethodPost, "http://localhost/token?grant_type=web3", &buffer)
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("My-Custom-Header", "5.6.7.8")
 	w = httptest.NewRecorder()

--- a/internal/conf/configuration.go
+++ b/internal/conf/configuration.go
@@ -257,6 +257,7 @@ type GlobalConfiguration struct {
 	RateLimitSso            float64 `split_words:"true" default:"30"`
 	RateLimitAnonymousUsers float64 `split_words:"true" default:"30"`
 	RateLimitOtp            float64 `split_words:"true" default:"30"`
+	RateLimitWeb3           float64 `split_words:"true" default:"30"`
 
 	SiteURL         string   `json:"site_url" split_words:"true" required:"true"`
 	URIAllowList    []string `json:"uri_allow_list" split_words:"true"`

--- a/internal/observability/request-logger.go
+++ b/internal/observability/request-logger.go
@@ -55,6 +55,10 @@ func (l *structuredLogger) NewLogEntry(r *http.Request) chimiddleware.LogEntry {
 		"referer":     referrer,
 	}
 
+	if r.URL.Path == "/token" {
+		logFields["grant_type"] = r.FormValue("grant_type")
+	}
+
 	if reqID := utilities.GetRequestID(r.Context()); reqID != "" {
 		logFields["request_id"] = reqID
 	}


### PR DESCRIPTION
Sign in with Web3 can be very prone to abuse. This is because all it takes for the `/token?grant_type=web3` endpoint to be abused is the generation of signed messages by a private key.

For this reason a new rate limit config is provided `GOTRUE_RATE_LIMIT_WEB3` which limits the number of such calls per IP address.

To achieve this, the rate limit enforcement on the `/token` API is moved inside in the `Token` handler. This provides a future basis for separating out the rate limiters for Sign in with Password and ID token, as well as rate limiters for PKCE.