### PR TITLE
feat: fix large group claim handling in azure id tokens

### DIFF
--- a/internal/api/provider/azure_test.go
+++ b/internal/api/provider/azure_test.go
@@ -1,6 +1,15 @@
 package provider
 
-import "testing"
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
 
 func TestIsAzureIssuer(t *testing.T) {
 	positiveExamples := []string{
@@ -26,4 +35,137 @@ func TestIsAzureIssuer(t *testing.T) {
 			t.Errorf("Example %q should be treated as not a valid Azure issuer", example)
 		}
 	}
+}
+
+func TestAzureResolveIndirectClaims(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		w.Write([]byte(`{
+    "@odata.context": "https://graph.microsoft.com/v1.0/$metadata#Collection(Edm.String)",
+    "value": [
+        "fee2c45b-915a-4a64-b130-f4eb9e75525e",
+        "4fe90ae7-065a-478b-9400-e0a0e1cbd540",
+        "c9ee2d50-9e8a-4352-b97c-4c2c99557c22",
+        "e0c3beaf-eeb4-43d8-abc5-94f037a65697"
+    ]
+}`))
+	}))
+
+	defer server.Close()
+
+	var claims AzureIDTokenClaims
+
+	resolvedClaims, err := claims.ResolveIndirectClaims(context.Background(), server.Client(), "access-token")
+	require.Nil(t, resolvedClaims)
+	require.Nil(t, err)
+
+	claims.ClaimNames = make(map[string]string)
+
+	resolvedClaims, err = claims.ResolveIndirectClaims(context.Background(), server.Client(), "access-token")
+	require.Nil(t, resolvedClaims)
+	require.Nil(t, err)
+
+	claims.ClaimNames = map[string]string{
+		"groups":         "src1",
+		"missing-source": "src2",
+		"not-https":      "src3",
+	}
+	claims.ClaimSources = map[string]AzureIDTokenClaimSource{
+		"src1": {
+			Endpoint: server.URL,
+		},
+		"src3": {
+			Endpoint: "http://example.com",
+		},
+	}
+
+	resolvedClaims, err = claims.ResolveIndirectClaims(context.Background(), server.Client(), "access-token")
+	require.NoError(t, err)
+	require.NotNil(t, resolvedClaims)
+	require.Equal(t, 1, len(resolvedClaims))
+	require.Equal(t, 4, len(resolvedClaims["groups"].([]interface{})))
+}
+
+func TestAzureResolveIndirectClaimsFailures(t *testing.T) {
+	examples := []struct {
+		name          string
+		urlSuffix     string
+		statusCode    int
+		body          []byte
+		expectedError string
+	}{
+		{
+			name:          "invalid url",
+			urlSuffix:     "\000",
+			expectedError: "azure: failed to create POST request to \"SERVER-URL\\x00\" (resolving overage claim \"groups\"): parse \"SERVER-URL\\x00\": net/url: invalid control character in URL",
+		},
+		{
+			name:          "no such server",
+			urlSuffix:     "000",
+			expectedError: "azure: failed to send POST request to \"SERVER-URL000\" (resolving overage claim \"groups\"): Post \"SERVER-URL000\": dial tcp: address PORT000: invalid port",
+		},
+		{
+			name:          "non 200 status code",
+			statusCode:    500,
+			body:          []byte(`something is wrong`),
+			expectedError: "azure: received 500 but expected 200 HTTP status code when sending POST to \"SERVER-URL\" (resolving overage claim \"groups\") with response body \"something is wrong\"",
+		},
+		{
+			name:          "non 200 status code, non utf8 valid body",
+			statusCode:    201,
+			body:          []byte{255, 255, 255, 255},
+			expectedError: "azure: received 201 but expected 200 HTTP status code when sending POST to \"SERVER-URL\" (resolving overage claim \"groups\") with response body \"<invalid-utf8>\"",
+		},
+		{
+			name:          "non 200 status code, empty body",
+			statusCode:    201,
+			body:          []byte{},
+			expectedError: "azure: received 201 but expected 200 HTTP status code when sending POST to \"SERVER-URL\" (resolving overage claim \"groups\") with response body \"<empty>\"",
+		},
+		{
+			name:          "non 200 status code, body over 2KB",
+			statusCode:    201,
+			body:          []byte(strings.Repeat("x", 2*1024+1)),
+			expectedError: "azure: received 201 but expected 200 HTTP status code when sending POST to \"SERVER-URL\" (resolving overage claim \"groups\") with response body \"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\"",
+		},
+		{
+			name:          "ok response, not json",
+			statusCode:    200,
+			body:          []byte("not json"),
+			expectedError: "azure: failed to parse JSON response from POST to \"SERVER-URL\" (resolving overage claim \"groups\"): invalid character 'o' in literal null (expecting 'u')",
+		},
+	}
+
+	for _, example := range examples {
+		t.Run(example.name, func(t *testing.T) {
+			server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(example.statusCode)
+
+				w.Write(example.body)
+			}))
+
+			defer server.Close()
+
+			u, _ := url.Parse(server.URL)
+
+			var claims AzureIDTokenClaims
+
+			claims.ClaimNames = map[string]string{
+				"groups": "src1",
+			}
+			claims.ClaimSources = map[string]AzureIDTokenClaimSource{
+				"src1": {
+					Endpoint: server.URL + example.urlSuffix,
+				},
+			}
+
+			resolvedClaims, err := claims.ResolveIndirectClaims(context.Background(), server.Client(), "access-token")
+			require.Nil(t, resolvedClaims)
+			require.Error(t, err)
+			require.Equal(t, example.expectedError, strings.ReplaceAll(strings.ReplaceAll(err.Error(), server.URL, "SERVER-URL"), u.Port(), "PORT"))
+		})
+	}
+
 }

--- a/internal/api/provider/oidc.go
+++ b/internal/api/provider/oidc.go
@@ -65,7 +65,7 @@ func ParseIDToken(ctx context.Context, provider *oidc.Provider, config *oidc.Con
 		token, data, err = parseVercelMarketplaceIDToken(token)
 	default:
 		if IsAzureIssuer(token.Issuer) {
-			token, data, err = parseAzureIDToken(token)
+			token, data, err = parseAzureIDToken(ctx, token, options.AccessToken)
 		} else {
 			token, data, err = parseGenericIDToken(token)
 		}
@@ -206,111 +206,6 @@ func parseLinkedinIDToken(token *oidc.IDToken) (*oidc.IDToken, *UserProvidedData
 		Locale:     claims.Locale,
 		Picture:    claims.Picture,
 		ProviderId: token.Subject,
-	}
-
-	return token, &data, nil
-}
-
-type AzureIDTokenClaims struct {
-	jwt.RegisteredClaims
-
-	Email                              string `json:"email"`
-	Name                               string `json:"name"`
-	PreferredUsername                  string `json:"preferred_username"`
-	XMicrosoftEmailDomainOwnerVerified any    `json:"xms_edov"`
-}
-
-func (c *AzureIDTokenClaims) IsEmailVerified() bool {
-	emailVerified := false
-
-	edov := c.XMicrosoftEmailDomainOwnerVerified
-
-	// If xms_edov is not set, and an email is present or xms_edov is true,
-	// only then is the email regarded as verified.
-	// https://learn.microsoft.com/en-us/azure/active-directory/develop/migrate-off-email-claim-authorization#using-the-xms_edov-optional-claim-to-determine-email-verification-status-and-migrate-users
-	if edov == nil {
-		// An email is provided, but xms_edov is not -- probably not
-		// configured, so we must assume the email is verified as Azure
-		// will only send out a potentially unverified email address in
-		// single-tenanat apps.
-		emailVerified = c.Email != ""
-	} else {
-		edovBool := false
-
-		// Azure can't be trusted with how they encode the xms_edov
-		// claim. Sometimes it's "xms_edov": "1", sometimes "xms_edov": true.
-		switch v := edov.(type) {
-		case bool:
-			edovBool = v
-
-		case string:
-			edovBool = v == "1" || v == "true"
-
-		default:
-			edovBool = false
-		}
-
-		emailVerified = c.Email != "" && edovBool
-	}
-
-	return emailVerified
-}
-
-// removeAzureClaimsFromCustomClaims contains the list of claims to be removed
-// from the CustomClaims map. See:
-// https://learn.microsoft.com/en-us/azure/active-directory/develop/id-token-claims-reference
-var removeAzureClaimsFromCustomClaims = []string{
-	"aud",
-	"iss",
-	"iat",
-	"nbf",
-	"exp",
-	"c_hash",
-	"at_hash",
-	"aio",
-	"nonce",
-	"rh",
-	"uti",
-	"jti",
-	"ver",
-	"sub",
-	"name",
-	"preferred_username",
-}
-
-func parseAzureIDToken(token *oidc.IDToken) (*oidc.IDToken, *UserProvidedData, error) {
-	var data UserProvidedData
-
-	var azureClaims AzureIDTokenClaims
-	if err := token.Claims(&azureClaims); err != nil {
-		return nil, nil, err
-	}
-
-	data.Metadata = &Claims{
-		Issuer:            token.Issuer,
-		Subject:           token.Subject,
-		ProviderId:        token.Subject,
-		PreferredUsername: azureClaims.PreferredUsername,
-		FullName:          azureClaims.Name,
-		CustomClaims:      make(map[string]any),
-	}
-
-	if azureClaims.Email != "" {
-		data.Emails = []Email{{
-			Email:    azureClaims.Email,
-			Verified: azureClaims.IsEmailVerified(),
-			Primary:  true,
-		}}
-	}
-
-	if err := token.Claims(&data.Metadata.CustomClaims); err != nil {
-		return nil, nil, err
-	}
-
-	if data.Metadata.CustomClaims != nil {
-		for _, claim := range removeAzureClaimsFromCustomClaims {
-			delete(data.Metadata.CustomClaims, claim)
-		}
 	}
 
 	return token, &data, nil


### PR DESCRIPTION
Handles [large `group` claims in Azure ID tokens](https://learn.microsoft.com/en-us/entra/identity-platform/id-token-claims-reference#groups-overage-claim) by fetching them from the ([usually](https://learn.microsoft.com/en-us/graph/api/directoryobject-getmemberobjects?view=graph-rest-1.0&tabs=http)) designated Azure endpoint.