### PR TITLE
feat: add before & after user creation hooks

### DIFF
--- a/internal/api/admin_test.go
+++ b/internal/api/admin_test.go
@@ -602,7 +602,8 @@ func (ts *AdminTestSuite) TestAdminUserDelete() {
 			require.NoError(ts.T(), json.NewEncoder(&buffer).Encode(c.body))
 			u, err := signupParams.ToUserModel(false /* <- isSSOUser */)
 			require.NoError(ts.T(), err)
-			u, err = ts.API.signupNewUser(ts.API.db, u)
+			r := httptest.NewRequest("GET", "/", nil)
+			u, err = ts.API.signupNewUser(r, ts.API.db, u)
 			require.NoError(ts.T(), err)
 
 			// Setup request

--- a/internal/api/anonymous.go
+++ b/internal/api/anonymous.go
@@ -37,7 +37,7 @@ func (a *API) SignupAnonymously(w http.ResponseWriter, r *http.Request) error {
 	var token *AccessTokenResponse
 	err = db.Transaction(func(tx *storage.Connection) error {
 		var terr error
-		newUser, terr = a.signupNewUser(tx, newUser)
+		newUser, terr = a.signupNewUser(r, tx, newUser)
 		if terr != nil {
 			return terr
 		}

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -87,7 +87,7 @@ func NewAPIWithVersion(globalConfig *conf.GlobalConfiguration, db *storage.Conne
 		api.limiterOpts = NewLimiterOptions(globalConfig)
 	}
 	if api.hooksMgr == nil {
-		api.hooksMgr = hooks.NewManager(db, globalConfig)
+		api.hooksMgr = hooks.New(globalConfig, db)
 	}
 	if api.config.Password.HIBP.Enabled {
 		httpClient := &http.Client{

--- a/internal/api/e2e_test.go
+++ b/internal/api/e2e_test.go
@@ -1,0 +1,104 @@
+package api_test
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/gofrs/uuid"
+	"github.com/stretchr/testify/require"
+	"github.com/supabase/auth/internal/api"
+	"github.com/supabase/auth/internal/conf"
+	"github.com/supabase/auth/internal/e2e/e2eapi"
+	"github.com/supabase/auth/internal/e2e/e2ehooks"
+	"github.com/supabase/auth/internal/hooks/v1hooks"
+	"github.com/supabase/auth/internal/models"
+)
+
+func TestE2EHooks(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+	defer cancel()
+
+	globalCfg, err := conf.LoadGlobal("../../hack/test.env")
+	if err != nil {
+		t.Fatalf("exp nil err; got %v", err)
+	}
+
+	inst, err := e2ehooks.New(globalCfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer inst.Close()
+
+	apiSrv := inst.APIServer
+	hookRec := inst.HookRecorder
+
+	// Basic tests for Before/After User Created hooks
+	{
+
+		// Signup a user
+		var signupUser *models.User
+		email := "e2etesthooks_" + uuid.Must(uuid.NewV4()).String() + "@localhost"
+		{
+			req := &api.SignupParams{
+				Email:    email,
+				Password: "password",
+			}
+			res := new(models.User)
+			err := e2eapi.Do(ctx, http.MethodPost, apiSrv.URL+"/signup", req, res)
+			if err != nil {
+				t.Fatalf("exp nil err; got %v", err)
+			}
+			signupUser = res
+
+			require.Equal(t, email, signupUser.Email.String())
+		}
+
+		{
+			calls := hookRec.BeforeUserCreated.GetCalls()
+			if exp, got := 1, len(calls); exp != got {
+				t.Fatalf("exp %v; got %v", exp, got)
+			}
+			call := calls[0]
+
+			hookReq := &v1hooks.BeforeUserCreatedRequest{}
+			if err := call.Unmarshal(hookReq); err != nil {
+				t.Fatalf("exp nil err; got %v", err)
+			}
+
+			u := hookReq.User
+			require.Equal(t, signupUser.ID, u.ID)
+			require.Equal(t, signupUser.Aud, u.Aud)
+			require.Equal(t, signupUser.Email, u.Email)
+			require.Equal(t, signupUser.AppMetaData, u.AppMetaData)
+
+			require.True(t, u.CreatedAt.IsZero())
+			require.True(t, u.UpdatedAt.IsZero())
+		}
+
+		{
+			calls := hookRec.AfterUserCreated.GetCalls()
+			if exp, got := 1, len(calls); exp != got {
+				t.Fatalf("exp %v; got %v", exp, got)
+			}
+			call := calls[0]
+
+			hookReq := &v1hooks.AfterUserCreatedRequest{}
+			if err := call.Unmarshal(hookReq); err != nil {
+				t.Fatalf("exp nil err; got %v", err)
+			}
+
+			u := hookReq.User
+			require.Equal(t, signupUser.ID, u.ID)
+			require.Equal(t, signupUser.Aud, u.Aud)
+			require.Equal(t, signupUser.Role, u.Role)
+			require.Equal(t, signupUser.Email, u.Email)
+			require.Equal(t, signupUser.AppMetaData, u.AppMetaData)
+
+			require.Equal(t, signupUser.CreatedAt, u.CreatedAt)
+			require.True(t, signupUser.CreatedAt.Before(u.UpdatedAt))
+			require.True(t, signupUser.UpdatedAt.After(u.UpdatedAt))
+		}
+	}
+}

--- a/internal/api/external.go
+++ b/internal/api/external.go
@@ -326,7 +326,7 @@ func (a *API) createAccountFromExternalIdentity(tx *storage.Connection, r *http.
 			return nil, terr
 		}
 
-		if user, terr = a.signupNewUser(tx, user); terr != nil {
+		if user, terr = a.signupNewUser(r, tx, user); terr != nil {
 			return nil, terr
 		}
 

--- a/internal/api/invite.go
+++ b/internal/api/invite.go
@@ -59,7 +59,7 @@ func (a *API) Invite(w http.ResponseWriter, r *http.Request) error {
 				return err
 			}
 
-			user, err = a.signupNewUser(tx, user)
+			user, err = a.signupNewUser(r, tx, user)
 			if err != nil {
 				return err
 			}

--- a/internal/api/mail.go
+++ b/internal/api/mail.go
@@ -153,7 +153,7 @@ func (a *API) adminGenerateLink(w http.ResponseWriter, r *http.Request) error {
 					return terr
 				}
 
-				user, terr = a.signupNewUser(tx, user)
+				user, terr = a.signupNewUser(r, tx, user)
 				if terr != nil {
 					return terr
 				}
@@ -198,7 +198,7 @@ func (a *API) adminGenerateLink(w http.ResponseWriter, r *http.Request) error {
 				// password here to generate a new user, use
 				// signupUser which is a model generated from
 				// SignupParams above
-				user, terr = a.signupNewUser(tx, signupUser)
+				user, terr = a.signupNewUser(r, tx, signupUser)
 				if terr != nil {
 					return terr
 				}

--- a/internal/conf/configuration.go
+++ b/internal/conf/configuration.go
@@ -640,6 +640,9 @@ type HookConfiguration struct {
 	CustomAccessToken           ExtensibilityPointConfiguration `json:"custom_access_token" split_words:"true"`
 	SendEmail                   ExtensibilityPointConfiguration `json:"send_email" split_words:"true"`
 	SendSMS                     ExtensibilityPointConfiguration `json:"send_sms" split_words:"true"`
+
+	BeforeUserCreated ExtensibilityPointConfiguration `json:"before_user_created" split_words:"true"`
+	AfterUserCreated  ExtensibilityPointConfiguration `json:"after_user_created" split_words:"true"`
 }
 
 type HTTPHookSecrets []string
@@ -671,6 +674,8 @@ func (h *HookConfiguration) Validate() error {
 		h.CustomAccessToken,
 		h.SendSMS,
 		h.SendEmail,
+		h.BeforeUserCreated,
+		h.AfterUserCreated,
 	}
 	for _, point := range points {
 		if err := point.ValidateExtensibilityPoint(); err != nil {
@@ -884,6 +889,18 @@ func populateGlobal(config *GlobalConfiguration) error {
 
 	if config.Hook.CustomAccessToken.Enabled {
 		if err := config.Hook.CustomAccessToken.PopulateExtensibilityPoint(); err != nil {
+			return err
+		}
+	}
+
+	if config.Hook.BeforeUserCreated.Enabled {
+		if err := config.Hook.BeforeUserCreated.PopulateExtensibilityPoint(); err != nil {
+			return err
+		}
+	}
+
+	if config.Hook.AfterUserCreated.Enabled {
+		if err := config.Hook.AfterUserCreated.PopulateExtensibilityPoint(); err != nil {
 			return err
 		}
 	}

--- a/internal/e2e/e2e.go
+++ b/internal/e2e/e2e.go
@@ -1,0 +1,62 @@
+// Package e2e provides a few utilities for use in unit tests.
+package e2e
+
+import (
+	"path/filepath"
+	"runtime"
+
+	"github.com/supabase/auth/internal/conf"
+	"github.com/supabase/auth/internal/storage"
+	"github.com/supabase/auth/internal/storage/test"
+)
+
+var (
+	projectRoot string
+	configPath  string
+)
+
+func init() {
+	_, thisFile, _, _ := runtime.Caller(0)
+	projectRoot = filepath.Join(filepath.Dir(thisFile), "../..")
+	configPath = filepath.Join(GetProjectRoot(), "hack", "test.env")
+}
+
+// GetProjectRoot returns the path to the root of the project. This may be used
+// to locate files without needing the relative path from a given test.
+func GetProjectRoot() string {
+	return projectRoot
+}
+
+// GetConfigPath returns the path for the "/hack/test.env" config file.
+func GetConfigPath() string {
+	return configPath
+}
+
+// Config calls conf.LoadGlobal using GetConfigPath().
+func Config() (*conf.GlobalConfiguration, error) {
+	globalCfg, err := conf.LoadGlobal(GetConfigPath())
+	if err != nil {
+		return nil, err
+	}
+	return globalCfg, nil
+}
+
+// Conn returns a connection for the given config.
+func Conn(globalCfg *conf.GlobalConfiguration) (*storage.Connection, error) {
+	conn, err := test.SetupDBConnection(globalCfg)
+	if err != nil {
+		return nil, err
+	}
+	return conn, nil
+}
+
+// Must may be used by Config and Conn, i.e.:
+//
+//	cfg := e2e.Must(e2e.Config())
+//	conn := e2e.Must(e2e.Conn(cfg))
+func Must[T any](res T, err error) T {
+	if err != nil {
+		panic(err)
+	}
+	return res
+}

--- a/internal/e2e/e2e_test.go
+++ b/internal/e2e/e2e_test.go
@@ -1,0 +1,97 @@
+package e2e
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/supabase/auth/internal/conf"
+)
+
+func TestUtils(t *testing.T) {
+
+	// check paths
+	require.Equal(t, projectRoot, GetProjectRoot())
+	require.Equal(t, configPath, GetConfigPath())
+
+	// Config
+	func() {
+
+		// positive
+		{
+			testCfgPath := "../../hack/test.env"
+			testCfg := Must(conf.LoadGlobal(testCfgPath))
+			globalCfg := Must(Config())
+			require.Equal(t, testCfg, globalCfg)
+		}
+
+		// negative
+		{
+			restore := configPath
+			defer func() {
+				configPath = restore
+			}()
+			configPath = "abc"
+
+			globalCfg, err := Config()
+			if err == nil {
+				t.Fatal("exp non-nil err")
+			}
+			if globalCfg != nil {
+				t.Fatal("exp nil conn")
+			}
+		}
+	}()
+
+	// Conn
+	func() {
+		// positive
+		{
+			globalCfg := Must(Config())
+			conn := Must(Conn(globalCfg))
+			if conn == nil {
+				t.Fatal("exp non-nil conn")
+			}
+		}
+
+		// negative
+		{
+			globalCfg := Must(Config())
+			globalCfg.DB.Driver = ""
+			globalCfg.DB.URL = "invalid"
+			conn, err := Conn(globalCfg)
+			if err == nil {
+				t.Fatal("exp non-nil err")
+			}
+			if conn != nil {
+				t.Fatal("exp nil conn")
+			}
+		}
+
+	}()
+
+	// Must
+	func() {
+		restore := configPath
+		defer func() {
+			configPath = restore
+		}()
+		configPath = "abc"
+
+		var err error
+		func() {
+			defer func() {
+				err = recover().(error)
+			}()
+
+			globalCfg := Must(Config())
+			if globalCfg != nil {
+				panic(errors.New("globalCfg != nil"))
+			}
+		}()
+
+		if err == nil {
+			t.Fatal("exp non-nil err")
+		}
+	}()
+}

--- a/internal/e2e/e2eapi/e2eapi.go
+++ b/internal/e2e/e2eapi/e2eapi.go
@@ -1,0 +1,153 @@
+// Package e2eapi provides utilities for end-to-end testing the api.
+package e2eapi
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+
+	"github.com/supabase/auth/internal/api"
+	"github.com/supabase/auth/internal/api/apierrors"
+	"github.com/supabase/auth/internal/conf"
+	"github.com/supabase/auth/internal/storage"
+	"github.com/supabase/auth/internal/storage/test"
+	"github.com/supabase/auth/internal/utilities"
+)
+
+type Instance struct {
+	Config    *conf.GlobalConfiguration
+	Conn      *storage.Connection
+	APIServer *httptest.Server
+
+	mu      sync.Mutex
+	closers []func()
+}
+
+func New(globalCfg *conf.GlobalConfiguration) (*Instance, error) {
+	o := new(Instance)
+	o.Config = globalCfg
+
+	conn, err := test.SetupDBConnection(globalCfg)
+	if err != nil {
+		return nil, fmt.Errorf("error setting up db connection: %w", err)
+	}
+	o.addCloser(func() {
+		if conn.Store != nil {
+			conn.Close()
+		}
+	})
+	o.Conn = conn
+
+	apiVer := utilities.Version
+	if apiVer == "" {
+		apiVer = "1"
+	}
+
+	a := api.NewAPIWithVersion(globalCfg, conn, apiVer)
+	apiSrv := httptest.NewServer(a)
+	o.addCloser(apiSrv)
+	o.APIServer = apiSrv
+
+	return o, nil
+}
+
+func (o *Instance) Close() error {
+	for _, fn := range o.closers {
+		defer fn()
+	}
+	return nil
+}
+
+func (o *Instance) addCloser(v any) {
+	switch T := any(v).(type) {
+	case func():
+		o.closers = append(o.closers, T)
+	case interface{ Close() }:
+		o.closers = append(o.closers, func() { T.Close() })
+	}
+}
+
+func Do(
+	ctx context.Context,
+	method string,
+	url string,
+	req, res any,
+) error {
+	var rdr io.Reader
+	if req != nil {
+		buf := new(bytes.Buffer)
+		err := json.NewEncoder(buf).Encode(req)
+		if err != nil {
+			return err
+		}
+		rdr = buf
+	}
+
+	data, err := do(ctx, method, url, rdr)
+	if err != nil {
+		return err
+	}
+	if err := json.Unmarshal(data, res); err != nil {
+		return err
+	}
+	return nil
+}
+
+func do(
+	ctx context.Context,
+	method string,
+	url string,
+	body io.Reader,
+) ([]byte, error) {
+	httpReq, err := http.NewRequestWithContext(ctx, method, url, body)
+	if err != nil {
+		return nil, err
+	}
+
+	h := httpReq.Header
+	h.Add("X-Client-Info", "auth-go/v1.0.0")
+	h.Add("X-Supabase-Api-Version", "2024-01-01")
+	h.Add("Content-Type", "application/json")
+	h.Add("Accept", "application/json")
+
+	httpRes, err := http.DefaultClient.Do(httpReq)
+	if err != nil {
+		return nil, err
+	}
+	defer httpRes.Body.Close()
+
+	switch sc := httpRes.StatusCode; {
+	case sc == http.StatusNoContent:
+		return nil, nil
+
+	case sc >= 400:
+		data, err := io.ReadAll(io.LimitReader(httpRes.Body, 1e8))
+		if err != nil {
+			return nil, err
+		}
+
+		apiErr := new(api.HTTPErrorResponse20240101)
+		if err := json.Unmarshal(data, apiErr); err != nil {
+			return nil, err
+		}
+
+		err = &apierrors.HTTPError{
+			HTTPStatus: sc,
+			ErrorCode:  apiErr.Code,
+			Message:    apiErr.Message,
+		}
+		return nil, err
+
+	default:
+		data, err := io.ReadAll(io.LimitReader(httpRes.Body, 1e8))
+		if err != nil {
+			return nil, err
+		}
+		return data, nil
+	}
+}

--- a/internal/e2e/e2eapi/e2eapi_test.go
+++ b/internal/e2e/e2eapi/e2eapi_test.go
@@ -1,0 +1,119 @@
+package e2eapi
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/gofrs/uuid"
+	"github.com/stretchr/testify/require"
+	"github.com/supabase/auth/internal/api"
+	"github.com/supabase/auth/internal/e2e"
+	"github.com/supabase/auth/internal/models"
+)
+
+func TestInstance(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*4)
+	defer cancel()
+
+	globalCfg := e2e.Must(e2e.Config())
+	inst, err := New(globalCfg)
+	if err != nil {
+		t.Fatalf("exp nil err; got %v", err)
+	}
+	defer inst.Close()
+
+	{
+		email := "e2etesthooks_" + uuid.Must(uuid.NewV4()).String() + "@localhost"
+		req := &api.SignupParams{
+			Email:    email,
+			Password: "password",
+		}
+		res := new(models.User)
+		err := Do(ctx, http.MethodPost, inst.APIServer.URL+"/signup", req, res)
+		if err != nil {
+			t.Fatalf("exp nil err; got %v", err)
+		}
+		require.Equal(t, email, res.Email.String())
+	}
+}
+
+func TestNew(t *testing.T) {
+	{
+		globalCfg := e2e.Must(e2e.Config())
+		globalCfg.DB.Driver = ""
+		globalCfg.DB.URL = "invalid"
+
+		inst, err := New(globalCfg)
+		if err == nil {
+			t.Fatal("exp non-nil err")
+		}
+		if inst != nil {
+			t.Fatal("exp nil *Instance")
+		}
+	}
+}
+
+func TestDo(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	globalCfg := e2e.Must(e2e.Config())
+	inst, err := New(globalCfg)
+	if err != nil {
+		t.Fatalf("exp nil err; got %v", err)
+	}
+	defer inst.Close()
+
+	{
+		req := make(chan string)
+		err := Do(ctx, http.MethodPost, "http://localhost", &req, nil)
+		if err == nil {
+			t.Fatal("exp non-nil err")
+		}
+		require.ErrorContains(t, err, "json: unsupported type: chan string")
+	}
+
+	{
+		res := make(chan string)
+		err := Do(ctx, http.MethodGet, inst.APIServer.URL+"/user", nil, &res)
+		if err == nil {
+			t.Fatal("exp non-nil err")
+		}
+		require.ErrorContains(t, err, "401: This endpoint requires a Bearer token")
+	}
+
+	{
+		res := make(chan string)
+		err := Do(ctx, http.MethodGet, inst.APIServer.URL+"/settings", nil, &res)
+		if err == nil {
+			t.Fatal("exp non-nil err")
+		}
+		require.ErrorContains(t, err, "json: cannot unmarshal object into Go value of type chan string")
+	}
+
+	{
+		err := Do(ctx, "\x01", "http://localhost", nil, nil)
+		if err == nil {
+			t.Fatal("exp non-nil err")
+		}
+		require.ErrorContains(t, err, "net/http: invalid method")
+	}
+
+	{
+		err := Do(ctx, http.MethodGet, inst.APIServer.URL+"/404", nil, nil)
+		if err == nil {
+			t.Fatal("exp non-nil err")
+		}
+		require.ErrorContains(t, err, "invalid character")
+	}
+
+	{
+		err := Do(ctx, http.MethodPost, "invalid", nil, nil)
+		if err == nil {
+			t.Fatal("exp non-nil err")
+		}
+		require.ErrorContains(t, err, "unsupported protocol")
+	}
+}

--- a/internal/e2e/e2ehooks/e2ehooks.go
+++ b/internal/e2e/e2ehooks/e2ehooks.go
@@ -1,0 +1,165 @@
+// Package e2ehooks provides utilities for end-to-end testing of hooks.
+package e2ehooks
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/http/httputil"
+	"slices"
+	"sync"
+
+	"github.com/supabase/auth/internal/conf"
+	"github.com/supabase/auth/internal/e2e/e2eapi"
+	"github.com/supabase/auth/internal/hooks/v0hooks"
+	"github.com/supabase/auth/internal/hooks/v1hooks"
+)
+
+type Instance struct {
+	*e2eapi.Instance
+
+	HookServer   *httptest.Server
+	HookRecorder *HookRecorder
+}
+
+func (o *Instance) Close() error {
+	defer o.Instance.Close()
+	defer o.HookServer.Close()
+	return nil
+}
+
+func New(globalCfg *conf.GlobalConfiguration) (*Instance, error) {
+	hookRec := NewHookRecorder()
+	hookSrv := httptest.NewServer(hookRec)
+	hookRec.Register(&globalCfg.Hook, hookSrv.URL)
+
+	test, err := e2eapi.New(globalCfg)
+	if err != nil {
+		defer hookSrv.Close()
+
+		return nil, err
+	}
+
+	o := &Instance{
+		Instance:     test,
+		HookServer:   hookSrv,
+		HookRecorder: hookRec,
+	}
+	return o, nil
+}
+
+type Hook struct {
+	mu    sync.Mutex
+	name  v0hooks.Name
+	calls []*HookCall
+
+	res string
+	hdr http.Header
+}
+
+func NewHook(name v0hooks.Name) *Hook {
+	o := &Hook{
+		name: name,
+	}
+	o.SetResponse(`{}`, http.Header{
+		"content-type": []string{"application/json"},
+	})
+	return o
+}
+
+func (o *Hook) GetCalls() []*HookCall {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	return slices.Clone(o.calls)
+}
+
+func (o *Hook) SetResponse(res string, hdr http.Header) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	o.res = res
+	o.hdr = hdr
+}
+
+func (o *Hook) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+
+	dump, _ := httputil.DumpRequest(r, true)
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		code := http.StatusInternalServerError
+		http.Error(w, http.StatusText(code), code)
+		return
+	}
+
+	hc := &HookCall{
+		Dump:   string(dump),
+		Body:   string(body),
+		Header: r.Header.Clone(),
+	}
+	o.calls = append(o.calls, hc)
+
+	for name, vals := range o.hdr {
+		for _, val := range vals {
+			w.Header().Add(name, val)
+		}
+	}
+	io.WriteString(w, o.res)
+}
+
+type HookCall struct {
+	Header http.Header
+	Body   string
+	Dump   string
+}
+
+func (o *HookCall) Unmarshal(v any) error {
+	return json.Unmarshal([]byte(o.Body), v)
+}
+
+type HookRecorder struct {
+	mux               *http.ServeMux
+	BeforeUserCreated *Hook
+	AfterUserCreated  *Hook
+}
+
+func NewHookRecorder() *HookRecorder {
+	o := &HookRecorder{
+		mux:               http.NewServeMux(),
+		BeforeUserCreated: NewHook(v1hooks.BeforeUserCreated),
+		AfterUserCreated:  NewHook(v1hooks.AfterUserCreated),
+	}
+
+	o.mux.HandleFunc("POST /hooks/{hook}", func(w http.ResponseWriter, r *http.Request) {
+		switch v0hooks.Name(r.PathValue("hook")) {
+		case v1hooks.BeforeUserCreated:
+			o.BeforeUserCreated.ServeHTTP(w, r)
+
+		case v1hooks.AfterUserCreated:
+			o.AfterUserCreated.ServeHTTP(w, r)
+
+		default:
+			http.NotFound(w, r)
+		}
+	})
+	return o
+}
+
+func (o *HookRecorder) Register(
+	hookCfg *conf.HookConfiguration,
+	baseURL string,
+) {
+	hookCfg.BeforeUserCreated = conf.ExtensibilityPointConfiguration{
+		Enabled: true,
+		URI:     baseURL + "/hooks/" + string(v1hooks.BeforeUserCreated),
+	}
+	hookCfg.AfterUserCreated = conf.ExtensibilityPointConfiguration{
+		Enabled: true,
+		URI:     baseURL + "/hooks/" + string(v1hooks.AfterUserCreated),
+	}
+}
+
+func (o *HookRecorder) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	o.mux.ServeHTTP(w, r)
+}

--- a/internal/e2e/e2ehooks/e2ehooks_test.go
+++ b/internal/e2e/e2ehooks/e2ehooks_test.go
@@ -1,0 +1,256 @@
+package e2ehooks
+
+import (
+	"context"
+	"errors"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"testing/iotest"
+	"time"
+
+	"github.com/supabase/auth/internal/conf"
+	"github.com/supabase/auth/internal/hooks/v0hooks"
+	"github.com/supabase/auth/internal/hooks/v1hooks"
+)
+
+func TestInstance(t *testing.T) {
+	{
+		globalCfg, err := conf.LoadGlobal("../../../hack/test.env")
+		if err != nil {
+			t.Fatalf("exp nil err; got %v", err)
+		}
+		globalCfg.DB.Driver = ""
+		globalCfg.DB.URL = "invalid"
+
+		inst, err := New(globalCfg)
+		if err == nil {
+			t.Fatal("exp non-nil err")
+		}
+		if inst != nil {
+			t.Fatal("exp nil *Instance")
+		}
+	}
+
+	{
+		globalCfg, err := conf.LoadGlobal("../../../hack/test.env")
+		if err != nil {
+			t.Fatalf("exp nil err; got %v", err)
+		}
+
+		inst, err := New(globalCfg)
+		if err != nil {
+			t.Fatalf("exp nil err; got %v", err)
+		}
+		if inst == nil {
+			t.Fatal("exp non-nil *Instance")
+		}
+		if err := inst.Close(); err != nil {
+			t.Fatalf("exp nil err from Close; got %v", err)
+		}
+	}
+}
+
+func TestHook(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+	defer cancel()
+
+	hook := NewHook(v1hooks.AfterUserCreated)
+
+	{
+		calls := hook.GetCalls()
+		if exp, got := 0, len(calls); exp != got {
+			t.Fatalf("exp %v; got %v", exp, got)
+		}
+
+		u := "http://localhost"
+		rdr := strings.NewReader("12345")
+		req := httptest.NewRequestWithContext(ctx, "POST", u, rdr)
+		res := httptest.NewRecorder()
+
+		hook.ServeHTTP(res, req)
+
+		calls = hook.GetCalls()
+		if exp, got := 1, len(calls); exp != got {
+			t.Fatalf("exp %v; got %v", exp, got)
+		}
+		call := calls[0]
+
+		var got int
+		if err := call.Unmarshal(&got); err != nil {
+			t.Fatalf("exp nil err; got %v", err)
+		}
+		if exp := 12345; exp != got {
+			t.Fatalf("exp %v; got %v", exp, got)
+		}
+	}
+
+	{
+		u := "http://localhost/hooks/before-user-created"
+		sentinel := errors.New("sentinel")
+		rdr := iotest.ErrReader(sentinel)
+		req := httptest.NewRequestWithContext(ctx, "POST", u, rdr)
+		res := httptest.NewRecorder()
+
+		hook.ServeHTTP(res, req)
+	}
+}
+
+func TestHookRecorder(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+	defer cancel()
+
+	hookRec := NewHookRecorder()
+	tests := []struct {
+		name v0hooks.Name
+		hook *Hook
+	}{
+		{
+			name: v1hooks.BeforeUserCreated,
+			hook: hookRec.BeforeUserCreated,
+		},
+		{
+			name: v1hooks.AfterUserCreated,
+			hook: hookRec.AfterUserCreated,
+		},
+	}
+
+	for _, test := range tests {
+
+		{
+			calls := test.hook.GetCalls()
+			if exp, got := 0, len(calls); exp != got {
+				t.Fatalf("exp %v; got %v", exp, got)
+			}
+		}
+
+		u := "http://localhost/hooks/" + string(test.name)
+		rdr := strings.NewReader("12345")
+		req := httptest.NewRequestWithContext(ctx, "POST", u, rdr)
+		res := httptest.NewRecorder()
+		hookRec.ServeHTTP(res, req)
+
+		{
+			calls := test.hook.GetCalls()
+			if exp, got := 1, len(calls); exp != got {
+				t.Fatalf("exp %v; got %v", exp, got)
+			}
+			call := calls[0]
+
+			var got int
+			if err := call.Unmarshal(&got); err != nil {
+				t.Fatalf("exp nil err; got %v", err)
+			}
+			if exp := 12345; exp != got {
+				t.Fatalf("exp %v; got %v", exp, got)
+			}
+		}
+	}
+
+	// not found
+	{
+		u := "http://localhost/hooks/__invalid-hook-name__"
+		rdr := strings.NewReader("12345")
+		req := httptest.NewRequestWithContext(ctx, "POST", u, rdr)
+		res := httptest.NewRecorder()
+		hookRec.ServeHTTP(res, req)
+
+		if exp, got := 404, res.Result().StatusCode; exp != got {
+			t.Fatalf("exp %v; got %v", exp, got)
+		}
+	}
+}
+
+/*
+
+func TestUserHooks(t *testing.T) {
+	t.SkipNow()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+	defer cancel()
+
+	globalCfg, err := conf.LoadGlobal("../../../hack/test.env")
+	if err != nil {
+		t.Fatalf("exp nil err; got %v", err)
+	}
+
+	inst, err := New(globalCfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer inst.Close()
+
+	apiCli := inst.APIClient
+	apiSrv := inst.APIServer
+	hookRec := inst.HookRecorder
+
+	// Basic tests for Before/After User Created hooks
+	{
+
+		// Signup a user
+		var signupUser *models.User
+		email := "e2etesthooks_" + uuid.Must(uuid.NewV4()).String() + "@localhost"
+		{
+			req := &api.SignupParams{
+				Email:    email,
+				Password: "password",
+			}
+			res := new(models.User)
+			err := apiCli.Do(ctx, http.MethodPost, apiSrv.URL+"/signup", req, res)
+			if err != nil {
+				t.Fatalf("exp nil err; got %v", err)
+			}
+			signupUser = res
+
+			require.Equal(t, email, signupUser.Email.String())
+		}
+
+		{
+			calls := hookRec.BeforeUserCreated.GetCalls()
+			if exp, got := 1, len(calls); exp != got {
+				t.Fatalf("exp %v; got %v", exp, got)
+			}
+			call := calls[0]
+
+			hookReq := &v1hooks.BeforeUserCreatedRequest{}
+			if err := call.Unmarshal(hookReq); err != nil {
+				t.Fatalf("exp nil err; got %v", err)
+			}
+
+			u := hookReq.User
+			require.Equal(t, signupUser.ID, u.ID)
+			require.Equal(t, signupUser.Aud, u.Aud)
+			require.Equal(t, signupUser.Email, u.Email)
+			require.Equal(t, signupUser.AppMetaData, u.AppMetaData)
+
+			require.True(t, u.CreatedAt.IsZero())
+			require.True(t, u.UpdatedAt.IsZero())
+		}
+
+		{
+			calls := hookRec.AfterUserCreated.GetCalls()
+			if exp, got := 1, len(calls); exp != got {
+				t.Fatalf("exp %v; got %v", exp, got)
+			}
+			call := calls[0]
+
+			hookReq := &v1hooks.AfterUserCreatedRequest{}
+			if err := call.Unmarshal(hookReq); err != nil {
+				t.Fatalf("exp nil err; got %v", err)
+			}
+
+			u := hookReq.User
+			require.Equal(t, signupUser.ID, u.ID)
+			require.Equal(t, signupUser.Aud, u.Aud)
+			require.Equal(t, signupUser.Role, u.Role)
+			require.Equal(t, signupUser.Email, u.Email)
+			require.Equal(t, signupUser.AppMetaData, u.AppMetaData)
+
+			require.Equal(t, signupUser.CreatedAt, u.CreatedAt)
+			require.True(t, signupUser.CreatedAt.Before(u.UpdatedAt))
+			require.True(t, signupUser.UpdatedAt.After(u.UpdatedAt))
+		}
+	}
+}
+
+*/

--- a/internal/e2e/example_test.go
+++ b/internal/e2e/example_test.go
@@ -1,0 +1,35 @@
+package e2e_test
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/supabase/auth/internal/conf"
+	"github.com/supabase/auth/internal/e2e"
+)
+
+func Example_config() {
+	testCfgPath := "../../hack/test.env"
+	testCfg := e2e.Must(conf.LoadGlobal(testCfgPath))
+	globalCfg := e2e.Must(e2e.Config())
+
+	if reflect.DeepEqual(testCfg, globalCfg) {
+		fmt.Println("e2e.Config is equal to the config in hack/test.env")
+	} else {
+		fmt.Println("e2e.Config loaded an unknown config file")
+	}
+
+	// Output:
+	// e2e.Config is equal to the config in hack/test.env
+}
+
+func Example_conn() {
+	globalCfg := e2e.Must(e2e.Config())
+	conn := e2e.Must(e2e.Conn(globalCfg))
+	if conn != nil {
+		fmt.Println("e2e.Conn connection returned using hack/test.env")
+	}
+
+	// Output:
+	// e2e.Conn connection returned using hack/test.env
+}

--- a/internal/hooks/dispatch/dispatch.go
+++ b/internal/hooks/dispatch/dispatch.go
@@ -1,0 +1,96 @@
+// Package dispatch is responsible for dispatching hook requests to the http
+// or pgfunc packages. It is utilized by both the v0 and v1 hooks packages.
+package dispatch
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"github.com/supabase/auth/internal/api/apierrors"
+	"github.com/supabase/auth/internal/conf"
+	"github.com/supabase/auth/internal/hooks/v0hooks/v0http"
+	"github.com/supabase/auth/internal/hooks/v0hooks/v0pgfunc"
+	"github.com/supabase/auth/internal/observability"
+	"github.com/supabase/auth/internal/storage"
+)
+
+type Service interface {
+	Dispatch(
+		ctx context.Context,
+		hookConfig *conf.ExtensibilityPointConfiguration,
+		conn *storage.Connection,
+		input, output any,
+	) error
+}
+
+type Dispatcher struct {
+	v0http   v0http.Service
+	v0pgfunc v0pgfunc.Service
+}
+
+func New(
+	v0http v0http.Service,
+	v0pgfunc v0pgfunc.Service,
+) *Dispatcher {
+	o := &Dispatcher{
+		v0http:   v0http,
+		v0pgfunc: v0pgfunc,
+	}
+	return o
+}
+
+func (o *Dispatcher) Dispatch(
+	ctx context.Context,
+	hookConfig *conf.ExtensibilityPointConfiguration,
+	conn *storage.Connection,
+	input, output any,
+) error {
+	logEntry := observability.GetLogEntryFromContext(ctx)
+	hookStart := time.Now()
+
+	var err error
+	switch {
+	case strings.HasPrefix(hookConfig.URI, "http:") ||
+		strings.HasPrefix(hookConfig.URI, "https:"):
+		err = o.v0http.HTTPDispatch(ctx, *hookConfig, input, output)
+
+	case strings.HasPrefix(hookConfig.URI, "pg-functions:"):
+		err = o.v0pgfunc.PGFuncDispatch(ctx, *hookConfig, conn, input, output)
+
+	default:
+		return fmt.Errorf(
+			"unsupported protocol: %q only postgres hooks and HTTPS functions"+
+				" are supported at the moment", hookConfig.URI)
+	}
+
+	duration := time.Since(hookStart)
+
+	if err != nil {
+		logEntry.Entry.WithFields(logrus.Fields{
+			"action":   "run_hook",
+			"hook":     hookConfig.URI,
+			"success":  false,
+			"duration": duration.Microseconds(),
+		}).WithError(err).Warn("Hook errored out")
+
+		e := new(apierrors.HTTPError)
+		if errors.As(err, &e) {
+			return e
+		}
+		return apierrors.NewInternalServerError(
+			"Error running hook URI: %v", hookConfig.URI).WithInternalError(err)
+	}
+
+	logEntry.Entry.WithFields(logrus.Fields{
+		"action":   "run_hook",
+		"hook":     hookConfig.URI,
+		"success":  true,
+		"duration": duration.Microseconds(),
+	}).WithError(err).Info("Hook ran successfully")
+
+	return nil
+}

--- a/internal/hooks/dispatch/dispatch_test.go
+++ b/internal/hooks/dispatch/dispatch_test.go
@@ -1,0 +1,133 @@
+package dispatch
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/supabase/auth/internal/conf"
+	"github.com/supabase/auth/internal/hooks/hookerrors"
+	"github.com/supabase/auth/internal/storage"
+)
+
+func TestDispatcher(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	basicErr := errors.New("error")
+	basicErrSvc := &mockService{err: basicErr}
+	hookErr := &hookerrors.Error{Message: "failed", HTTPCode: 403}
+	hookErrSvc := &mockService{err: hookErr}
+
+	cases := []struct {
+		desc   string
+		cfg    *conf.ExtensibilityPointConfiguration
+		dr     *Dispatcher
+		errStr string
+	}{
+		{
+			desc: "success - dispatch to pg-functions",
+			cfg: &conf.ExtensibilityPointConfiguration{
+				URI: `pg-functions://postgres/test`,
+			},
+		},
+
+		{
+			desc: "success - dispatch to http uri",
+			cfg: &conf.ExtensibilityPointConfiguration{
+				URI: `http://localhost/test`,
+			},
+		},
+
+		{
+			desc: "success - dispatch to https uri",
+			cfg: &conf.ExtensibilityPointConfiguration{
+				URI: `https://localhost/test`,
+			},
+		},
+
+		{
+			desc: "failure - dispatch to invalid uri",
+			cfg: &conf.ExtensibilityPointConfiguration{
+				URI: `unknown://localhost/test`,
+			},
+			errStr: `unsupported protocol: "unknown://localhost/test"`,
+		},
+
+		{
+			desc: "failure - dispatch has service error",
+			cfg: &conf.ExtensibilityPointConfiguration{
+				URI: `https://localhost/test`,
+			},
+			dr:     New(hookErrSvc, hookErrSvc),
+			errStr: `403: failed`,
+		},
+
+		{
+			desc: "failure - dispatch has service error not HTTPError",
+			cfg: &conf.ExtensibilityPointConfiguration{
+				URI: `https://localhost/test`,
+			},
+			dr:     New(basicErrSvc, basicErrSvc),
+			errStr: `500: Error running hook URI: https://localhost/test`,
+		},
+	}
+
+	for idx, tc := range cases {
+		t.Logf("test #%v - %v", idx, tc.desc)
+
+		dr := tc.dr
+		if dr == nil {
+			mockSvc := &mockService{}
+			dr = New(mockSvc, mockSvc)
+		}
+
+		err := dr.Dispatch(ctx, tc.cfg, nil, nil, nil)
+		if tc.errStr != "" {
+			require.Error(t, err)
+			require.Contains(t, err.Error(), tc.errStr)
+			continue
+		}
+		require.NoError(t, err)
+	}
+}
+
+type mockService struct{ err error }
+
+func (o *mockService) PGFuncDispatch(
+	ctx context.Context,
+	cfg conf.ExtensibilityPointConfiguration,
+	tx *storage.Connection,
+	req any,
+	res any,
+) error {
+	return o.err
+}
+
+func (o *mockService) RunPostgresHook(
+	ctx context.Context,
+	hookConfig conf.ExtensibilityPointConfiguration,
+	tx *storage.Connection,
+	input any,
+) ([]byte, error) {
+	return nil, o.err
+}
+
+func (o *mockService) HTTPDispatch(
+	ctx context.Context,
+	cfg conf.ExtensibilityPointConfiguration,
+	req any,
+	res any,
+) error {
+	return o.err
+}
+
+func (o *mockService) RunHTTPHook(
+	ctx context.Context,
+	hookConfig conf.ExtensibilityPointConfiguration,
+	input any,
+) ([]byte, error) {
+	return nil, o.err
+}

--- a/internal/hooks/hookerrors/hookerrors.go
+++ b/internal/hooks/hookerrors/hookerrors.go
@@ -1,0 +1,97 @@
+package hookerrors
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/supabase/auth/internal/api/apierrors"
+)
+
+type Error struct {
+	HTTPCode int    `json:"http_code,omitempty"`
+	Message  string `json:"message,omitempty"`
+}
+
+func (e *Error) Error() string { return e.Message }
+func (e *Error) As(target any) bool {
+	switch T := target.(type) {
+	case **Error:
+		v := (*T)
+		if v == nil {
+			return false
+		}
+		v.HTTPCode = e.HTTPCode
+		v.Message = e.Message
+		return true
+	case *Error:
+		T.HTTPCode = e.HTTPCode
+		T.Message = e.Message
+		return true
+	case **apierrors.HTTPError:
+		v := (*T)
+		if v == nil {
+			return false
+		}
+		v.HTTPStatus = e.HTTPCode
+		v.Message = e.Message
+		return true
+	case *apierrors.HTTPError:
+		T.HTTPStatus = e.HTTPCode
+		T.Message = e.Message
+		return true
+	default:
+		return false
+	}
+}
+
+func Check(b []byte) error {
+	e, ok := fromBytes(b)
+	if !ok {
+		return nil
+	}
+	return check(e)
+}
+
+func check(e *Error) error {
+	if e == nil {
+		return nil
+	}
+
+	// TODO(cstockton): Changing this would be a BC break, but it also
+	// doesn't seem to be the best API. For example returning an error object
+	// with an http_code field set to 500 would not count as an error.
+	if e.Message == "" {
+		return nil
+	}
+
+	httpCode := e.HTTPCode
+	if httpCode == 0 {
+		httpCode = http.StatusInternalServerError
+	}
+
+	httpError := &apierrors.HTTPError{
+		HTTPStatus: httpCode,
+		Message:    e.Message,
+	}
+	return httpError.WithInternalError(e)
+}
+
+func fromBytes(b []byte) (*Error, bool) {
+	var dst struct {
+		Error *struct {
+			HTTPCode int    `json:"http_code,omitempty"`
+			Message  string `json:"message,omitempty"`
+		} `json:"error,omitempty"`
+	}
+	if err := json.Unmarshal(b, &dst); err != nil {
+		return nil, false
+	}
+	if dst.Error == nil {
+		return nil, false
+	}
+	e := &Error{
+		HTTPCode: dst.Error.HTTPCode,
+		Message:  dst.Error.Message,
+	}
+	return e, true
+}

--- a/internal/hooks/hookerrors/hookerrors_test.go
+++ b/internal/hooks/hookerrors/hookerrors_test.go
@@ -1,0 +1,255 @@
+package hookerrors
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/supabase/auth/internal/api/apierrors"
+)
+
+func TestFromBytes(t *testing.T) {
+	cases := []struct {
+		from string
+		ok   bool
+		exp  *Error
+	}{
+		{from: `<b>text</b>`},
+		{from: `null`},
+		{from: `{}`},
+		{from: `{"key": "val"}`},
+		{from: `{"error": null}`},
+
+		{
+			from: `{"error": {"message": "failed"}}`,
+			ok:   true, exp: &Error{HTTPCode: 0, Message: "failed"},
+		},
+		{
+			from: `{"error": {"http_code": 400}}`,
+			ok:   true, exp: &Error{HTTPCode: 400},
+		},
+		{
+			from: `{"error": {"message": "failed", "http_code": 400}}`,
+			ok:   true, exp: &Error{HTTPCode: 400, Message: "failed"},
+		},
+		{
+			from: `{"error": {"message": "failed", "http_code": 403}}`,
+			ok:   true, exp: &Error{HTTPCode: 403, Message: "failed"},
+		},
+	}
+	for idx, tc := range cases {
+		t.Logf("test #%v - exp Check(%v) = (%#v, %v)", idx, tc.from, tc.exp, tc.ok)
+
+		e, ok := fromBytes([]byte(tc.from))
+		if exp, got := tc.ok, ok; exp != got {
+			t.Fatalf("exp %v; got %v", exp, got)
+		}
+		if !tc.ok {
+			if e != nil {
+				t.Fatalf("exp nil; got %v", e)
+			}
+			continue
+		}
+		if exp, got := tc.exp.HTTPCode, e.HTTPCode; exp != got {
+			t.Fatalf("exp HTTPCode %v; got %v", exp, got)
+		}
+		if exp, got := tc.exp.Message, e.Message; exp != got {
+			t.Fatalf("exp Message %q; got %q", exp, got)
+		}
+
+		err := (error)(e)
+		if exp, got := tc.exp.Message, err.Error(); exp != got {
+			t.Fatalf("exp Error() %q; got %q", exp, got)
+		}
+	}
+}
+
+func TestCheck(t *testing.T) {
+	{
+		if err := Check([]byte(`invalidjson`)); err != nil {
+			t.Fatalf("exp nil err; got %v", err)
+		}
+		if err := Check([]byte(`{"error": nil}`)); err != nil {
+			t.Fatalf("exp nil err; got %v", err)
+		}
+		if err := Check([]byte(`{"error": {"message": "failed"}}`)); err == nil {
+			t.Fatal("exp non-nil err")
+		}
+
+		{
+			data := `{"error": {"message": "failed", "http_code": 403}}`
+			err := Check([]byte(data))
+			if err == nil {
+				t.Fatal("exp non-nil err")
+			}
+
+			e, ok := err.(*apierrors.HTTPError)
+			if !ok {
+				t.Fatal("exp error to be http.Error")
+			}
+			if exp, got := e.HTTPStatus, 403; exp != got {
+				t.Fatalf("exp HTTPCode %v; got %v", exp, got)
+			}
+			if exp, got := e.Message, "failed"; exp != got {
+				t.Fatalf("exp Message %q; got %q", exp, got)
+			}
+		}
+	}
+
+	{
+		if err := check(nil); err != nil {
+			t.Fatalf("exp nil err; got %v", err)
+		}
+		if err := check(&Error{Message: ""}); err != nil {
+			t.Fatalf("exp nil err; got %v", err)
+		}
+		if err := check(&Error{Message: "failed"}); err == nil {
+			t.Fatal("exp non-nil err")
+		}
+	}
+}
+
+func TestAs(t *testing.T) {
+
+	{
+		err := &Error{
+			Message:  "failed",
+			HTTPCode: 403,
+		}
+		e := new(apierrors.HTTPError)
+		if !errors.As(err, &e) {
+			t.Fatal("exp errors.As to return true")
+		}
+		if exp, got := e.HTTPStatus, 403; exp != got {
+			t.Fatalf("exp HTTPCode %v; got %v", exp, got)
+		}
+		if exp, got := e.Message, "failed"; exp != got {
+			t.Fatalf("exp Message %q; got %q", exp, got)
+		}
+	}
+
+	{
+		err := &Error{
+			Message:  "failed",
+			HTTPCode: 403,
+		}
+		e := new(Error)
+		if !errors.As(err, &e) {
+			t.Fatal("exp errors.As to return true")
+		}
+		if exp, got := e.HTTPCode, 403; exp != got {
+			t.Fatalf("exp HTTPCode %v; got %v", exp, got)
+		}
+		if exp, got := e.Message, "failed"; exp != got {
+			t.Fatalf("exp Message %q; got %q", exp, got)
+		}
+	}
+
+	{
+		err := &Error{
+			Message:  "failed",
+			HTTPCode: 403,
+		}
+		e := new(apierrors.HTTPError)
+		if !err.As(&e) {
+			t.Fatal("exp errors.As to return true")
+		}
+		if exp, got := e.HTTPStatus, 403; exp != got {
+			t.Fatalf("exp HTTPCode %v; got %v", exp, got)
+		}
+		if exp, got := e.Message, "failed"; exp != got {
+			t.Fatalf("exp Message %q; got %q", exp, got)
+		}
+	}
+
+	{
+		err := &Error{
+			Message:  "failed",
+			HTTPCode: 403,
+		}
+		e := new(Error)
+		if !err.As(&e) {
+			t.Fatal("exp errors.As to return true")
+		}
+		if exp, got := e.HTTPCode, 403; exp != got {
+			t.Fatalf("exp HTTPCode %v; got %v", exp, got)
+		}
+		if exp, got := e.Message, "failed"; exp != got {
+			t.Fatalf("exp Message %q; got %q", exp, got)
+		}
+	}
+
+	{
+		err := &Error{
+			Message:  "failed",
+			HTTPCode: 403,
+		}
+		e := new(apierrors.HTTPError)
+		if !err.As(e) {
+			t.Fatal("exp errors.As to return true")
+		}
+		if exp, got := e.HTTPStatus, 403; exp != got {
+			t.Fatalf("exp HTTPCode %v; got %v", exp, got)
+		}
+		if exp, got := e.Message, "failed"; exp != got {
+			t.Fatalf("exp Message %q; got %q", exp, got)
+		}
+	}
+
+	{
+		err := &Error{
+			Message:  "failed",
+			HTTPCode: 403,
+		}
+		e := new(Error)
+		if !err.As(e) {
+			t.Fatal("exp errors.As to return true")
+		}
+		if exp, got := e.HTTPCode, 403; exp != got {
+			t.Fatalf("exp HTTPCode %v; got %v", exp, got)
+		}
+		if exp, got := e.Message, "failed"; exp != got {
+			t.Fatalf("exp Message %q; got %q", exp, got)
+		}
+	}
+
+	{
+		err := errors.New("sentinel")
+		e := new(Error)
+		if errors.As(err, &e) {
+			t.Fatal("exp errors.As to return false")
+		}
+	}
+
+	{
+		err := &Error{
+			Message:  "failed",
+			HTTPCode: 403,
+		}
+		e := (*Error)(nil)
+		if err.As(&e) {
+			t.Fatal("exp errors.As to return false")
+		}
+	}
+
+	{
+		err := &Error{
+			Message:  "failed",
+			HTTPCode: 403,
+		}
+		e := (*apierrors.HTTPError)(nil)
+		if err.As(&e) {
+			t.Fatal("exp errors.As to return false")
+		}
+	}
+
+	{
+		err := &Error{
+			Message:  "failed",
+			HTTPCode: 403,
+		}
+		e := (*error)(nil)
+		if err.As(&e) {
+			t.Fatal("exp errors.As to return false")
+		}
+	}
+}

--- a/internal/hooks/hooks.go
+++ b/internal/hooks/hooks.go
@@ -1,28 +1,47 @@
 package hooks
 
 import (
+	"context"
 	"net/http"
 
 	"github.com/supabase/auth/internal/conf"
+	"github.com/supabase/auth/internal/hooks/dispatch"
 	"github.com/supabase/auth/internal/hooks/v0hooks"
 	"github.com/supabase/auth/internal/hooks/v0hooks/v0http"
 	"github.com/supabase/auth/internal/hooks/v0hooks/v0pgfunc"
+	"github.com/supabase/auth/internal/hooks/v1hooks"
 	"github.com/supabase/auth/internal/storage"
 )
 
 type Manager struct {
-	v0mgr *v0hooks.Manager
+	v0svc v0hooks.Service
+	v1svc v1hooks.Service
 }
 
-func NewManager(
+func New(
+	globalConfig *conf.GlobalConfiguration,
 	db *storage.Connection,
-	config *conf.GlobalConfiguration,
 ) *Manager {
 	httpDr := v0http.New()
 	pgfuncDr := v0pgfunc.New(db)
+	dr := dispatch.New(httpDr, pgfuncDr)
+	v0svc := v0hooks.New(globalConfig, httpDr, pgfuncDr)
+	v1svc := v1hooks.New(&globalConfig.Hook, dr)
+	return NewFromServices(v0svc, v1svc)
+}
+
+func NewFromServices(
+	v0svc v0hooks.Service,
+	v1svc v1hooks.Service,
+) *Manager {
 	return &Manager{
-		v0mgr: v0hooks.NewManager(config, httpDr, pgfuncDr),
+		v0svc: v0svc,
+		v1svc: v1svc,
 	}
+}
+
+func (o *Manager) Enabled(name v0hooks.Name) bool {
+	return o.v0svc.Enabled(name) || o.v1svc.Enabled(name)
 }
 
 func (o *Manager) InvokeHook(
@@ -30,7 +49,7 @@ func (o *Manager) InvokeHook(
 	r *http.Request,
 	input, output any,
 ) error {
-	return o.v0mgr.InvokeHook(conn, r, input, output)
+	return o.v0svc.InvokeHook(conn, r, input, output)
 }
 
 func (o *Manager) RunHTTPHook(
@@ -38,5 +57,23 @@ func (o *Manager) RunHTTPHook(
 	hookConfig conf.ExtensibilityPointConfiguration,
 	input any,
 ) ([]byte, error) {
-	return o.v0mgr.RunHTTPHook(r, hookConfig, input)
+	return o.v0svc.RunHTTPHook(r, hookConfig, input)
+}
+
+func (o *Manager) BeforeUserCreated(
+	ctx context.Context,
+	tx *storage.Connection,
+	req *v1hooks.BeforeUserCreatedRequest,
+	res *v1hooks.BeforeUserCreatedResponse,
+) error {
+	return o.v1svc.BeforeUserCreated(ctx, tx, req, res)
+}
+
+func (o *Manager) AfterUserCreated(
+	ctx context.Context,
+	tx *storage.Connection,
+	req *v1hooks.AfterUserCreatedRequest,
+	res *v1hooks.AfterUserCreatedResponse,
+) error {
+	return o.v1svc.AfterUserCreated(ctx, tx, req, res)
 }

--- a/internal/hooks/v0hooks/manager.go
+++ b/internal/hooks/v0hooks/manager.go
@@ -1,38 +1,59 @@
 package v0hooks
 
 import (
-	"fmt"
 	"net/http"
-	"strings"
-	"time"
-
-	"github.com/sirupsen/logrus"
-	"github.com/xeipuuv/gojsonschema"
 
 	"github.com/supabase/auth/internal/api/apierrors"
 	"github.com/supabase/auth/internal/conf"
+	"github.com/supabase/auth/internal/hooks/dispatch"
 	"github.com/supabase/auth/internal/hooks/v0hooks/v0http"
 	"github.com/supabase/auth/internal/hooks/v0hooks/v0pgfunc"
-	"github.com/supabase/auth/internal/observability"
 	"github.com/supabase/auth/internal/storage"
 )
 
 type Manager struct {
-	config   *conf.GlobalConfiguration
-	v0http   *v0http.Dispatcher
-	v0pgfunc *v0pgfunc.Dispatcher
+	config *conf.GlobalConfiguration
+	v0http v0http.Service
+	dr     dispatch.Service
 }
 
-func NewManager(
+func New(
 	config *conf.GlobalConfiguration,
-	httpDr *v0http.Dispatcher,
-	pgfuncDr *v0pgfunc.Dispatcher,
+	httpSvc v0http.Service,
+	pgfuncSvc v0pgfunc.Service,
 ) *Manager {
 	return &Manager{
-		config:   config,
-		v0http:   httpDr,
-		v0pgfunc: pgfuncDr,
+		config: config,
+		v0http: httpSvc,
+		dr:     dispatch.New(httpSvc, pgfuncSvc),
 	}
+}
+
+func configByName(
+	cfg *conf.HookConfiguration,
+	name Name,
+) (*conf.ExtensibilityPointConfiguration, bool) {
+	switch name {
+	case SendSMS:
+		return &cfg.SendSMS, true
+	case SendEmail:
+		return &cfg.SendEmail, true
+	case CustomizeAccessToken:
+		return &cfg.CustomAccessToken, true
+	case MFAVerification:
+		return &cfg.MFAVerificationAttempt, true
+	case PasswordVerification:
+		return &cfg.PasswordVerificationAttempt, true
+	default:
+		return nil, false
+	}
+}
+
+func (o *Manager) Enabled(name Name) bool {
+	if cfg, ok := configByName(&o.config.Hook, name); ok {
+		return cfg.Enabled
+	}
+	return false
 }
 
 func (o *Manager) InvokeHook(
@@ -60,175 +81,50 @@ func (o *Manager) invokeHook(
 	r *http.Request,
 	input, output any,
 ) error {
-	var err error
 	switch input.(type) {
 	default:
 		return apierrors.NewInternalServerError(
 			"Unknown hook type %T.", input)
 
 	case *SendSMSInput:
-		hookOutput, ok := output.(*SendSMSOutput)
-		if !ok {
+		if _, ok := output.(*SendSMSOutput); !ok {
 			return apierrors.NewInternalServerError(
 				"output should be *hooks.SendSMSOutput")
 		}
-		if err = o.runHook(r, conn, o.config.Hook.SendSMS, input, hookOutput); err != nil {
-			return err
-		}
-		return checkError(hookOutput)
+		return o.dr.Dispatch(
+			r.Context(), &o.config.Hook.SendSMS, conn, input, output)
 
 	case *SendEmailInput:
-		hookOutput, ok := output.(*SendEmailOutput)
-		if !ok {
+		if _, ok := output.(*SendEmailOutput); !ok {
 			return apierrors.NewInternalServerError(
 				"output should be *hooks.SendEmailOutput")
 		}
-		if err := o.runHook(r, conn, o.config.Hook.SendEmail, input, hookOutput); err != nil {
-			return err
-		}
-		return checkError(hookOutput)
+		return o.dr.Dispatch(
+			r.Context(), &o.config.Hook.SendEmail, conn, input, output)
 
 	case *MFAVerificationAttemptInput:
-		hookOutput, ok := output.(*MFAVerificationAttemptOutput)
-		if !ok {
+		if _, ok := output.(*MFAVerificationAttemptOutput); !ok {
 			return apierrors.NewInternalServerError(
 				"output should be *hooks.MFAVerificationAttemptOutput")
 		}
-		if err := o.runHook(r, conn, o.config.Hook.MFAVerificationAttempt, input, hookOutput); err != nil {
-			return err
-		}
-		return checkError(hookOutput)
+		return o.dr.Dispatch(
+			r.Context(), &o.config.Hook.MFAVerificationAttempt, conn, input, output)
 
 	case *PasswordVerificationAttemptInput:
-		hookOutput, ok := output.(*PasswordVerificationAttemptOutput)
-		if !ok {
+		if _, ok := output.(*PasswordVerificationAttemptOutput); !ok {
 			return apierrors.NewInternalServerError(
 				"output should be *hooks.PasswordVerificationAttemptOutput")
 		}
-		if err := o.runHook(r, conn, o.config.Hook.PasswordVerificationAttempt, input, hookOutput); err != nil {
-			return err
-		}
-		return checkError(hookOutput)
+		return o.dr.Dispatch(
+			r.Context(), &o.config.Hook.PasswordVerificationAttempt, conn, input, output)
 
 	case *CustomAccessTokenInput:
-		hookOutput, ok := output.(*CustomAccessTokenOutput)
+		_, ok := output.(*CustomAccessTokenOutput)
 		if !ok {
 			return apierrors.NewInternalServerError(
 				"output should be *hooks.CustomAccessTokenOutput")
 		}
-		if err := o.runHook(r, conn, o.config.Hook.CustomAccessToken, input, hookOutput); err != nil {
-			return err
-		}
-		if err := checkError(hookOutput); err != nil {
-			return err
-		}
-		if err := validateTokenClaims(hookOutput.Claims); err != nil {
-			httpCode := hookOutput.HookError.HTTPCode
-
-			if httpCode == 0 {
-				httpCode = http.StatusInternalServerError
-			}
-			httpError := &apierrors.HTTPError{
-				HTTPStatus: httpCode,
-				Message:    err.Error(),
-			}
-			return httpError
-		}
-		return nil
+		return o.dr.Dispatch(
+			r.Context(), &o.config.Hook.CustomAccessToken, conn, input, output)
 	}
-}
-
-func (o *Manager) runHook(
-	r *http.Request,
-	conn *storage.Connection,
-	hookConfig conf.ExtensibilityPointConfiguration,
-	input, output any,
-) error {
-	ctx := r.Context()
-
-	logEntry := observability.GetLogEntry(r)
-	hookStart := time.Now()
-
-	var err error
-	switch {
-	case strings.HasPrefix(hookConfig.URI, "http:") ||
-		strings.HasPrefix(hookConfig.URI, "https:"):
-		err = o.v0http.Dispatch(ctx, hookConfig, input, output)
-
-	case strings.HasPrefix(hookConfig.URI, "pg-functions:"):
-		err = o.v0pgfunc.Dispatch(ctx, hookConfig, conn, input, output)
-
-	default:
-		return fmt.Errorf(
-			"unsupported protocol: %q only postgres hooks and HTTPS functions"+
-				" are supported at the moment", hookConfig.URI)
-	}
-
-	duration := time.Since(hookStart)
-
-	if err != nil {
-		logEntry.Entry.WithFields(logrus.Fields{
-			"action":   "run_hook",
-			"hook":     hookConfig.URI,
-			"success":  false,
-			"duration": duration.Microseconds(),
-		}).WithError(err).Warn("Hook errored out")
-
-		return apierrors.NewInternalServerError(
-			"Error running hook URI: %v", hookConfig.URI).WithInternalError(err)
-	}
-
-	logEntry.Entry.WithFields(logrus.Fields{
-		"action":   "run_hook",
-		"hook":     hookConfig.URI,
-		"success":  true,
-		"duration": duration.Microseconds(),
-	}).WithError(err).Info("Hook ran successfully")
-
-	return nil
-}
-
-func checkError(
-	hookOutput HookOutput,
-) error {
-	if hookOutput.IsError() {
-		he := hookOutput.GetHookError()
-		httpCode := he.HTTPCode
-
-		if httpCode == 0 {
-			httpCode = http.StatusInternalServerError
-		}
-
-		httpError := &apierrors.HTTPError{
-			HTTPStatus: httpCode,
-			Message:    he.Message,
-		}
-		return httpError.WithInternalError(&he)
-	}
-	return nil
-}
-
-func validateTokenClaims(outputClaims map[string]interface{}) error {
-	schemaLoader := gojsonschema.NewStringLoader(MinimumViableTokenSchema)
-
-	documentLoader := gojsonschema.NewGoLoader(outputClaims)
-
-	result, err := gojsonschema.Validate(schemaLoader, documentLoader)
-	if err != nil {
-		return err
-	}
-
-	if !result.Valid() {
-		var errorMessages string
-
-		for _, desc := range result.Errors() {
-			errorMessages += fmt.Sprintf("- %s\n", desc)
-			fmt.Printf("- %s\n", desc)
-		}
-		return fmt.Errorf(
-			"output claims do not conform to the expected schema: \n%s", errorMessages)
-
-	}
-
-	return nil
 }

--- a/internal/hooks/v0hooks/service.go
+++ b/internal/hooks/v0hooks/service.go
@@ -1,0 +1,24 @@
+package v0hooks
+
+import (
+	"net/http"
+
+	"github.com/supabase/auth/internal/conf"
+	"github.com/supabase/auth/internal/storage"
+)
+
+type Service interface {
+	Enabled(name Name) bool
+
+	InvokeHook(
+		conn *storage.Connection,
+		r *http.Request,
+		input, output any,
+	) error
+
+	RunHTTPHook(
+		r *http.Request,
+		hookConfig conf.ExtensibilityPointConfiguration,
+		input any,
+	) ([]byte, error)
+}

--- a/internal/hooks/v0hooks/v0hooks.go
+++ b/internal/hooks/v0hooks/v0hooks.go
@@ -7,26 +7,24 @@ import (
 	"github.com/supabase/auth/internal/models"
 )
 
-type HookType string
+type Name string
 
 const (
-	PostgresHook HookType = "pg-functions"
+	SendSMS              Name = "send-sms"
+	SendEmail            Name = "send-email"
+	CustomizeAccessToken Name = "customize-access-token"
+	MFAVerification      Name = "mfa-verification"
+	PasswordVerification Name = "password-verification"
 )
 
-// Hook Names
 const (
 	HookRejection = "reject"
 )
 
-type HTTPHookInput interface {
-	IsHTTPHook()
-}
-
-type HookOutput interface {
-	IsError() bool
-	Error() string
-	GetHookError() AuthHookError
-}
+const (
+	DefaultMFAHookRejectionMessage      = "Further MFA verification attempts will be rejected."
+	DefaultPasswordHookRejectionMessage = "Further password verification attempts will be rejected."
+)
 
 // TODO(joel): Move this to phone package
 type SMS struct {
@@ -115,9 +113,8 @@ type MFAVerificationAttemptInput struct {
 }
 
 type MFAVerificationAttemptOutput struct {
-	Decision  string        `json:"decision"`
-	Message   string        `json:"message"`
-	HookError AuthHookError `json:"error"`
+	Decision string `json:"decision"`
+	Message  string `json:"message"`
 }
 
 type PasswordVerificationAttemptInput struct {
@@ -126,10 +123,9 @@ type PasswordVerificationAttemptInput struct {
 }
 
 type PasswordVerificationAttemptOutput struct {
-	Decision         string        `json:"decision"`
-	Message          string        `json:"message"`
-	ShouldLogoutUser bool          `json:"should_logout_user"`
-	HookError        AuthHookError `json:"error"`
+	Decision         string `json:"decision"`
+	Message          string `json:"message"`
+	ShouldLogoutUser bool   `json:"should_logout_user"`
 }
 
 type CustomAccessTokenInput struct {
@@ -139,8 +135,7 @@ type CustomAccessTokenInput struct {
 }
 
 type CustomAccessTokenOutput struct {
-	Claims    map[string]interface{} `json:"claims"`
-	HookError AuthHookError          `json:"error,omitempty"`
+	Claims map[string]interface{} `json:"claims"`
 }
 
 type SendSMSInput struct {
@@ -149,7 +144,6 @@ type SendSMSInput struct {
 }
 
 type SendSMSOutput struct {
-	HookError AuthHookError `json:"error,omitempty"`
 }
 
 type SendEmailInput struct {
@@ -158,69 +152,4 @@ type SendEmailInput struct {
 }
 
 type SendEmailOutput struct {
-	HookError AuthHookError `json:"error,omitempty"`
 }
-
-func (mf *MFAVerificationAttemptOutput) IsError() bool {
-	return mf.HookError.Message != ""
-}
-
-func (mf *MFAVerificationAttemptOutput) Error() string {
-	return mf.HookError.Message
-}
-
-func (mf *MFAVerificationAttemptOutput) GetHookError() AuthHookError { return mf.HookError }
-
-func (p *PasswordVerificationAttemptOutput) IsError() bool {
-	return p.HookError.Message != ""
-}
-
-func (p *PasswordVerificationAttemptOutput) Error() string {
-	return p.HookError.Message
-}
-
-func (p *PasswordVerificationAttemptOutput) GetHookError() AuthHookError { return p.HookError }
-
-func (ca *CustomAccessTokenOutput) IsError() bool {
-	return ca.HookError.Message != ""
-}
-
-func (ca *CustomAccessTokenOutput) Error() string {
-	return ca.HookError.Message
-}
-
-func (ca *CustomAccessTokenOutput) GetHookError() AuthHookError { return ca.HookError }
-
-func (cs *SendSMSOutput) IsError() bool {
-	return cs.HookError.Message != ""
-}
-
-func (cs *SendSMSOutput) Error() string {
-	return cs.HookError.Message
-}
-
-func (cs *SendSMSOutput) GetHookError() AuthHookError { return cs.HookError }
-
-func (cs *SendEmailOutput) IsError() bool {
-	return cs.HookError.Message != ""
-}
-
-func (cs *SendEmailOutput) Error() string {
-	return cs.HookError.Message
-}
-
-func (cs *SendEmailOutput) GetHookError() AuthHookError { return cs.HookError }
-
-type AuthHookError struct {
-	HTTPCode int    `json:"http_code,omitempty"`
-	Message  string `json:"message,omitempty"`
-}
-
-func (a *AuthHookError) Error() string {
-	return a.Message
-}
-
-const (
-	DefaultMFAHookRejectionMessage      = "Further MFA verification attempts will be rejected."
-	DefaultPasswordHookRejectionMessage = "Further password verification attempts will be rejected."
-)

--- a/internal/hooks/v0hooks/v0http/service.go
+++ b/internal/hooks/v0hooks/v0http/service.go
@@ -1,0 +1,22 @@
+package v0http
+
+import (
+	"context"
+
+	"github.com/supabase/auth/internal/conf"
+)
+
+type Service interface {
+	HTTPDispatch(
+		ctx context.Context,
+		cfg conf.ExtensibilityPointConfiguration,
+		req any,
+		res any,
+	) error
+
+	RunHTTPHook(
+		ctx context.Context,
+		hookConfig conf.ExtensibilityPointConfiguration,
+		input any,
+	) ([]byte, error)
+}

--- a/internal/hooks/v0hooks/v0http/v0http.go
+++ b/internal/hooks/v0hooks/v0http/v0http.go
@@ -17,6 +17,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/supabase/auth/internal/api/apierrors"
 	"github.com/supabase/auth/internal/conf"
+	"github.com/supabase/auth/internal/hooks/hookerrors"
 	"github.com/supabase/auth/internal/observability"
 
 	standardwebhooks "github.com/standard-webhooks/standard-webhooks/libraries/go"
@@ -80,7 +81,7 @@ func New(opts ...Option) *Dispatcher {
 	return dr
 }
 
-func (o *Dispatcher) Dispatch(
+func (o *Dispatcher) HTTPDispatch(
 	ctx context.Context,
 	cfg conf.ExtensibilityPointConfiguration,
 	req any,
@@ -218,6 +219,9 @@ func (o *Dispatcher) RunHTTPHook(
 					return nil, apierrors.NewUnprocessableEntityError(
 						apierrors.ErrorCodeHookPayloadOverSizeLimit, msg)
 				}
+			}
+			if err := hookerrors.Check(body); err != nil {
+				return nil, err
 			}
 			return body, nil
 		case http.StatusTooManyRequests, http.StatusServiceUnavailable:

--- a/internal/hooks/v0hooks/v0pgfunc/service.go
+++ b/internal/hooks/v0hooks/v0pgfunc/service.go
@@ -1,0 +1,25 @@
+package v0pgfunc
+
+import (
+	"context"
+
+	"github.com/supabase/auth/internal/conf"
+	"github.com/supabase/auth/internal/storage"
+)
+
+type Service interface {
+	PGFuncDispatch(
+		ctx context.Context,
+		cfg conf.ExtensibilityPointConfiguration,
+		tx *storage.Connection,
+		req any,
+		res any,
+	) error
+
+	RunPostgresHook(
+		ctx context.Context,
+		hookConfig conf.ExtensibilityPointConfiguration,
+		tx *storage.Connection,
+		input any,
+	) ([]byte, error)
+}

--- a/internal/hooks/v0hooks/v0pgfunc/v0pgfunc.go
+++ b/internal/hooks/v0hooks/v0pgfunc/v0pgfunc.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/supabase/auth/internal/api/apierrors"
 	"github.com/supabase/auth/internal/conf"
+	"github.com/supabase/auth/internal/hooks/hookerrors"
 	"github.com/supabase/auth/internal/storage"
 )
 
@@ -45,7 +46,7 @@ func New(db *storage.Connection, opts ...Option) *Dispatcher {
 	return dr
 }
 
-func (o *Dispatcher) Dispatch(
+func (o *Dispatcher) PGFuncDispatch(
 	ctx context.Context,
 	cfg conf.ExtensibilityPointConfiguration,
 	tx *storage.Connection,
@@ -107,6 +108,9 @@ func (o *Dispatcher) RunPostgresHook(
 		if err := db.Transaction(invokeHookFunc); err != nil {
 			return nil, err
 		}
+	}
+	if err := hookerrors.Check(response); err != nil {
+		return nil, err
 	}
 	return response, nil
 }

--- a/internal/hooks/v1hooks/manager.go
+++ b/internal/hooks/v1hooks/manager.go
@@ -1,0 +1,65 @@
+package v1hooks
+
+import (
+	"context"
+
+	"github.com/supabase/auth/internal/conf"
+	"github.com/supabase/auth/internal/hooks/dispatch"
+	"github.com/supabase/auth/internal/hooks/v0hooks"
+	"github.com/supabase/auth/internal/storage"
+)
+
+type Manager struct {
+	cfg *conf.HookConfiguration
+	dr  dispatch.Service
+}
+
+func New(
+	cfg *conf.HookConfiguration,
+	dr dispatch.Service,
+) *Manager {
+	o := &Manager{
+		cfg: cfg,
+		dr:  dr,
+	}
+	return o
+}
+
+func (o *Manager) Enabled(name v0hooks.Name) bool {
+	if cfg, ok := configByName(o.cfg, name); ok {
+		return cfg.Enabled
+	}
+	return false
+}
+
+func (o *Manager) BeforeUserCreated(
+	ctx context.Context,
+	tx *storage.Connection,
+	req *BeforeUserCreatedRequest,
+	res *BeforeUserCreatedResponse,
+) error {
+	return o.dr.Dispatch(ctx, &o.cfg.BeforeUserCreated, tx, req, res)
+}
+
+func (o *Manager) AfterUserCreated(
+	ctx context.Context,
+	tx *storage.Connection,
+	req *AfterUserCreatedRequest,
+	res *AfterUserCreatedResponse,
+) error {
+	return o.dr.Dispatch(ctx, &o.cfg.AfterUserCreated, tx, req, res)
+}
+
+func configByName(
+	cfg *conf.HookConfiguration,
+	name v0hooks.Name,
+) (*conf.ExtensibilityPointConfiguration, bool) {
+	switch name {
+	case BeforeUserCreated:
+		return &cfg.BeforeUserCreated, true
+	case AfterUserCreated:
+		return &cfg.AfterUserCreated, true
+	default:
+		return nil, false
+	}
+}

--- a/internal/hooks/v1hooks/manager_test.go
+++ b/internal/hooks/v1hooks/manager_test.go
@@ -1,0 +1,272 @@
+package v1hooks
+
+import (
+	"context"
+	"errors"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/supabase/auth/internal/conf"
+	"github.com/supabase/auth/internal/hooks/v0hooks"
+	"github.com/supabase/auth/internal/models"
+	"github.com/supabase/auth/internal/storage"
+)
+
+func TestNew(t *testing.T) {
+	const sentinelStr = "sentinel"
+	r := httptest.NewRequest("GET", "http://localhost/test", nil)
+	r.Header.Set("x-forwarded-for", "1.2.3.4")
+	now := time.Now()
+
+	checkHeader := func(hdr *Header, name v0hooks.Name) {
+		if exp, got := false, hdr.UUID.IsNil(); exp != got {
+			t.Fatalf("exp %v; got %v", exp, got)
+		}
+		if exp, got := false, now.After(hdr.Time); exp != got {
+			t.Fatalf("exp %v; got %v", exp, got)
+		}
+		if exp, got := name, hdr.Name; exp != got {
+			t.Fatalf("exp %v; got %v", exp, got)
+		}
+		if exp, got := "1.2.3.4", hdr.IPAddress; exp != got {
+			t.Fatalf("exp %v; got %v", exp, got)
+		}
+	}
+
+	{
+		hdr := NewHeader(r, v0hooks.SendEmail)
+		if hdr == nil {
+			t.Fatal("exp non-nil *Header")
+		}
+		checkHeader(hdr, v0hooks.SendEmail)
+	}
+
+	{
+		user := &models.User{
+			Aud: sentinelStr,
+		}
+		req := NewBeforeUserCreatedRequest(r, user)
+		if req == nil {
+			t.Fatal("exp non-nil *Header")
+		}
+		checkHeader(req.Header, BeforeUserCreated)
+
+		if exp, got := user, req.User; exp != got {
+			t.Fatalf("exp %v; got %v", exp, got)
+		}
+		if exp, got := sentinelStr, req.User.Aud; exp != got {
+			t.Fatalf("exp %v; got %v", exp, got)
+		}
+	}
+
+	{
+		user := &models.User{
+			Aud: sentinelStr,
+		}
+		req := NewAfterUserCreatedRequest(r, user)
+		if req == nil {
+			t.Fatal("exp non-nil *Header")
+		}
+		checkHeader(req.Header, AfterUserCreated)
+
+		if exp, got := user, req.User; exp != got {
+			t.Fatalf("exp %v; got %v", exp, got)
+		}
+		if exp, got := sentinelStr, req.User.Aud; exp != got {
+			t.Fatalf("exp %v; got %v", exp, got)
+		}
+	}
+}
+
+func TestConfig(t *testing.T) {
+	cfg := helpConfig(false)
+	mockSvc := new(mockService)
+	mr := New(cfg, mockSvc)
+
+	tests := []struct {
+		cfg  *conf.HookConfiguration
+		name v0hooks.Name
+		exp  *conf.ExtensibilityPointConfiguration
+		ok   bool
+	}{
+		{},
+		{cfg: cfg, ok: true,
+			name: BeforeUserCreated, exp: &cfg.BeforeUserCreated},
+		{cfg: cfg, ok: true,
+			name: AfterUserCreated, exp: &cfg.AfterUserCreated},
+	}
+	for idx, test := range tests {
+		t.Logf("test #%v - exp ok %v with cfg %v from name %v",
+			idx, test.ok, test.exp, test.name)
+
+		require.Equal(t, false, mr.Enabled(test.name))
+
+		got, ok := configByName(test.cfg, test.name)
+		require.Equal(t, test.ok, ok)
+		require.Equal(t, test.exp, got)
+
+		if got == nil {
+			continue
+		}
+
+		got.Enabled = true
+		require.Equal(t, true, mr.Enabled(test.name))
+	}
+}
+
+func TestHooks(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	t.Run("BeforeUserCreated", func(t *testing.T) {
+		httpReq := httptest.NewRequest("GET", "http://localhost/test", nil)
+		user := &models.User{}
+		req := NewBeforeUserCreatedRequest(httpReq, user)
+		res := new(BeforeUserCreatedResponse)
+
+		t.Run("BeforeUserCreatedSuccess", func(t *testing.T) {
+			cfg := helpConfig(true)
+			dr := newMockService(nil)
+			mr := New(cfg, dr)
+
+			err := mr.BeforeUserCreated(ctx, nil, req, res)
+			if err != nil {
+				t.Fatalf("exp nil err; got %v", err)
+			}
+			if exp, got := 1, len(dr.calls); exp != got {
+				t.Fatalf("exp %v; got %v", exp, got)
+			}
+
+			call := dr.calls[0]
+			if exp, got := req, call.input; exp != got {
+				t.Fatalf("exp %v; got %v", exp, got)
+			}
+			if exp, got := res, call.output; exp != got {
+				t.Fatalf("exp %v; got %v", exp, got)
+			}
+		})
+
+		t.Run("BeforeUserCreatedError", func(t *testing.T) {
+			cfg := helpConfig(true)
+			sentinel := errors.New("sentinel")
+			dr := newMockService(sentinel)
+			mr := New(cfg, dr)
+
+			err := mr.BeforeUserCreated(ctx, nil, req, res)
+			if err != sentinel {
+				t.Fatalf("exp err %v; got %v", sentinel, err)
+			}
+			if exp, got := 1, len(dr.calls); exp != got {
+				t.Fatalf("exp %v; got %v", exp, got)
+			}
+
+			call := dr.calls[0]
+			if exp, got := req, call.input; exp != got {
+				t.Fatalf("exp %v; got %v", exp, got)
+			}
+			if exp, got := res, call.output; exp != got {
+				t.Fatalf("exp %v; got %v", exp, got)
+			}
+		})
+	})
+
+	t.Run("AfterUserCreated", func(t *testing.T) {
+		httpReq := httptest.NewRequest("GET", "http://localhost/test", nil)
+		user := &models.User{}
+		req := NewAfterUserCreatedRequest(httpReq, user)
+		res := new(AfterUserCreatedResponse)
+
+		t.Run("AfterUserCreatedSuccess", func(t *testing.T) {
+			cfg := helpConfig(true)
+			dr := newMockService(nil)
+			mr := New(cfg, dr)
+
+			err := mr.AfterUserCreated(ctx, nil, req, res)
+			if err != nil {
+				t.Fatalf("exp nil err; got %v", err)
+			}
+			if exp, got := 1, len(dr.calls); exp != got {
+				t.Fatalf("exp %v; got %v", exp, got)
+			}
+
+			call := dr.calls[0]
+			if exp, got := req, call.input; exp != got {
+				t.Fatalf("exp %v; got %v", exp, got)
+			}
+			if exp, got := res, call.output; exp != got {
+				t.Fatalf("exp %v; got %v", exp, got)
+			}
+		})
+
+		t.Run("AfterUserCreatedError", func(t *testing.T) {
+			cfg := helpConfig(true)
+			sentinel := errors.New("sentinel")
+			dr := newMockService(sentinel)
+			mr := New(cfg, dr)
+
+			err := mr.AfterUserCreated(ctx, nil, req, res)
+			if err != sentinel {
+				t.Fatalf("exp err %v; got %v", sentinel, err)
+			}
+			if exp, got := 1, len(dr.calls); exp != got {
+				t.Fatalf("exp %v; got %v", exp, got)
+			}
+
+			call := dr.calls[0]
+			if exp, got := req, call.input; exp != got {
+				t.Fatalf("exp %v; got %v", exp, got)
+			}
+			if exp, got := res, call.output; exp != got {
+				t.Fatalf("exp %v; got %v", exp, got)
+			}
+		})
+	})
+}
+
+func helpConfig(enabled bool) *conf.HookConfiguration {
+	cfg := &conf.HookConfiguration{
+		BeforeUserCreated: conf.ExtensibilityPointConfiguration{
+			URI:     "http:localhost/" + string(BeforeUserCreated),
+			Enabled: enabled,
+		},
+		AfterUserCreated: conf.ExtensibilityPointConfiguration{
+			URI:     "http:localhost/" + string(AfterUserCreated),
+			Enabled: enabled,
+		},
+	}
+	return cfg
+}
+
+type mockCall struct {
+	conn          *storage.Connection
+	hookConfig    *conf.ExtensibilityPointConfiguration
+	input, output any
+}
+
+type mockService struct {
+	mu    sync.Mutex
+	err   error
+	calls []*mockCall
+}
+
+func newMockService(err error) *mockService { return &mockService{err: err} }
+
+func (o *mockService) Dispatch(
+	ctx context.Context,
+	hookConfig *conf.ExtensibilityPointConfiguration,
+	conn *storage.Connection,
+	input, output any,
+) error {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	o.calls = append(o.calls, &mockCall{
+		conn:       conn,
+		hookConfig: hookConfig,
+		input:      input,
+		output:     output,
+	})
+	return o.err
+}

--- a/internal/hooks/v1hooks/service.go
+++ b/internal/hooks/v1hooks/service.go
@@ -1,0 +1,26 @@
+package v1hooks
+
+import (
+	"context"
+
+	"github.com/supabase/auth/internal/hooks/v0hooks"
+	"github.com/supabase/auth/internal/storage"
+)
+
+type Service interface {
+	Enabled(name v0hooks.Name) bool
+
+	BeforeUserCreated(
+		ctx context.Context,
+		tx *storage.Connection,
+		req *BeforeUserCreatedRequest,
+		res *BeforeUserCreatedResponse,
+	) error
+
+	AfterUserCreated(
+		ctx context.Context,
+		tx *storage.Connection,
+		req *AfterUserCreatedRequest,
+		res *AfterUserCreatedResponse,
+	) error
+}

--- a/internal/hooks/v1hooks/v1hooks.go
+++ b/internal/hooks/v1hooks/v1hooks.go
@@ -1,0 +1,74 @@
+package v1hooks
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/gofrs/uuid"
+	"github.com/supabase/auth/internal/hooks/v0hooks"
+	"github.com/supabase/auth/internal/models"
+	"github.com/supabase/auth/internal/utilities"
+)
+
+const (
+	BeforeUserCreated v0hooks.Name = "before-user-created"
+	AfterUserCreated  v0hooks.Name = "after-user-created"
+)
+
+type Header struct {
+	UUID uuid.UUID `json:"uuid"`
+	Time time.Time `json:"time"`
+
+	// Hook name
+	Name v0hooks.Name `json:"name,omitempty"`
+
+	// IP Address of the request, if present
+	IPAddress string `json:"ip_address,omitempty"`
+}
+
+func NewHeader(r *http.Request, name v0hooks.Name) *Header {
+	return &Header{
+		UUID:      uuid.Must(uuid.NewV4()),
+		Time:      time.Now(),
+		IPAddress: utilities.GetIPAddress(r),
+		Name:      name,
+	}
+}
+
+type BeforeUserCreatedRequest struct {
+	Header *Header      `json:"header"`
+	User   *models.User `json:"user"`
+}
+
+func NewBeforeUserCreatedRequest(
+	r *http.Request,
+	user *models.User,
+) *BeforeUserCreatedRequest {
+	return &BeforeUserCreatedRequest{
+		Header: NewHeader(r, BeforeUserCreated),
+		User:   user,
+	}
+}
+
+type BeforeUserCreatedResponse struct {
+	User *models.User `json:"user"`
+}
+
+type AfterUserCreatedRequest struct {
+	Header *Header      `json:"header"`
+	User   *models.User `json:"user"`
+}
+
+func NewAfterUserCreatedRequest(
+	r *http.Request,
+	user *models.User,
+) *AfterUserCreatedRequest {
+	return &AfterUserCreatedRequest{
+		Header: NewHeader(r, AfterUserCreated),
+		User:   user,
+	}
+}
+
+type AfterUserCreatedResponse struct {
+	User *models.User `json:"user"`
+}


### PR DESCRIPTION
These two new hooks are called inside internal/api/signup.go
at the `signupNewUser` func.

Adding these new hooks required a good deal of refactoring to
ensure high test coverage and consistent behavior across the
new and old hooks.

Some notable changes:
- Removed the AuthHookError embedding across v0hook structs
- Made consistent error handling the responsibility of the
  v0pgfunc and v0http packages. Added an additional
  hookerrors function in support of this. This allowed me
  to simplify some of the code in v0hooks.
- Broke down a lot of the packages into smaller pieces to
  make them more testable. This led to me defining several
  Service interfaces to make it trivial to mock tests.
- Added several packages in the "e2e" directory to make
  writing tests that needed an API server, hook server or
  both easier. Also added some simple helpers for config
  and connection loading from within unit tests.

A quick guide to how things are structured:
  internal/api/API
    internal/hooks/Manager
      internal/hooks/v0hooks/Manager
        internal/hooks/dispatcher
          internal/hooks/v0hooks/v0http
            internal/hookerrors
          internal/hooks/v0hooks/v0pgfunc
            internal/hookerrors
      internal/hooks/v1hooks/Manager
        internal/hooks/dispatcher
          internal/hooks/v0hooks/v0http
            internal/hookerrors
          internal/hooks/v0hooks/v0pgfunc
            internal/hookerrors