### PR TITLE
ci: improve go version management by using `go.mod`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,7 +82,7 @@ jobs:
       - uses: actions/setup-go@v5
         if: ${{ steps.release.outputs.release_created == 'true' || steps.release.outputs.prs_created == 'true' }}
         with:
-          go-version: "1.23.7" # The Go version to download (if necessary) and use.
+          go-version-file: go.mod
 
       - name: Build release artifacts
         if: ${{ steps.release.outputs.release_created == 'true' || steps.release.outputs.prs_created == 'true' }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,9 +12,6 @@ permissions:
 
 jobs:
   test:
-    strategy:
-      matrix:
-        go-version: [1.23.7]
     runs-on: ubuntu-latest
     services:
       postgres:
@@ -34,7 +31,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: ${{ matrix.go-version }}
+          go-version-file: go.mod
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Check gofmt

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,12 +28,12 @@ jobs:
           --health-timeout 5s
           --health-retries 5
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
       - name: Install Go
         uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
-      - name: Checkout code
-        uses: actions/checkout@v2
       - name: Check gofmt
         run: |
           set -x

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
           --health-retries 5
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Install Go
         uses: actions/setup-go@v5
         with:


### PR DESCRIPTION
Additionally, remove unused strategy-matrix from test job

## What kind of change does this PR introduce?

Github workflow actions cleanup

## What is the current behavior?

Job `actions/setup-go@v5` takes go version to install from the provided string literal

## What is the new behavior?

Job `actions/setup-go@v5` take go version from `go.mod`

## Additional context

Now there are less things to maintain and less changes need to be done on go version bump.
Additionally, unused strategy-matrix from test job is removed.
