### PR TITLE
Fix inconsistent outdated oapi-codegen `make dev-deps`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ dev-deps: ## Install developer dependencies
 	@go install github.com/gobuffalo/pop/soda@latest
 	@go install github.com/securego/gosec/v2/cmd/gosec@latest
 	@go install honnef.co/go/tools/cmd/staticcheck@latest
-	@go install github.com/deepmap/oapi-codegen/cmd/oapi-codegen@latest
+	@go install github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen@latest
 	@go install github.com/nishanths/exhaustive/cmd/exhaustive@latest
 
 deps: ## Install dependencies.


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fix oapi-codegen reference in `make dev-deps`

## What is the current behavior?

`make dev-deps` installs outdated inconsistent version v1 of oapi-codegen (rest of codebase uses v2, see `tools/tools.go` and `client/admin/gen.go`)

## What is the new behavior?

`make dev-deps` installs oapi-codegen v2, same it should be

## Additional context

Additionally, the repo `github.com/deepmap/oapi-codegen` doesn't exist anymore. Github redirect to `github.com/oapi-codegen/oapi-codegen`, so this is the new official pkg repo.
