### PR TITLE
feat: hooks round 3 - begin adding the Before and After user created hooks

### DIFF
--- a/internal/conf/configuration.go
+++ b/internal/conf/configuration.go
@@ -640,6 +640,9 @@ type HookConfiguration struct {
 	CustomAccessToken           ExtensibilityPointConfiguration `json:"custom_access_token" split_words:"true"`
 	SendEmail                   ExtensibilityPointConfiguration `json:"send_email" split_words:"true"`
 	SendSMS                     ExtensibilityPointConfiguration `json:"send_sms" split_words:"true"`
+
+	BeforeUserCreated ExtensibilityPointConfiguration `json:"before_user_created" split_words:"true"`
+	AfterUserCreated  ExtensibilityPointConfiguration `json:"after_user_created" split_words:"true"`
 }
 
 type HTTPHookSecrets []string
@@ -671,6 +674,8 @@ func (h *HookConfiguration) Validate() error {
 		h.CustomAccessToken,
 		h.SendSMS,
 		h.SendEmail,
+		h.BeforeUserCreated,
+		h.AfterUserCreated,
 	}
 	for _, point := range points {
 		if err := point.ValidateExtensibilityPoint(); err != nil {
@@ -884,6 +889,18 @@ func populateGlobal(config *GlobalConfiguration) error {
 
 	if config.Hook.CustomAccessToken.Enabled {
 		if err := config.Hook.CustomAccessToken.PopulateExtensibilityPoint(); err != nil {
+			return err
+		}
+	}
+
+	if config.Hook.BeforeUserCreated.Enabled {
+		if err := config.Hook.BeforeUserCreated.PopulateExtensibilityPoint(); err != nil {
+			return err
+		}
+	}
+
+	if config.Hook.AfterUserCreated.Enabled {
+		if err := config.Hook.AfterUserCreated.PopulateExtensibilityPoint(); err != nil {
 			return err
 		}
 	}

--- a/internal/e2e/e2e.go
+++ b/internal/e2e/e2e.go
@@ -16,8 +16,14 @@ var (
 	configPath  string
 )
 
+var isTesting func() bool = testing.Testing
+
 func init() {
-	if testing.Testing() {
+	initPackage()
+}
+
+func initPackage() {
+	if isTesting() {
 		_, thisFile, _, _ := runtime.Caller(0)
 		projectRoot = filepath.Join(filepath.Dir(thisFile), "../..")
 		configPath = filepath.Join(GetProjectRoot(), "hack", "test.env")

--- a/internal/e2e/e2e_test.go
+++ b/internal/e2e/e2e_test.go
@@ -94,4 +94,27 @@ func TestUtils(t *testing.T) {
 			t.Fatal("exp non-nil err")
 		}
 	}()
+
+	// block init from main()
+	func() {
+		restore := isTesting
+		defer func() {
+			isTesting = restore
+		}()
+		isTesting = func() bool { return false }
+
+		var errStr string
+		func() {
+			defer func() {
+				errStr = recover().(string)
+			}()
+
+			initPackage()
+		}()
+
+		exp := "package e2e may not be used in a main package"
+		if errStr != exp {
+			t.Fatalf("exp %v; got %v", exp, errStr)
+		}
+	}()
 }

--- a/internal/e2e/e2eapi/e2eapi.go
+++ b/internal/e2e/e2eapi/e2eapi.go
@@ -90,11 +90,17 @@ func Do(
 	if err != nil {
 		return err
 	}
-	if err := json.Unmarshal(data, res); err != nil {
-		return err
+	if len(data) > 0 {
+		if err := json.Unmarshal(data, res); err != nil {
+			return err
+		}
 	}
 	return nil
 }
+
+const responseLimit = 1e6
+
+var defaultClient = http.DefaultClient
 
 func do(
 	ctx context.Context,
@@ -113,7 +119,7 @@ func do(
 	h.Add("Content-Type", "application/json")
 	h.Add("Accept", "application/json")
 
-	httpRes, err := http.DefaultClient.Do(httpReq)
+	httpRes, err := defaultClient.Do(httpReq)
 	if err != nil {
 		return nil, err
 	}
@@ -124,7 +130,7 @@ func do(
 		return nil, nil
 
 	case sc >= 400:
-		data, err := io.ReadAll(io.LimitReader(httpRes.Body, 1e8))
+		data, err := io.ReadAll(io.LimitReader(httpRes.Body, responseLimit))
 		if err != nil {
 			return nil, err
 		}
@@ -142,7 +148,7 @@ func do(
 		return nil, err
 
 	default:
-		data, err := io.ReadAll(io.LimitReader(httpRes.Body, 1e8))
+		data, err := io.ReadAll(io.LimitReader(httpRes.Body, responseLimit))
 		if err != nil {
 			return nil, err
 		}

--- a/internal/e2e/e2eapi/e2eapi_test.go
+++ b/internal/e2e/e2eapi/e2eapi_test.go
@@ -3,6 +3,7 @@ package e2eapi
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -21,42 +22,34 @@ func TestInstance(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*4)
 	defer cancel()
 
-	globalCfg := e2e.Must(e2e.Config())
-	inst, err := New(globalCfg)
-	if err != nil {
-		t.Fatalf("exp nil err; got %v", err)
-	}
-	defer inst.Close()
+	t.Run("New", func(t *testing.T) {
+		t.Run("Success", func(t *testing.T) {
+			globalCfg := e2e.Must(e2e.Config())
+			inst, err := New(globalCfg)
+			require.NoError(t, err)
+			defer inst.Close()
 
-	{
-		email := "e2etesthooks_" + uuid.Must(uuid.NewV4()).String() + "@localhost"
-		req := &api.SignupParams{
-			Email:    email,
-			Password: "password",
-		}
-		res := new(models.User)
-		err := Do(ctx, http.MethodPost, inst.APIServer.URL+"/signup", req, res)
-		if err != nil {
-			t.Fatalf("exp nil err; got %v", err)
-		}
-		require.Equal(t, email, res.Email.String())
-	}
-}
+			email := "e2etesthooks_" + uuid.Must(uuid.NewV4()).String() + "@localhost"
+			req := &api.SignupParams{
+				Email:    email,
+				Password: "password",
+			}
+			res := new(models.User)
+			err = Do(ctx, http.MethodPost, inst.APIServer.URL+"/signup", req, res)
+			require.NoError(t, err)
+			require.Equal(t, email, res.Email.String())
+		})
 
-func TestNew(t *testing.T) {
-	{
-		globalCfg := e2e.Must(e2e.Config())
-		globalCfg.DB.Driver = ""
-		globalCfg.DB.URL = "invalid"
+		t.Run("Failure", func(t *testing.T) {
+			globalCfg := e2e.Must(e2e.Config())
+			globalCfg.DB.Driver = ""
+			globalCfg.DB.URL = "invalid"
 
-		inst, err := New(globalCfg)
-		if err == nil {
-			t.Fatal("exp non-nil err")
-		}
-		if inst != nil {
-			t.Fatal("exp nil *Instance")
-		}
-	}
+			inst, err := New(globalCfg)
+			require.Error(t, err)
+			require.Nil(t, inst)
+		})
+	})
 }
 
 func TestDo(t *testing.T) {
@@ -65,63 +58,57 @@ func TestDo(t *testing.T) {
 
 	globalCfg := e2e.Must(e2e.Config())
 	inst, err := New(globalCfg)
-	if err != nil {
-		t.Fatalf("exp nil err; got %v", err)
-	}
+	require.NoError(t, err)
 	defer inst.Close()
 
-	{
+	// Covers calls to Do with a `req` param type which can't marshaled
+	t.Run("InvalidRequestType", func(t *testing.T) {
 		req := make(chan string)
 		err := Do(ctx, http.MethodPost, "http://localhost", &req, nil)
-		if err == nil {
-			t.Fatal("exp non-nil err")
-		}
+		require.Error(t, err)
 		require.ErrorContains(t, err, "json: unsupported type: chan string")
-	}
+	})
 
-	{
-		res := make(chan string)
-		err := Do(ctx, http.MethodGet, inst.APIServer.URL+"/user", nil, &res)
-		if err == nil {
-			t.Fatal("exp non-nil err")
-		}
-		require.ErrorContains(t, err, "401: This endpoint requires a Bearer token")
-	}
-
-	{
+	// Covers calls to Do with a `res` param type which can't marshaled
+	t.Run("InvalidResponseType", func(t *testing.T) {
 		res := make(chan string)
 		err := Do(ctx, http.MethodGet, inst.APIServer.URL+"/settings", nil, &res)
-		if err == nil {
-			t.Fatal("exp non-nil err")
-		}
+		require.Error(t, err)
 		require.ErrorContains(t, err, "json: cannot unmarshal object into Go value of type chan string")
-	}
+	})
 
-	{
+	// Covers status code >= 400 error handling switch statement
+	t.Run("api.HTTPErrorResponse_to_apierrors.HTTPError", func(t *testing.T) {
+		res := make(chan string)
+		err := Do(ctx, http.MethodGet, inst.APIServer.URL+"/user", nil, &res)
+		require.Error(t, err)
+		require.ErrorContains(t, err, "401: This endpoint requires a Bearer token")
+	})
+
+	// Covers http.NewRequestWithContext
+	t.Run("InvalidHTTPMethod", func(t *testing.T) {
 		err := Do(ctx, "\x01", "http://localhost", nil, nil)
-		if err == nil {
-			t.Fatal("exp non-nil err")
-		}
+		require.Error(t, err)
 		require.ErrorContains(t, err, "net/http: invalid method")
-	}
+	})
 
-	{
+	// Covers status code >= 400 error handling switch statement json.Unmarshal
+	// by hitting the default error handler that returns html
+	t.Run("InvalidResponse", func(t *testing.T) {
 		err := Do(ctx, http.MethodGet, inst.APIServer.URL+"/404", nil, nil)
-		if err == nil {
-			t.Fatal("exp non-nil err")
-		}
+		require.Error(t, err)
 		require.ErrorContains(t, err, "invalid character")
-	}
+	})
 
-	{
+	// Covers defaultClient.Do failure
+	t.Run("InvalidURL", func(t *testing.T) {
 		err := Do(ctx, http.MethodPost, "invalid", nil, nil)
-		if err == nil {
-			t.Fatal("exp non-nil err")
-		}
+		require.Error(t, err)
 		require.ErrorContains(t, err, "unsupported protocol")
-	}
+	})
 
-	func() {
+	// Covers http.StatusNoContent handling
+	t.Run("InvalidRequestType", func(t *testing.T) {
 		hr := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusNoContent)
 		})
@@ -130,46 +117,71 @@ func TestDo(t *testing.T) {
 		defer ts.Close()
 
 		err := Do(ctx, http.MethodPost, ts.URL, nil, nil)
-		if err != nil {
-			t.Fatalf("exp nil err; got %v", err)
+		require.NoError(t, err)
+	})
+
+	// Covers IO errors
+	t.Run("IOError", func(t *testing.T) {
+
+		for _, statusCode := range []int{http.StatusBadRequest, http.StatusOK} {
+
+			// Covers IO errors for the sc >= 400 and default status code
+			// handling in the switch statement within do.
+			testName := fmt.Sprintf("Status=%v", http.StatusText(statusCode))
+			t.Run(testName, func(t *testing.T) {
+
+				// We assign a sentinel error to ensure propagation.
+				sentinel := errors.New("sentinel")
+
+				// This implementation of the http.RoundTripper is a way to
+				// cover the io.ReadAll(io.LimitReader(...)) lines in the switch
+				// statements inside do().
+				rtFn := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+
+					// Call the default http.RoundTripper implementation provided
+					// by the http.Default client to build a valid http.Response.
+					res, err := http.DefaultClient.Do(req)
+					if err != nil {
+						return nil, err
+					}
+
+					// Wrap the res.Body in an io.ErrReader using our sentinel
+					// error. This causes the first call to read the response
+					// body to return our sentinel error.
+					res.Body = io.NopCloser(iotest.ErrReader(sentinel))
+					return res, nil
+				})
+
+				// We need to swap the defaultClient with a new client which has
+				// the (*Client).Transport set to our http.RoundTripper above.
+				prev := defaultClient
+				defer func() {
+					defaultClient = prev
+				}()
+				defaultClient = new(http.Client)
+				defaultClient.Transport = rtFn
+
+				hr := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					w.WriteHeader(statusCode)
+				})
+
+				ts := httptest.NewServer(hr)
+				defer ts.Close()
+
+				// We send the request and expect back our sentinel error.
+				err := Do(ctx, http.MethodPost, ts.URL, nil, nil)
+				require.Error(t, err)
+				require.Equal(t, sentinel, err)
+
+			})
 		}
-	}()
-
-	for _, statusCode := range []int{http.StatusBadRequest, http.StatusOK} {
-		func() {
-			sentinel := errors.New("sentinel")
-			rtFn := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
-				res, err := http.DefaultClient.Do(req)
-				if err != nil {
-					return nil, err
-				}
-				res.Body = io.NopCloser(iotest.ErrReader(sentinel))
-				return res, nil
-			})
-
-			prev := defaultClient
-			defer func() {
-				defaultClient = prev
-			}()
-			defaultClient = new(http.Client)
-			defaultClient.Transport = rtFn
-
-			hr := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.WriteHeader(statusCode)
-			})
-
-			ts := httptest.NewServer(hr)
-			defer ts.Close()
-
-			err := Do(ctx, http.MethodPost, ts.URL, nil, nil)
-			require.Error(t, err)
-			require.Equal(t, sentinel, err)
-		}()
-	}
+	})
 }
 
+// roundTripperFunc is like http.HandlerFunc for a http.RoundTripper
 type roundTripperFunc func(*http.Request) (*http.Response, error)
 
+// RoundTrip implements http.RoundTripper by calling itself.
 func (f roundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {
 	return f(req)
 }

--- a/internal/e2e/e2ehooks/e2ehooks.go
+++ b/internal/e2e/e2ehooks/e2ehooks.go
@@ -1,0 +1,201 @@
+// Package e2ehooks provides utilities for end-to-end testing of hooks.
+package e2ehooks
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/http/httputil"
+	"slices"
+	"sync"
+
+	"github.com/supabase/auth/internal/conf"
+	"github.com/supabase/auth/internal/e2e/e2eapi"
+	"github.com/supabase/auth/internal/hooks/v0hooks"
+)
+
+type Instance struct {
+	*e2eapi.Instance
+
+	HookServer   *httptest.Server
+	HookRecorder *HookRecorder
+}
+
+func (o *Instance) Close() error {
+	defer o.Instance.Close()
+	defer o.HookServer.Close()
+	return nil
+}
+
+func New(globalCfg *conf.GlobalConfiguration) (*Instance, error) {
+	hookRec := NewHookRecorder()
+	hookSrv := httptest.NewServer(hookRec)
+	hookRec.Register(&globalCfg.Hook, hookSrv.URL)
+
+	test, err := e2eapi.New(globalCfg)
+	if err != nil {
+		defer hookSrv.Close()
+
+		return nil, err
+	}
+
+	o := &Instance{
+		Instance:     test,
+		HookServer:   hookSrv,
+		HookRecorder: hookRec,
+	}
+	return o, nil
+}
+
+func HandleSuccess() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Add("content-type", "application/json")
+		_, _ = io.WriteString(w, "{}")
+	})
+}
+
+type Hook struct {
+	mu    sync.Mutex
+	name  v0hooks.Name
+	calls []*HookCall
+
+	hr http.Handler
+}
+
+func NewHook(name v0hooks.Name) *Hook {
+	o := &Hook{
+		name: name,
+	}
+	o.SetHandler(HandleSuccess())
+	return o
+}
+
+func (o *Hook) ClearCalls() {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	o.calls = nil
+}
+
+func (o *Hook) GetCalls() []*HookCall {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	return slices.Clone(o.calls)
+}
+
+func (o *Hook) SetHandler(hr http.Handler) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	o.hr = hr
+}
+
+func (o *Hook) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+
+	dump, _ := httputil.DumpRequest(r, true)
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		code := http.StatusInternalServerError
+		http.Error(w, http.StatusText(code), code)
+		return
+	}
+	r.Body = io.NopCloser(bytes.NewReader(body))
+
+	hc := &HookCall{
+		Dump:   string(dump),
+		Body:   string(body),
+		Header: r.Header.Clone(),
+	}
+	o.calls = append(o.calls, hc)
+
+	o.hr.ServeHTTP(w, r)
+}
+
+type HookCall struct {
+	Header http.Header
+	Body   string
+	Dump   string
+}
+
+func (o *HookCall) Unmarshal(v any) error {
+	return json.Unmarshal([]byte(o.Body), v)
+}
+
+type HookRecorder struct {
+	mux                  *http.ServeMux
+	BeforeUserCreated    *Hook
+	AfterUserCreated     *Hook
+	CustomizeAccessToken *Hook
+	MFAVerification      *Hook
+	PasswordVerification *Hook
+	SendEmail            *Hook
+	SendSMS              *Hook
+}
+
+func NewHookRecorder() *HookRecorder {
+	o := &HookRecorder{
+		mux:                  http.NewServeMux(),
+		BeforeUserCreated:    NewHook(v0hooks.BeforeUserCreated),
+		AfterUserCreated:     NewHook(v0hooks.AfterUserCreated),
+		CustomizeAccessToken: NewHook(v0hooks.CustomizeAccessToken),
+		MFAVerification:      NewHook(v0hooks.MFAVerification),
+		PasswordVerification: NewHook(v0hooks.PasswordVerification),
+		SendEmail:            NewHook(v0hooks.SendEmail),
+		SendSMS:              NewHook(v0hooks.SendSMS),
+	}
+
+	o.mux.HandleFunc("POST /hooks/{hook}", func(w http.ResponseWriter, r *http.Request) {
+		//exhaustive:ignore
+		switch v0hooks.Name(r.PathValue("hook")) {
+		case v0hooks.BeforeUserCreated:
+			o.BeforeUserCreated.ServeHTTP(w, r)
+
+		case v0hooks.AfterUserCreated:
+			o.AfterUserCreated.ServeHTTP(w, r)
+
+		case v0hooks.CustomizeAccessToken:
+			o.CustomizeAccessToken.ServeHTTP(w, r)
+
+		case v0hooks.MFAVerification:
+			o.MFAVerification.ServeHTTP(w, r)
+
+		case v0hooks.PasswordVerification:
+			o.PasswordVerification.ServeHTTP(w, r)
+
+		case v0hooks.SendEmail:
+			o.SendEmail.ServeHTTP(w, r)
+
+		case v0hooks.SendSMS:
+			o.SendSMS.ServeHTTP(w, r)
+
+		default:
+			http.NotFound(w, r)
+		}
+	})
+	return o
+}
+
+func (o *HookRecorder) Register(
+	hookCfg *conf.HookConfiguration,
+	baseURL string,
+) {
+	set := func(cfg *conf.ExtensibilityPointConfiguration, name v0hooks.Name) {
+		*cfg = conf.ExtensibilityPointConfiguration{
+			Enabled: true,
+			URI:     baseURL + "/hooks/" + string(name),
+		}
+	}
+	set(&hookCfg.BeforeUserCreated, v0hooks.BeforeUserCreated)
+	set(&hookCfg.AfterUserCreated, v0hooks.AfterUserCreated)
+	set(&hookCfg.CustomAccessToken, v0hooks.CustomizeAccessToken)
+	set(&hookCfg.MFAVerificationAttempt, v0hooks.MFAVerification)
+	set(&hookCfg.PasswordVerificationAttempt, v0hooks.PasswordVerification)
+	set(&hookCfg.SendEmail, v0hooks.SendEmail)
+	set(&hookCfg.SendSMS, v0hooks.SendSMS)
+}
+
+func (o *HookRecorder) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	o.mux.ServeHTTP(w, r)
+}

--- a/internal/e2e/e2ehooks/e2ehooks_test.go
+++ b/internal/e2e/e2ehooks/e2ehooks_test.go
@@ -1,0 +1,186 @@
+package e2ehooks
+
+import (
+	"context"
+	"errors"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"testing/iotest"
+	"time"
+
+	"github.com/supabase/auth/internal/conf"
+	"github.com/supabase/auth/internal/hooks/v0hooks"
+)
+
+func TestInstance(t *testing.T) {
+	{
+		globalCfg, err := conf.LoadGlobal("../../../hack/test.env")
+		if err != nil {
+			t.Fatalf("exp nil err; got %v", err)
+		}
+		globalCfg.DB.Driver = ""
+		globalCfg.DB.URL = "invalid"
+
+		inst, err := New(globalCfg)
+		if err == nil {
+			t.Fatal("exp non-nil err")
+		}
+		if inst != nil {
+			t.Fatal("exp nil *Instance")
+		}
+	}
+
+	{
+		globalCfg, err := conf.LoadGlobal("../../../hack/test.env")
+		if err != nil {
+			t.Fatalf("exp nil err; got %v", err)
+		}
+
+		inst, err := New(globalCfg)
+		if err != nil {
+			t.Fatalf("exp nil err; got %v", err)
+		}
+		if inst == nil {
+			t.Fatal("exp non-nil *Instance")
+		}
+		if err := inst.Close(); err != nil {
+			t.Fatalf("exp nil err from Close; got %v", err)
+		}
+	}
+}
+
+func TestHook(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+	defer cancel()
+
+	hook := NewHook(v0hooks.AfterUserCreated)
+
+	{
+		calls := hook.GetCalls()
+		if exp, got := 0, len(calls); exp != got {
+			t.Fatalf("exp %v; got %v", exp, got)
+		}
+
+		u := "http://localhost"
+		rdr := strings.NewReader("12345")
+		req := httptest.NewRequestWithContext(ctx, "POST", u, rdr)
+		res := httptest.NewRecorder()
+
+		hook.ServeHTTP(res, req)
+
+		calls = hook.GetCalls()
+		if exp, got := 1, len(calls); exp != got {
+			t.Fatalf("exp %v; got %v", exp, got)
+		}
+		call := calls[0]
+
+		var got int
+		if err := call.Unmarshal(&got); err != nil {
+			t.Fatalf("exp nil err; got %v", err)
+		}
+		if exp := 12345; exp != got {
+			t.Fatalf("exp %v; got %v", exp, got)
+		}
+	}
+
+	{
+		u := "http://localhost/hooks/before-user-created"
+		sentinel := errors.New("sentinel")
+		rdr := iotest.ErrReader(sentinel)
+		req := httptest.NewRequestWithContext(ctx, "POST", u, rdr)
+		res := httptest.NewRecorder()
+
+		hook.ServeHTTP(res, req)
+	}
+}
+
+func TestHookRecorder(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+	defer cancel()
+
+	hookRec := NewHookRecorder()
+	tests := []struct {
+		name v0hooks.Name
+		hook *Hook
+	}{
+		{
+			name: v0hooks.BeforeUserCreated,
+			hook: hookRec.BeforeUserCreated,
+		},
+		{
+			name: v0hooks.AfterUserCreated,
+			hook: hookRec.AfterUserCreated,
+		},
+		{
+			name: v0hooks.CustomizeAccessToken,
+			hook: hookRec.CustomizeAccessToken,
+		},
+		{
+			name: v0hooks.MFAVerification,
+			hook: hookRec.MFAVerification,
+		},
+		{
+			name: v0hooks.PasswordVerification,
+			hook: hookRec.PasswordVerification,
+		},
+		{
+			name: v0hooks.SendEmail,
+			hook: hookRec.SendEmail,
+		},
+		{
+			name: v0hooks.SendSMS,
+			hook: hookRec.SendSMS,
+		},
+	}
+
+	for _, test := range tests {
+
+		{
+			calls := test.hook.GetCalls()
+			if exp, got := 0, len(calls); exp != got {
+				t.Fatalf("exp %v; got %v", exp, got)
+			}
+		}
+
+		u := "http://localhost/hooks/" + string(test.name)
+		rdr := strings.NewReader("12345")
+		req := httptest.NewRequestWithContext(ctx, "POST", u, rdr)
+		res := httptest.NewRecorder()
+		hookRec.ServeHTTP(res, req)
+
+		{
+			calls := test.hook.GetCalls()
+			if exp, got := 1, len(calls); exp != got {
+				t.Fatalf("exp %v; got %v", exp, got)
+			}
+			call := calls[0]
+
+			test.hook.ClearCalls()
+			if exp, got := 0, len(test.hook.GetCalls()); exp != got {
+				t.Fatalf("exp %v; got %v", exp, got)
+			}
+
+			var got int
+			if err := call.Unmarshal(&got); err != nil {
+				t.Fatalf("exp nil err; got %v", err)
+			}
+			if exp := 12345; exp != got {
+				t.Fatalf("exp %v; got %v", exp, got)
+			}
+		}
+	}
+
+	// not found
+	{
+		u := "http://localhost/hooks/__invalid-hook-name__"
+		rdr := strings.NewReader("12345")
+		req := httptest.NewRequestWithContext(ctx, "POST", u, rdr)
+		res := httptest.NewRecorder()
+		hookRec.ServeHTTP(res, req)
+
+		if exp, got := 404, res.Result().StatusCode; exp != got {
+			t.Fatalf("exp %v; got %v", exp, got)
+		}
+	}
+}

--- a/internal/hooks/v0hooks/manager.go
+++ b/internal/hooks/v0hooks/manager.go
@@ -58,9 +58,31 @@ func configByName(
 		return &cfg.MFAVerificationAttempt, true
 	case PasswordVerification:
 		return &cfg.PasswordVerificationAttempt, true
+	case BeforeUserCreated:
+		return &cfg.BeforeUserCreated, true
+	case AfterUserCreated:
+		return &cfg.AfterUserCreated, true
 	default:
 		return nil, false
 	}
+}
+
+func (o *Manager) BeforeUserCreated(
+	ctx context.Context,
+	tx *storage.Connection,
+	req *BeforeUserCreatedInput,
+	res *BeforeUserCreatedOutput,
+) error {
+	return o.dispatch(ctx, &o.config.Hook.BeforeUserCreated, tx, req, res)
+}
+
+func (o *Manager) AfterUserCreated(
+	ctx context.Context,
+	tx *storage.Connection,
+	req *AfterUserCreatedInput,
+	res *AfterUserCreatedOutput,
+) error {
+	return o.dispatch(ctx, &o.config.Hook.AfterUserCreated, tx, req, res)
 }
 
 func (o *Manager) InvokeHook(

--- a/internal/hooks/v0hooks/manager.go
+++ b/internal/hooks/v0hooks/manager.go
@@ -67,24 +67,6 @@ func configByName(
 	}
 }
 
-func (o *Manager) BeforeUserCreated(
-	ctx context.Context,
-	tx *storage.Connection,
-	req *BeforeUserCreatedInput,
-	res *BeforeUserCreatedOutput,
-) error {
-	return o.dispatch(ctx, &o.config.Hook.BeforeUserCreated, tx, req, res)
-}
-
-func (o *Manager) AfterUserCreated(
-	ctx context.Context,
-	tx *storage.Connection,
-	req *AfterUserCreatedInput,
-	res *AfterUserCreatedOutput,
-) error {
-	return o.dispatch(ctx, &o.config.Hook.AfterUserCreated, tx, req, res)
-}
-
 func (o *Manager) InvokeHook(
 	conn *storage.Connection,
 	r *http.Request,
@@ -147,6 +129,23 @@ func (o *Manager) invokeHook(
 		}
 		return o.dispatch(
 			r.Context(), &o.config.Hook.CustomAccessToken, conn, input, output)
+
+	case *BeforeUserCreatedInput:
+		if _, ok := output.(*BeforeUserCreatedOutput); !ok {
+			return apierrors.NewInternalServerError(
+				"output should be *hooks.BeforeUserCreatedOutput")
+		}
+		return o.dispatch(
+			r.Context(), &o.config.Hook.BeforeUserCreated, conn, input, output)
+
+	case *AfterUserCreatedInput:
+		_, ok := output.(*AfterUserCreatedOutput)
+		if !ok {
+			return apierrors.NewInternalServerError(
+				"output should be *hooks.AfterUserCreatedOutput")
+		}
+		return o.dispatch(
+			r.Context(), &o.config.Hook.AfterUserCreated, conn, input, output)
 	}
 }
 

--- a/internal/hooks/v0hooks/v0hooks.go
+++ b/internal/hooks/v0hooks/v0hooks.go
@@ -53,8 +53,8 @@ func NewMetadata(r *http.Request, name Name) *Metadata {
 }
 
 type BeforeUserCreatedInput struct {
-	Header *Metadata    `json:"header"`
-	User   *models.User `json:"user"`
+	Metadata *Metadata    `json:"metadata"`
+	User     *models.User `json:"user"`
 }
 
 func NewBeforeUserCreatedInput(
@@ -62,8 +62,8 @@ func NewBeforeUserCreatedInput(
 	user *models.User,
 ) *BeforeUserCreatedInput {
 	return &BeforeUserCreatedInput{
-		Header: NewMetadata(r, BeforeUserCreated),
-		User:   user,
+		Metadata: NewMetadata(r, BeforeUserCreated),
+		User:     user,
 	}
 }
 
@@ -73,8 +73,8 @@ type BeforeUserCreatedOutput struct {
 }
 
 type AfterUserCreatedInput struct {
-	Header *Metadata    `json:"header"`
-	User   *models.User `json:"user"`
+	Metadata *Metadata    `json:"metadata"`
+	User     *models.User `json:"user"`
 }
 
 func NewAfterUserCreatedInput(
@@ -82,8 +82,8 @@ func NewAfterUserCreatedInput(
 	user *models.User,
 ) *AfterUserCreatedInput {
 	return &AfterUserCreatedInput{
-		Header: NewMetadata(r, AfterUserCreated),
-		User:   user,
+		Metadata: NewMetadata(r, AfterUserCreated),
+		User:     user,
 	}
 }
 


### PR DESCRIPTION
## Hooks Round 3

This PR will contain a series of commits preparing for the implementation of before & after user created hooks. It takes the feedback from https://github.com/supabase/auth/pull/2012 into consideration.

### Summary

Begin adding the Before and After user created hooks:
* update pkg `internal/conf` [d5f5436](https://github.com/supabase/auth/pull/2028/commits/d5f5436ce173d3973fd32c9f970e57e739ae90f6)
    * add `BeforeUserCreated` and `AfterUserCreated` to `HookConfiguration` struct
    * add test cases for `EmailValidationBlockedMX` to restore 100% test coverage
* update pkg `internal/hooks/v0hooks` [bd37fe2](https://github.com/supabase/auth/pull/2028/commits/bd37fe23cb784939a81f782b533e4fe0247283f5)
    * add `BeforeUserCreated` method to `v0hooks.Manager` struct
    * add `AfterUserCreated` method to `v0hooks.Manager` struct
    * add tests to reach 100% coverage
* add pkg `internal/e2e/e2ehooks` [903e623](https://github.com/supabase/auth/pull/2028/commits/903e623ea110add81c40bb6ff6832f43dd53fb2f)
    * add `HookCall` to record calls to hooks
    * add `Hook` struct to hold `[]*HookCall` for a given hook name
    * add `HookRecorder` to hold one `Hook` object per hook name
    * add `Instance` struct to hold the `httptest.Server` and `HookRecorder`
    * add `AfterUserCreated` method to `v0hooks.Manager` struct
    * add tests to reach 100% coverage in all `internal/e2e` packages
* update pkg `internal/hooks/v0hooks` [829aec6](https://github.com/supabase/auth/pull/2028/commits/829aec6bb9371bfb9923a848ecac4dd7b3235bf3)
    * fix struct and json tag to match to match the Metadata type
* update pkg `internal/hooks/v0hooks` [ca67be0](https://github.com/supabase/auth/pull/2028/commits/ca67be0db26bd096697de8b0b53346791f3a3268)
    * remove `BeforeUserCreated` and `AfterUserCreated` methods
    * add Before & After user created hooks in `InvokeHook`
* update pkg `internal/e2e/e2eapi` [46c144e](https://github.com/supabase/auth/pull/2028/commits/46c144e1ea9eac8019621d6942d2166f74c5c7fd)
    * add comments in IOError tests involving `http.RoundTripper`
    * update calls to `t.Fatal` to use `require`

### Depends on
[feat: hooks round 1](https://github.com/supabase/auth/pull/2023) - prepare package structure
* Renamed pkg `internal/hooks/v0hooks/v0http` -> `internal/hooks/hookshttp` [8a398ab](https://github.com/supabase/auth/pull/2023/commits/8a398aba564267e4caa4c32bf661699d47d29174)
* Renamed pkg `internal/hooks/v0hooks/v0pgfunc` -> `internal/hooks/hookspgfunc` [8a398ab](https://github.com/supabase/auth/pull/2023/commits/8a398aba564267e4caa4c32bf661699d47d29174)
* Use pkg `internal/e2e` for test setup in:
    * pkg `internal/hooks/hookspgfunc` [4d60288](https://github.com/supabase/auth/pull/2023/commits/4d6028869f6303321571f0978a4151f4747f9c31)
    * pkg `internal/hooks/v0hooks` [4a7432b](https://github.com/supabase/auth/pull/2023/commits/4a7432b66a767c57d25423b1e13708c47cc3a69a)

[feat: hooks round 2](https://github.com/supabase/auth/pull/2025) - remove indirection and simplify error handling
* update pkg `internal/api` to:
    * uses `internal/hooks/v0hooks.Manager` instead of `internal/hooks/hooks.Manager` [aec5995](https://github.com/supabase/auth/pull/2025/commits/aec59956b1c68ac4bbcaa656251a3085bc64e551)
* remove pkg `internal/hooks/hooks.Manager` [062da5d](https://github.com/supabase/auth/pull/2025/commits/062da5da58c95552c2312d1d2709486226613c8f)
* add pkg `internal/hooks/hookserrors` [7e80afc](https://github.com/supabase/auth/pull/2025/commits/7e80afc355322f3970a7c7715cdbde7a144c716d)
* use pkg `internal/hooks/hookserrors` in `internal/hooks/v0hooks` [57744e8](https://github.com/supabase/auth/pull/2025/commits/57744e8c4136d54d77a7520242a98ff5c3b7799d)
* update pkg `internal/hooks/v0hooks` with an `Enabled` method [16cc4c9](https://github.com/supabase/auth/pull/2025/commits/16cc4c912475f7df632f958628fca49cfba482e1)

