### PR TITLE
feat: hooks round 4 - update tests to use require package

### DIFF
--- a/internal/e2e/e2e_test.go
+++ b/internal/e2e/e2e_test.go
@@ -34,12 +34,8 @@ func TestUtils(t *testing.T) {
 			configPath = "abc"
 
 			globalCfg, err := Config()
-			if err == nil {
-				t.Fatal("exp non-nil err")
-			}
-			if globalCfg != nil {
-				t.Fatal("exp nil conn")
-			}
+			require.Error(t, err)
+			require.Nil(t, globalCfg)
 		}
 	}()
 
@@ -49,9 +45,7 @@ func TestUtils(t *testing.T) {
 		{
 			globalCfg := Must(Config())
 			conn := Must(Conn(globalCfg))
-			if conn == nil {
-				t.Fatal("exp non-nil conn")
-			}
+			require.NotNil(t, conn)
 		}
 
 		// negative
@@ -60,12 +54,8 @@ func TestUtils(t *testing.T) {
 			globalCfg.DB.Driver = ""
 			globalCfg.DB.URL = "invalid"
 			conn, err := Conn(globalCfg)
-			if err == nil {
-				t.Fatal("exp non-nil err")
-			}
-			if conn != nil {
-				t.Fatal("exp nil conn")
-			}
+			require.Error(t, err)
+			require.Nil(t, conn)
 		}
 
 	}()
@@ -89,10 +79,7 @@ func TestUtils(t *testing.T) {
 				panic(errors.New("globalCfg != nil"))
 			}
 		}()
-
-		if err == nil {
-			t.Fatal("exp non-nil err")
-		}
+		require.Error(t, err)
 	}()
 
 	// block init from main()
@@ -113,8 +100,6 @@ func TestUtils(t *testing.T) {
 		}()
 
 		exp := "package e2e may not be used in a main package"
-		if errStr != exp {
-			t.Fatalf("exp %v; got %v", exp, errStr)
-		}
+		require.Equal(t, exp, errStr)
 	}()
 }

--- a/internal/hooks/hookshttp/hookshttp_test.go
+++ b/internal/hooks/hookshttp/hookshttp_test.go
@@ -238,48 +238,49 @@ func TestDispatch(t *testing.T) {
 		)
 	}
 
-	for idx, tc := range cases {
-		t.Logf("test #%v - %v", idx, tc.desc)
+	for _, tc := range cases {
+		t.Run(tc.desc, func(t *testing.T) {
 
-		testCtx := tc.ctx
-		if testCtx == nil {
-			testCtx = ctx
-		}
+			testCtx := tc.ctx
+			if testCtx == nil {
+				testCtx = ctx
+			}
 
-		dr := tc.dr
-		if dr == nil {
-			dr = New(
-				WithTimeout(time.Second/10),
-				WithRetries(3),
-				WithBackoff(time.Second/50),
-			)
-		}
+			dr := tc.dr
+			if dr == nil {
+				dr = New(
+					WithTimeout(time.Second/10),
+					WithRetries(3),
+					WithBackoff(time.Second/50),
+				)
+			}
 
-		hr := tc.hr
-		if hr == nil {
-			hr = &mockHandler{}
-		}
-		ah.Store(hr)
+			hr := tc.hr
+			if hr == nil {
+				hr = &mockHandler{}
+			}
+			ah.Store(hr)
 
-		cfg := tc.cfg
-		if cfg.URI == "" {
-			cfg.URI = ts.URL
-		}
+			cfg := tc.cfg
+			if cfg.URI == "" {
+				cfg.URI = ts.URL
+			}
 
-		res := M{}
-		err := dr.Dispatch(testCtx, &cfg, tc.req, &res)
-		if tc.err != nil {
-			require.Error(t, err)
-			require.Equal(t, tc.err, err)
-			continue
-		}
-		if tc.errStr != "" {
-			require.Error(t, err)
-			require.Contains(t, err.Error(), tc.errStr)
-			continue
-		}
-		require.NoError(t, err)
-		require.Equal(t, tc.exp, res)
+			res := M{}
+			err := dr.Dispatch(testCtx, &cfg, tc.req, &res)
+			if tc.err != nil {
+				require.Error(t, err)
+				require.Equal(t, tc.err, err)
+				return
+			}
+			if tc.errStr != "" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tc.errStr)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.exp, res)
+		})
 	}
 }
 

--- a/internal/hooks/hookspgfunc/hookspgfunc_test.go
+++ b/internal/hooks/hookspgfunc/hookspgfunc_test.go
@@ -216,44 +216,43 @@ func TestDispatch(t *testing.T) {
 		},
 	}
 
-	for idx, tc := range cases {
-		t.Logf("test #%v - %v", idx, tc.desc)
-
-		testCtx := tc.ctx
-		if testCtx == nil {
-			testCtx = ctx
-		}
-
-		dr := tc.dr
-		if dr == nil {
-			dr = New(
-				db,
-				WithTimeout(time.Second*2),
-			)
-		}
-
-		sql := tc.sql
-		if sql != "" {
-			if err := db.RawQuery(sql).Exec(); err != nil {
-				t.Fatalf("exp nil err; got %v", err)
+	for _, tc := range cases {
+		t.Run(tc.desc, func(t *testing.T) {
+			testCtx := tc.ctx
+			if testCtx == nil {
+				testCtx = ctx
 			}
-		}
 
-		tx := tc.tx
-		cfg := tc.cfg
-		res := M{}
-		err := dr.Dispatch(testCtx, &cfg, tx, tc.req, &res)
-		if tc.err != nil {
-			require.Error(t, err)
-			require.Equal(t, tc.err, err)
-			continue
-		}
-		if tc.errStr != "" {
-			require.Error(t, err)
-			require.Contains(t, err.Error(), tc.errStr)
-			continue
-		}
-		require.NoError(t, err)
-		require.Equal(t, tc.exp, res)
+			dr := tc.dr
+			if dr == nil {
+				dr = New(
+					db,
+					WithTimeout(time.Second*2),
+				)
+			}
+
+			sql := tc.sql
+			if sql != "" {
+				err := db.RawQuery(sql).Exec()
+				require.NoError(t, err)
+			}
+
+			tx := tc.tx
+			cfg := tc.cfg
+			res := M{}
+			err := dr.Dispatch(testCtx, &cfg, tx, tc.req, &res)
+			if tc.err != nil {
+				require.Error(t, err)
+				require.Equal(t, tc.err, err)
+				return
+			}
+			if tc.errStr != "" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tc.errStr)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.exp, res)
+		})
 	}
 }


### PR DESCRIPTION
## Hooks Round 4

This PR will contain a series of commits preparing for the implementation of before & after user created hooks. It takes the feedback from https://github.com/supabase/auth/pull/2012 into consideration.

### Summary

[feat: hooks round 4](https://github.com/supabase/auth/pull/2030) - update tests to use require package
* use pkg `require` for tests in: [f2b3600](https://github.com/supabase/auth/pull/2030/commits/f2b36005c924faf7e7f50b24ab2eca1a27600d0c)
    * pkg `internal/e2e/...`
    * pkg `internal/hooks/...`


### Depends on

[feat: hooks round 1](https://github.com/supabase/auth/pull/2023) - prepare package structure
* Renamed pkg `internal/hooks/v0hooks/v0http` -> `internal/hooks/hookshttp` [8a398ab](https://github.com/supabase/auth/pull/2023/commits/8a398aba564267e4caa4c32bf661699d47d29174)
* Renamed pkg `internal/hooks/v0hooks/v0pgfunc` -> `internal/hooks/hookspgfunc` [8a398ab](https://github.com/supabase/auth/pull/2023/commits/8a398aba564267e4caa4c32bf661699d47d29174)
* Use pkg `internal/e2e` for test setup in:
    * pkg `internal/hooks/hookspgfunc` [4d60288](https://github.com/supabase/auth/pull/2023/commits/4d6028869f6303321571f0978a4151f4747f9c31)
    * pkg `internal/hooks/v0hooks` [4a7432b](https://github.com/supabase/auth/pull/2023/commits/4a7432b66a767c57d25423b1e13708c47cc3a69a)

[feat: hooks round 2](https://github.com/supabase/auth/pull/2025) - remove indirection and simplify error handling
* update pkg `internal/api` to:
    * uses `internal/hooks/v0hooks.Manager` instead of `internal/hooks/hooks.Manager` [aec5995](https://github.com/supabase/auth/pull/2025/commits/aec59956b1c68ac4bbcaa656251a3085bc64e551)
* remove pkg `internal/hooks/hooks.Manager` [062da5d](https://github.com/supabase/auth/pull/2025/commits/062da5da58c95552c2312d1d2709486226613c8f)
* add pkg `internal/hooks/hookserrors` [7e80afc](https://github.com/supabase/auth/pull/2025/commits/7e80afc355322f3970a7c7715cdbde7a144c716d)
* use pkg `internal/hooks/hookserrors` in `internal/hooks/v0hooks` [57744e8](https://github.com/supabase/auth/pull/2025/commits/57744e8c4136d54d77a7520242a98ff5c3b7799d)
* update pkg `internal/hooks/v0hooks` with an `Enabled` method [16cc4c9](https://github.com/supabase/auth/pull/2025/commits/16cc4c912475f7df632f958628fca49cfba482e1)

[feat: hooks round 3](https://github.com/supabase/auth/pull/2028) - begin adding the Before and After user created hooks
* update pkg `internal/conf` [d5f5436](https://github.com/supabase/auth/pull/2028/commits/d5f5436ce173d3973fd32c9f970e57e739ae90f6)
    * add `BeforeUserCreated` and `AfterUserCreated` to `HookConfiguration` struct
    * add test cases for `EmailValidationBlockedMX` to restore 100% test coverage
* update pkg `internal/hooks/v0hooks` [bd37fe2](https://github.com/supabase/auth/pull/2028/commits/bd37fe23cb784939a81f782b533e4fe0247283f5)
    * add `BeforeUserCreated` method to `v0hooks.Manager` struct
    * add `AfterUserCreated` method to `v0hooks.Manager` struct
    * add tests to reach 100% coverage
* add pkg `internal/e2e/e2ehooks` [903e623](https://github.com/supabase/auth/pull/2028/commits/903e623ea110add81c40bb6ff6832f43dd53fb2f)
    * add `HookCall` to record calls to hooks
    * add `Hook` struct to hold `[]*HookCall` for a given hook name
    * add `HookRecorder` to hold one `Hook` object per hook name
    * add `Instance` struct to hold the `httptest.Server` and `HookRecorder`
    * add `AfterUserCreated` method to `v0hooks.Manager` struct
    * add tests to reach 100% coverage in all `internal/e2e` packages
* update pkg `internal/hooks/v0hooks` [829aec6](https://github.com/supabase/auth/pull/2028/commits/829aec6bb9371bfb9923a848ecac4dd7b3235bf3)
    * fix struct and json tag to match to match the Metadata type
* update pkg `internal/hooks/v0hooks` [ca67be0](https://github.com/supabase/auth/pull/2028/commits/ca67be0db26bd096697de8b0b53346791f3a3268)
    * remove `BeforeUserCreated` and `AfterUserCreated` methods
    * add Before & After user created hooks in `InvokeHook`
* update pkg `internal/e2e/e2eapi` [46c144e](https://github.com/supabase/auth/pull/2028/commits/46c144e1ea9eac8019621d6942d2166f74c5c7fd)
    * add comments in IOError tests involving `http.RoundTripper`
    * update calls to `t.Fatal` to use `require`
