### PR TITLE
feat: hooks round 5 (Option 1) - add before-user-created hook

### DIFF
--- a/internal/api/admin_test.go
+++ b/internal/api/admin_test.go
@@ -602,7 +602,9 @@ func (ts *AdminTestSuite) TestAdminUserDelete() {
 			require.NoError(ts.T(), json.NewEncoder(&buffer).Encode(c.body))
 			u, err := signupParams.ToUserModel(false /* <- isSSOUser */)
 			require.NoError(ts.T(), err)
-			u, err = ts.API.signupNewUser(ts.API.db, u)
+			signupReq, err := http.NewRequest("GET", "/", nil)
+			require.NoError(ts.T(), err)
+			u, err = ts.API.signupNewUser(signupReq, ts.API.db, u)
 			require.NoError(ts.T(), err)
 
 			// Setup request

--- a/internal/api/anonymous.go
+++ b/internal/api/anonymous.go
@@ -37,7 +37,7 @@ func (a *API) SignupAnonymously(w http.ResponseWriter, r *http.Request) error {
 	var token *AccessTokenResponse
 	err = db.Transaction(func(tx *storage.Connection) error {
 		var terr error
-		newUser, terr = a.signupNewUser(tx, newUser)
+		newUser, terr = a.signupNewUser(r, tx, newUser)
 		if terr != nil {
 			return terr
 		}

--- a/internal/api/external.go
+++ b/internal/api/external.go
@@ -326,7 +326,7 @@ func (a *API) createAccountFromExternalIdentity(tx *storage.Connection, r *http.
 			return nil, terr
 		}
 
-		if user, terr = a.signupNewUser(tx, user); terr != nil {
+		if user, terr = a.signupNewUser(r, tx, user); terr != nil {
 			return nil, terr
 		}
 

--- a/internal/api/hooks.go
+++ b/internal/api/hooks.go
@@ -1,0 +1,23 @@
+package api
+
+import (
+	"net/http"
+
+	"github.com/supabase/auth/internal/hooks/v0hooks"
+	"github.com/supabase/auth/internal/models"
+	"github.com/supabase/auth/internal/storage"
+)
+
+func (a *API) triggerBeforeUserCreated(
+	r *http.Request,
+	conn *storage.Connection,
+	user *models.User,
+) error {
+	if !a.hooksMgr.Enabled(v0hooks.BeforeUserCreated) {
+		return nil
+	}
+
+	req := v0hooks.NewBeforeUserCreatedInput(r, user)
+	res := new(v0hooks.BeforeUserCreatedOutput)
+	return a.hooksMgr.InvokeHook(conn, r, req, res)
+}

--- a/internal/api/invite.go
+++ b/internal/api/invite.go
@@ -59,7 +59,7 @@ func (a *API) Invite(w http.ResponseWriter, r *http.Request) error {
 				return err
 			}
 
-			user, err = a.signupNewUser(tx, user)
+			user, err = a.signupNewUser(r, tx, user)
 			if err != nil {
 				return err
 			}

--- a/internal/api/mail.go
+++ b/internal/api/mail.go
@@ -153,7 +153,7 @@ func (a *API) adminGenerateLink(w http.ResponseWriter, r *http.Request) error {
 					return terr
 				}
 
-				user, terr = a.signupNewUser(tx, user)
+				user, terr = a.signupNewUser(r, tx, user)
 				if terr != nil {
 					return terr
 				}
@@ -198,7 +198,7 @@ func (a *API) adminGenerateLink(w http.ResponseWriter, r *http.Request) error {
 				// password here to generate a new user, use
 				// signupUser which is a model generated from
 				// SignupParams above
-				user, terr = a.signupNewUser(tx, signupUser)
+				user, terr = a.signupNewUser(r, tx, signupUser)
 				if terr != nil {
 					return terr
 				}


### PR DESCRIPTION
## Hooks Round 5 - Option 1

This PR contains Option 1 for implementing the `before-user-created` hook. See https://github.com/supabase/auth/pull/2034 for option 2.

### Summary

This commit explores one possible implementation of this hook by:
- Adding a `triggerBeforeUserCreated` to the *API object
- Updating `signupNewUser` to accept an `*http.Request` param
- Updating the following files with param r:
    - anonymous.go
    - external.go
    - invite.go
    - mail.go
    - signup.go
- Calling `triggerBeforeUserCreated` from `signupNewUser`

Pros:
- Very minor change
- Requires minimal testing
- This pattern will be easy to replicate for future hooks as well

Cons:
- Requires calling the hook in a transaction, something we do today but want to move away from over time.

Note:
I've omitted tests from this commit but they have already been written in a previous pr.


### Depends on

[feat: hooks round 1](https://github.com/supabase/auth/pull/2023) - prepare package structure
* renamed pkg `internal/hooks/v0hooks/v0http` -> `internal/hooks/hookshttp` [8a398ab](https://github.com/supabase/auth/pull/2023/commits/8a398aba564267e4caa4c32bf661699d47d29174)
* renamed pkg `internal/hooks/v0hooks/v0pgfunc` -> `internal/hooks/hookspgfunc` [8a398ab](https://github.com/supabase/auth/pull/2023/commits/8a398aba564267e4caa4c32bf661699d47d29174)
* use pkg `internal/e2e` for test setup in:
    * pkg `internal/hooks/hookspgfunc` [4d60288](https://github.com/supabase/auth/pull/2023/commits/4d6028869f6303321571f0978a4151f4747f9c31)
    * pkg `internal/hooks/v0hooks` [4a7432b](https://github.com/supabase/auth/pull/2023/commits/4a7432b66a767c57d25423b1e13708c47cc3a69a)

[feat: hooks round 2](https://github.com/supabase/auth/pull/2025) - remove indirection and simplify error handling
* update pkg `internal/api` to:
    * uses `internal/hooks/v0hooks.Manager` instead of `internal/hooks/hooks.Manager` [aec5995](https://github.com/supabase/auth/pull/2025/commits/aec59956b1c68ac4bbcaa656251a3085bc64e551)
* remove pkg `internal/hooks/hooks.Manager` [062da5d](https://github.com/supabase/auth/pull/2025/commits/062da5da58c95552c2312d1d2709486226613c8f)
* add pkg `internal/hooks/hookserrors` [7e80afc](https://github.com/supabase/auth/pull/2025/commits/7e80afc355322f3970a7c7715cdbde7a144c716d)
* use pkg `internal/hooks/hookserrors` in `internal/hooks/v0hooks` [57744e8](https://github.com/supabase/auth/pull/2025/commits/57744e8c4136d54d77a7520242a98ff5c3b7799d)
* update pkg `internal/hooks/v0hooks` with an `Enabled` method [16cc4c9](https://github.com/supabase/auth/pull/2025/commits/16cc4c912475f7df632f958628fca49cfba482e1)

[feat: hooks round 3](https://github.com/supabase/auth/pull/2028) - begin adding the Before and After user created hooks
* update pkg `internal/conf` [d5f5436](https://github.com/supabase/auth/pull/2028/commits/d5f5436ce173d3973fd32c9f970e57e739ae90f6)
    * add `BeforeUserCreated` and `AfterUserCreated` to `HookConfiguration` struct
    * add test cases for `EmailValidationBlockedMX` to restore 100% test coverage
* update pkg `internal/hooks/v0hooks` [bd37fe2](https://github.com/supabase/auth/pull/2028/commits/bd37fe23cb784939a81f782b533e4fe0247283f5)
    * add `BeforeUserCreated` method to `v0hooks.Manager` struct
    * add `AfterUserCreated` method to `v0hooks.Manager` struct
    * add tests to reach 100% coverage
* add pkg `internal/e2e/e2ehooks` [903e623](https://github.com/supabase/auth/pull/2028/commits/903e623ea110add81c40bb6ff6832f43dd53fb2f)
    * add `HookCall` to record calls to hooks
    * add `Hook` struct to hold `[]*HookCall` for a given hook name
    * add `HookRecorder` to hold one `Hook` object per hook name
    * add `Instance` struct to hold the `httptest.Server` and `HookRecorder`
    * add `AfterUserCreated` method to `v0hooks.Manager` struct
    * add tests to reach 100% coverage in all `internal/e2e` packages
* update pkg `internal/hooks/v0hooks` [829aec6](https://github.com/supabase/auth/pull/2028/commits/829aec6bb9371bfb9923a848ecac4dd7b3235bf3)
    * fix struct and json tag to match to match the Metadata type
* update pkg `internal/hooks/v0hooks` [ca67be0](https://github.com/supabase/auth/pull/2028/commits/ca67be0db26bd096697de8b0b53346791f3a3268)
    * remove `BeforeUserCreated` and `AfterUserCreated` methods
    * add Before & After user created hooks in `InvokeHook`
* update pkg `internal/e2e/e2eapi` [46c144e](https://github.com/supabase/auth/pull/2028/commits/46c144e1ea9eac8019621d6942d2166f74c5c7fd)
    * add comments in IOError tests involving `http.RoundTripper`
    * update calls to `t.Fatal` to use `require`

[feat: hooks round 4](https://github.com/supabase/auth/pull/2030) - update tests to use require package
* use pkg `require` for tests in: [f2b3600](https://github.com/supabase/auth/pull/2030/commits/f2b36005c924faf7e7f50b24ab2eca1a27600d0c)
    * pkg `internal/e2e/...`
    * pkg `internal/hooks/...`