### PR TITLE
feat: hooks round 5 (Option 2) - add before-user-created hook

### DIFF
--- a/internal/api/anonymous.go
+++ b/internal/api/anonymous.go
@@ -30,6 +30,9 @@ func (a *API) SignupAnonymously(w http.ResponseWriter, r *http.Request) error {
 	if err != nil {
 		return err
 	}
+	if err := a.triggerBeforeUserCreated(r, db, newUser); err != nil {
+		return err
+	}
 
 	var grantParams models.GrantParams
 	grantParams.FillGrantParams(r)

--- a/internal/api/e2e_test.go
+++ b/internal/api/e2e_test.go
@@ -1,0 +1,258 @@
+package api_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/gofrs/uuid"
+	jwt "github.com/golang-jwt/jwt/v5"
+	"github.com/stretchr/testify/require"
+	"github.com/supabase/auth/internal/api"
+	"github.com/supabase/auth/internal/conf"
+	"github.com/supabase/auth/internal/e2e"
+	"github.com/supabase/auth/internal/e2e/e2eapi"
+	"github.com/supabase/auth/internal/e2e/e2ehooks"
+	"github.com/supabase/auth/internal/hooks/v0hooks"
+	"github.com/supabase/auth/internal/models"
+)
+
+func TestE2EHooks(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+	defer cancel()
+
+	globalCfg := e2e.Must(e2e.Config())
+	inst, err := e2ehooks.New(globalCfg)
+	require.NoError(t, err)
+	defer inst.Close()
+
+	apiSrv := inst.APIServer
+	hookRec := inst.HookRecorder
+
+	var currentUser *models.User
+
+	// Basic tests for Before/After User Created hooks
+	t.Run("UserHooks", func(t *testing.T) {
+
+		// Signup a user
+		var signupUser *models.User
+		email := "e2etesthooks_" + uuid.Must(uuid.NewV4()).String() + "@localhost"
+		t.Run("Signup", func(t *testing.T) {
+			req := &api.SignupParams{
+				Email:    email,
+				Password: "password",
+			}
+			res := new(models.User)
+			err := e2eapi.Do(ctx, http.MethodPost, apiSrv.URL+"/signup", req, res)
+			require.NoError(t, err)
+
+			signupUser = res
+
+			require.Equal(t, email, signupUser.Email.String())
+		})
+
+		t.Run("BeforeUserCreated", func(t *testing.T) {
+			calls := hookRec.BeforeUserCreated.GetCalls()
+			require.Equal(t, 1, len(calls))
+			call := calls[0]
+
+			hookReq := &v0hooks.BeforeUserCreatedInput{}
+			err := call.Unmarshal(hookReq)
+			require.NoError(t, err)
+
+			u := hookReq.User
+			require.Equal(t, signupUser.ID, u.ID)
+			require.Equal(t, signupUser.Aud, u.Aud)
+			require.Equal(t, signupUser.Email, u.Email)
+			require.Equal(t, signupUser.AppMetaData, u.AppMetaData)
+
+			require.True(t, u.CreatedAt.IsZero())
+			require.True(t, u.UpdatedAt.IsZero())
+
+			err = signupUser.Confirm(inst.Conn)
+			require.NoError(t, err)
+
+			latest, err := models.FindUserByID(inst.Conn, signupUser.ID)
+			require.NoError(t, err)
+
+			// Assign currentUser for next tests.
+			currentUser = latest
+			require.NotNil(t, currentUser)
+		})
+	})
+
+	// Basic tests for CustomizeAccessToken
+	t.Run("CustomizeAccessToken", func(t *testing.T) {
+		require.NotNil(t, currentUser)
+
+		type M = map[string]any
+
+		copyMap := func(t *testing.T, m M) (out M) {
+			b, err := json.Marshal(m)
+			require.NoError(t, err)
+			err = json.Unmarshal(b, &out)
+			require.NoError(t, err)
+			return out
+		}
+		checkClaims := func(t *testing.T, in, out M, exclude ...string) {
+			if aud, ok := in["aud"].([]any); ok && len(aud) > 0 {
+				require.Equal(t, aud[0].(string), out["aud"])
+			}
+			if aud, ok := in["aud"].(string); ok {
+				require.Equal(t, aud, out["aud"])
+			}
+
+			for _, k := range []string{
+				"iss",
+				"sub",
+				"exp",
+				"iat",
+				"aal",
+				"role",
+				"amr",
+				"session_id",
+				"is_anonymous",
+				"app_metadata",
+				"user_metadata",
+				"phone",
+				"email",
+			} {
+				if !slices.Contains(exclude, k) {
+					require.Equal(t, in[k], out[k])
+				}
+			}
+		}
+
+		cases := []struct {
+			desc   string
+			from   func(claimsIn M) (claimsOut M)
+			errStr string
+			check  func(
+				t *testing.T,
+				claimsIn, claimsOut M,
+			)
+		}{
+			{
+				desc:   `empty claims`,
+				from:   func(in M) M { return M{"claims": M{}} },
+				errStr: "500: error generating jwt token",
+			},
+
+			{
+				desc: `add app_metadata claims`,
+				from: func(in M) M {
+					out := copyMap(t, in)
+					out["claims"].(M)["app_metadata"].(M)["bool_true"] = true
+					out["claims"].(M)["app_metadata"].(M)["string_hello"] = "hello"
+					return out
+				},
+				check: func(
+					t *testing.T,
+					in, out M,
+				) {
+					checkClaims(t, in, out, "app_metadata")
+
+					for k := range in {
+						if k == "app_metadata" {
+							require.Equal(t,
+								out["app_metadata"].(M)["bool_true"],
+								true,
+							)
+							require.Equal(t,
+								out["app_metadata"].(M)["string_hello"],
+								"hello",
+							)
+							continue
+						}
+					}
+				},
+			},
+		}
+
+		for _, tc := range cases {
+			t.Run(string(tc.desc), func(t *testing.T) {
+				var claimsIn, claimsOut M
+				hr := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					w.Header().Add("content-type", "application/json")
+					w.WriteHeader(http.StatusOK)
+
+					err := json.NewDecoder(r.Body).Decode(&claimsIn)
+					require.NoError(t, err)
+
+					claimsOut = tc.from(copyMap(t, claimsIn))
+					err = json.NewEncoder(w).Encode(claimsOut)
+					require.NoError(t, err)
+				})
+
+				hookRec.CustomizeAccessToken.ClearCalls()
+				hookRec.CustomizeAccessToken.SetHandler(hr)
+				req := &api.PasswordGrantParams{
+					Email:    string(currentUser.Email),
+					Password: "password",
+				}
+
+				res := new(api.AccessTokenResponse)
+				err := e2eapi.Do(ctx, http.MethodPost, apiSrv.URL+"/token?grant_type=password", req, res)
+
+				// always verify the hook request before checking response
+				{
+					calls := hookRec.CustomizeAccessToken.GetCalls()
+					require.Equal(t, 1, len(calls))
+					call := calls[0]
+
+					hookReq := &v0hooks.CustomAccessTokenInput{}
+					err := call.Unmarshal(hookReq)
+					require.NoError(t, err)
+					require.Equal(t, currentUser.ID, hookReq.UserID)
+					require.Equal(t, currentUser.ID.String(), hookReq.Claims.Subject)
+				}
+
+				// check if we expected an error
+				if tc.errStr != "" {
+					require.Error(t, err)
+					require.Contains(t, err.Error(), tc.errStr)
+					return
+				}
+				require.True(t, len(res.Token) > 0)
+
+				// parse the token we got back
+				p := jwt.NewParser(jwt.WithValidMethods(globalCfg.JWT.ValidMethods))
+				token, err := p.ParseWithClaims(
+					res.Token,
+					&api.AccessTokenClaims{},
+					func(token *jwt.Token,
+					) (any, error) {
+						if kid, ok := token.Header["kid"]; ok {
+							if kidStr, ok := kid.(string); ok {
+								return conf.FindPublicKeyByKid(kidStr, &globalCfg.JWT)
+							}
+						}
+						if alg, ok := token.Header["alg"]; ok {
+							if alg == jwt.SigningMethodHS256.Name {
+								// preserve backward compatibility for cases where the kid is not set
+								return []byte(globalCfg.JWT.Secret), nil
+							}
+						}
+						return nil, fmt.Errorf("missing kid")
+					})
+				require.NoError(t, err)
+
+				tokenClaims := M{}
+				{
+					b, err := json.Marshal(token.Claims)
+					require.NoError(t, err)
+					err = json.Unmarshal(b, &tokenClaims)
+					require.NoError(t, err)
+				}
+
+				if tc.check != nil {
+					tc.check(t, claimsIn["claims"].(M), tokenClaims)
+				}
+			})
+		}
+	})
+}

--- a/internal/api/hooks.go
+++ b/internal/api/hooks.go
@@ -1,0 +1,99 @@
+package api
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/fatih/structs"
+	"github.com/supabase/auth/internal/api/apierrors"
+	"github.com/supabase/auth/internal/api/provider"
+	"github.com/supabase/auth/internal/hooks/v0hooks"
+	"github.com/supabase/auth/internal/models"
+	"github.com/supabase/auth/internal/storage"
+)
+
+func (a *API) triggerBeforeUserCreated(
+	r *http.Request,
+	conn *storage.Connection,
+	user *models.User,
+) error {
+	if !a.hooksMgr.Enabled(v0hooks.BeforeUserCreated) {
+		return nil
+	}
+	if conn.TX != nil {
+		// TODO(cstockton): remove this
+		panic("unable to trigger hooks during transaction")
+	}
+
+	req := v0hooks.NewBeforeUserCreatedInput(r, user)
+	res := new(v0hooks.BeforeUserCreatedOutput)
+	return a.hooksMgr.InvokeHook(conn, r, req, res)
+}
+
+func (a *API) triggerBeforeUserCreatedExternal(
+	r *http.Request,
+	conn *storage.Connection,
+	userData *provider.UserProvidedData,
+	providerType string,
+) error {
+	if !a.hooksMgr.Enabled(v0hooks.BeforeUserCreated) {
+		return nil
+	}
+	if conn.TX != nil {
+		// TODO(cstockton): remove this
+		panic("unable to trigger hooks during transaction")
+	}
+
+	ctx := r.Context()
+	aud := a.requestAud(ctx, r)
+	config := a.config
+
+	var identityData map[string]interface{}
+	if userData.Metadata != nil {
+		identityData = structs.Map(userData.Metadata)
+	}
+
+	var (
+		err      error
+		decision models.AccountLinkingResult
+	)
+	err = a.db.Transaction(func(tx *storage.Connection) error {
+		decision, err = models.DetermineAccountLinking(
+			tx, config, userData.Emails, aud,
+			providerType, userData.Metadata.Subject)
+		if err != nil {
+			return err
+		}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	if decision.Decision != models.CreateAccount {
+		return nil
+	}
+	if config.DisableSignup {
+		return apierrors.NewUnprocessableEntityError(
+			apierrors.ErrorCodeSignupDisabled,
+			"Signups not allowed for this instance")
+	}
+
+	params := &SignupParams{
+		Provider: providerType,
+		Email:    decision.CandidateEmail.Email,
+		Aud:      aud,
+		Data:     identityData,
+	}
+
+	isSSOUser := false
+	if strings.HasPrefix(decision.LinkingDomain, "sso:") {
+		isSSOUser = true
+	}
+
+	user, err := params.ToUserModel(isSSOUser)
+	if err != nil {
+		return err
+	}
+	return a.triggerBeforeUserCreated(r, conn, user)
+}

--- a/internal/api/invite.go
+++ b/internal/api/invite.go
@@ -37,41 +37,38 @@ func (a *API) Invite(w http.ResponseWriter, r *http.Request) error {
 	if err != nil && !models.IsNotFoundError(err) {
 		return apierrors.NewInternalServerError("Database error finding user").WithInternalError(err)
 	}
+	if user != nil && user.IsConfirmed() {
+		return apierrors.NewUnprocessableEntityError(apierrors.ErrorCodeEmailExists, DuplicateEmailMsg)
+	}
+
+	signupParams := SignupParams{
+		Email:    params.Email,
+		Data:     params.Data,
+		Aud:      aud,
+		Provider: "email",
+	}
+
+	user, err = signupParams.ToUserModel(false /* <- isSSOUser */)
+	if err != nil {
+		return err
+	}
+	if err := a.triggerBeforeUserCreated(r, db, user); err != nil {
+		return err
+	}
 
 	err = db.Transaction(func(tx *storage.Connection) error {
-		if user != nil {
-			if user.IsConfirmed() {
-				return apierrors.NewUnprocessableEntityError(apierrors.ErrorCodeEmailExists, DuplicateEmailMsg)
-			}
-		} else {
-			signupParams := SignupParams{
-				Email:    params.Email,
-				Data:     params.Data,
-				Aud:      aud,
-				Provider: "email",
-			}
-
-			// because params above sets no password, this method
-			// is not computationally hard so it can be used within
-			// a database transaction
-			user, err = signupParams.ToUserModel(false /* <- isSSOUser */)
-			if err != nil {
-				return err
-			}
-
-			user, err = a.signupNewUser(tx, user)
-			if err != nil {
-				return err
-			}
-			identity, err := a.createNewIdentity(tx, user, "email", structs.Map(provider.Claims{
-				Subject: user.ID.String(),
-				Email:   user.GetEmail(),
-			}))
-			if err != nil {
-				return err
-			}
-			user.Identities = []models.Identity{*identity}
+		user, err = a.signupNewUser(tx, user)
+		if err != nil {
+			return err
 		}
+		identity, err := a.createNewIdentity(tx, user, "email", structs.Map(provider.Claims{
+			Subject: user.ID.String(),
+			Email:   user.GetEmail(),
+		}))
+		if err != nil {
+			return err
+		}
+		user.Identities = []models.Identity{*identity}
 
 		if terr := models.NewAuditLogEntry(r, tx, adminUser, models.UserInvitedAction, "", map[string]interface{}{
 			"user_id":    user.ID,

--- a/internal/api/samlacs.go
+++ b/internal/api/samlacs.go
@@ -281,12 +281,18 @@ func (a *API) handleSamlAcs(w http.ResponseWriter, r *http.Request) error {
 		}
 	}
 
+	providerType := "sso:" + ssoProvider.ID.String()
+	if err := a.triggerBeforeUserCreatedExternal(
+		r, db, &userProvidedData, providerType); err != nil {
+		return err
+	}
+
 	if err := db.Transaction(func(tx *storage.Connection) error {
 		var terr error
 		var user *models.User
 
 		// accounts potentially created via SAML can contain non-unique email addresses in the auth.users table
-		if user, terr = a.createAccountFromExternalIdentity(tx, r, &userProvidedData, "sso:"+ssoProvider.ID.String()); terr != nil {
+		if user, terr = a.createAccountFromExternalIdentity(tx, r, &userProvidedData, providerType); terr != nil {
 			return terr
 		}
 		if flowState != nil {

--- a/internal/api/signup.go
+++ b/internal/api/signup.go
@@ -183,6 +183,9 @@ func (a *API) Signup(w http.ResponseWriter, r *http.Request) error {
 		if err != nil {
 			return err
 		}
+		if err := a.triggerBeforeUserCreated(r, db, signupUser); err != nil {
+			return err
+		}
 	}
 
 	err = db.Transaction(func(tx *storage.Connection) error {

--- a/internal/api/token_oidc.go
+++ b/internal/api/token_oidc.go
@@ -224,6 +224,10 @@ func (a *API) IdTokenGrant(ctx context.Context, w http.ResponseWriter, r *http.R
 
 	grantParams.FillGrantParams(r)
 
+	if err := a.triggerBeforeUserCreatedExternal(r, db, userData, providerType); err != nil {
+		return err
+	}
+
 	if err := db.Transaction(func(tx *storage.Connection) error {
 		var user *models.User
 		var terr error

--- a/internal/e2e/e2eapi/e2eapi_test.go
+++ b/internal/e2e/e2eapi/e2eapi_test.go
@@ -172,7 +172,6 @@ func TestDo(t *testing.T) {
 				err := Do(ctx, http.MethodPost, ts.URL, nil, nil)
 				require.Error(t, err)
 				require.Equal(t, sentinel, err)
-
 			})
 		}
 	})


### PR DESCRIPTION
### Summary

This commit explores one possible implementation of this hook by:
- Adding a `triggerBeforeUserCreated` method to the `*API` object in `internal/api/hooks.go`
- Adding a `triggerBeforeUserCreatedExternal` method to the `*API` object in `internal/api/hooks.go`
- Updating callers of `signupNewUser` to first call `triggerBeforeUserCreated` in:
    - internal/api/anonymous.go
    - internal/api/external.go
    - internal/api/invite.go
    - internal/api/mail.go
    - internal/api/signup.go
- Updating callers of `signupNewUser` to first call `triggerBeforeUserCreatedExternal` in:
    - internal/api/external.go
    - internal/api/samlacs.go
    - internal/api/token_oidc.go
    - internal/api/web3.go
- Add end to end tests in `internal/api/e2e_test.go`


### Depends on

[feat: hooks round 1](https://github.com/supabase/auth/pull/2023) - prepare package structure
* renamed pkg `internal/hooks/v0hooks/v0http` -> `internal/hooks/hookshttp` [8a398ab](https://github.com/supabase/auth/pull/2023/commits/8a398aba564267e4caa4c32bf661699d47d29174)
* renamed pkg `internal/hooks/v0hooks/v0pgfunc` -> `internal/hooks/hookspgfunc` [8a398ab](https://github.com/supabase/auth/pull/2023/commits/8a398aba564267e4caa4c32bf661699d47d29174)
* use pkg `internal/e2e` for test setup in:
    * pkg `internal/hooks/hookspgfunc` [4d60288](https://github.com/supabase/auth/pull/2023/commits/4d6028869f6303321571f0978a4151f4747f9c31)
    * pkg `internal/hooks/v0hooks` [4a7432b](https://github.com/supabase/auth/pull/2023/commits/4a7432b66a767c57d25423b1e13708c47cc3a69a)

[feat: hooks round 2](https://github.com/supabase/auth/pull/2025) - remove indirection and simplify error handling
* update pkg `internal/api` to:
    * uses `internal/hooks/v0hooks.Manager` instead of `internal/hooks/hooks.Manager` [aec5995](https://github.com/supabase/auth/pull/2025/commits/aec59956b1c68ac4bbcaa656251a3085bc64e551)
* remove pkg `internal/hooks/hooks.Manager` [062da5d](https://github.com/supabase/auth/pull/2025/commits/062da5da58c95552c2312d1d2709486226613c8f)
* add pkg `internal/hooks/hookserrors` [7e80afc](https://github.com/supabase/auth/pull/2025/commits/7e80afc355322f3970a7c7715cdbde7a144c716d)
* use pkg `internal/hooks/hookserrors` in `internal/hooks/v0hooks` [57744e8](https://github.com/supabase/auth/pull/2025/commits/57744e8c4136d54d77a7520242a98ff5c3b7799d)
* update pkg `internal/hooks/v0hooks` with an `Enabled` method [16cc4c9](https://github.com/supabase/auth/pull/2025/commits/16cc4c912475f7df632f958628fca49cfba482e1)

[feat: hooks round 3](https://github.com/supabase/auth/pull/2028) - begin adding the Before and After user created hooks
* update pkg `internal/conf` [d5f5436](https://github.com/supabase/auth/pull/2028/commits/d5f5436ce173d3973fd32c9f970e57e739ae90f6)
    * add `BeforeUserCreated` and `AfterUserCreated` to `HookConfiguration` struct
    * add test cases for `EmailValidationBlockedMX` to restore 100% test coverage
* update pkg `internal/hooks/v0hooks` [bd37fe2](https://github.com/supabase/auth/pull/2028/commits/bd37fe23cb784939a81f782b533e4fe0247283f5)
    * add `BeforeUserCreated` method to `v0hooks.Manager` struct
    * add `AfterUserCreated` method to `v0hooks.Manager` struct
    * add tests to reach 100% coverage
* add pkg `internal/e2e/e2ehooks` [903e623](https://github.com/supabase/auth/pull/2028/commits/903e623ea110add81c40bb6ff6832f43dd53fb2f)
    * add `HookCall` to record calls to hooks
    * add `Hook` struct to hold `[]*HookCall` for a given hook name
    * add `HookRecorder` to hold one `Hook` object per hook name
    * add `Instance` struct to hold the `httptest.Server` and `HookRecorder`
    * add `AfterUserCreated` method to `v0hooks.Manager` struct
    * add tests to reach 100% coverage in all `internal/e2e` packages
* update pkg `internal/hooks/v0hooks` [829aec6](https://github.com/supabase/auth/pull/2028/commits/829aec6bb9371bfb9923a848ecac4dd7b3235bf3)
    * fix struct and json tag to match to match the Metadata type
* update pkg `internal/hooks/v0hooks` [ca67be0](https://github.com/supabase/auth/pull/2028/commits/ca67be0db26bd096697de8b0b53346791f3a3268)
    * remove `BeforeUserCreated` and `AfterUserCreated` methods
    * add Before & After user created hooks in `InvokeHook`
* update pkg `internal/e2e/e2eapi` [46c144e](https://github.com/supabase/auth/pull/2028/commits/46c144e1ea9eac8019621d6942d2166f74c5c7fd)
    * add comments in IOError tests involving `http.RoundTripper`
    * update calls to `t.Fatal` to use `require`

[feat: hooks round 4](https://github.com/supabase/auth/pull/2030) - update tests to use require package
* use pkg `require` for tests in: [f2b3600](https://github.com/supabase/auth/pull/2030/commits/f2b36005c924faf7e7f50b24ab2eca1a27600d0c)
    * pkg `internal/e2e/...`
    * pkg `internal/hooks/...`
