### PR TITLE
feat: adds artifact checksums to release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,6 +101,27 @@ jobs:
           mv auth gotrue
           tar -czvf auth-v$RELEASE_VERSION.supafast-arm64.tar.gz gotrue migrations/
 
+      - name: Generate checksums
+        if: ${{ steps.release.outputs.release_created == 'true' || steps.release.outputs.prs_created == 'true' }}
+        run: |
+          set -ex
+          # Function to generate checksums for a specific hash type
+          generate_checksums() {
+            local hash_type=$1
+            local hash_cmd=$2
+            echo "### ${hash_type}" >> checksums.txt
+            for file in auth-v$RELEASE_VERSION*.tar.gz; do
+              echo "\`$file\`:\n\`\`\`" >> checksums.txt
+              $hash_cmd "$file" | awk '{print $1}' >> checksums.txt
+              echo "\`\`\`\n" >> checksums.txt
+            done
+          }
+
+          # Generate the checksum file to be appended to the release notes later
+          echo "## Checksums" > checksums.txt
+          generate_checksums "SHA1" "sha1sum"
+          generate_checksums "SHA256" "sha256sum"
+
       - name: Upload release artifacts
         if: ${{ steps.release.outputs.release_created == 'true' || steps.release.outputs.prs_created == 'true' }}
         run: |
@@ -109,12 +130,13 @@ jobs:
           if [ "$RELEASE_CANDIDATE" == "true" ]
           then
             PR_NUMBER='${{ steps.release.outputs.pr && fromJSON(steps.release.outputs.pr).number }}'
+            CHECKSUM_CONTENT=$(cat checksums.txt)
 
             GH_TOKEN='${{ github.token }}' gh release \
               create $RELEASE_NAME \
               --title "v$RELEASE_VERSION" \
               --prerelease \
-              -n "This is a release candidate. See release-please PR #$PR_NUMBER for context."
+              -n "This is a release candidate. See release-please PR #$PR_NUMBER for context.\n\n$CHECKSUM_CONTENT"
 
             GH_TOKEN='${{ github.token }}' gh pr comment "$PR_NUMBER" \
               -b "Release candidate [v$RELEASE_VERSION](https://github.com/supabase/gotrue/releases/tag/$RELEASE_NAME) published."
@@ -138,6 +160,12 @@ jobs:
                 fi
               fi
           fi
+
+          # Append checksums to existing release notes
+          EXISTING_NOTES=$(GH_TOKEN='${{ github.token }}' gh release view $RELEASE_NAME --json body -q .body)
+          CHECKSUM_CONTENT=$(cat checksums.txt)
+          FULL_NOTES="${EXISTING_NOTES}\n\n${CHECKSUM_CONTENT}"
+          GH_TOKEN='${{ github.token }}' gh release edit $RELEASE_NAME -n "$FULL_NOTES"
 
           GH_TOKEN='${{ github.token }}' gh release upload $RELEASE_NAME ./auth-v$RELEASE_VERSION-x86.tar.gz ./auth-v$RELEASE_VERSION-arm64.tar.gz ./auth-v$RELEASE_VERSION.supafast-arm64.tar.gz
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

- Add SHA1 and SHA256 checksums for all release artifacts
- Append checksums to existing release notes

## What is the current behavior?

Checksums manually calculated.

## What is the new behavior?

Checksums appended to the release notes.

