### PR TITLE
enh: prefix schema to enum migrations

### DIFF
--- a/migrations/20221003041349_add_mfa_schema.up.sql
+++ b/migrations/20221003041349_add_mfa_schema.up.sql
@@ -1,8 +1,8 @@
 -- see: https://stackoverflow.com/questions/7624919/check-if-a-user-defined-type-already-exists-in-postgresql/48382296#48382296
 do $$ begin
-    create type factor_type as enum('totp', 'webauthn');
-    create type factor_status as enum('unverified', 'verified');
-    create type aal_level as enum('aal1', 'aal2', 'aal3');
+    create type {{ index .Options "Namespace" }}.factor_type as enum('totp', 'webauthn');
+    create type {{ index .Options "Namespace" }}.factor_status as enum('unverified', 'verified');
+    create type {{ index .Options "Namespace" }}.aal_level as enum('aal1', 'aal2', 'aal3');
 exception
     when duplicate_object then null;
 end $$;
@@ -12,8 +12,8 @@ create table if not exists {{ index .Options "Namespace" }}.mfa_factors(
        id uuid not null,
        user_id uuid not null,
        friendly_name text null,
-       factor_type factor_type not null,
-       status factor_status not null,
+       factor_type {{ index .Options "Namespace" }}.factor_type not null,
+       status {{ index .Options "Namespace" }}.factor_status not null,
        created_at timestamptz not null,
        updated_at timestamptz not null,
        secret text null,

--- a/migrations/20221003041400_add_aal_and_factor_id_to_sessions.up.sql
+++ b/migrations/20221003041400_add_aal_and_factor_id_to_sessions.up.sql
@@ -1,3 +1,3 @@
 -- add factor_id to sessions
  alter table {{ index .Options "Namespace" }}.sessions add column if not exists factor_id uuid null;
- alter table {{ index .Options "Namespace" }}.sessions add column if not exists aal aal_level null;
+ alter table {{ index .Options "Namespace" }}.sessions add column if not exists aal {{ index .Options "Namespace" }}.aal_level null;

--- a/migrations/20230322519590_add_flow_state_table.up.sql
+++ b/migrations/20230322519590_add_flow_state_table.up.sql
@@ -1,6 +1,6 @@
 -- see: https://stackoverflow.com/questions/7624919/check-if-a-user-defined-type-already-exists-in-postgresql/48382296#48382296
 do $$ begin
-    create type code_challenge_method as enum('s256', 'plain');
+    create type {{ index .Options "Namespace" }}.code_challenge_method as enum('s256', 'plain');
 exception
     when duplicate_object then null;
 end $$;
@@ -8,7 +8,7 @@ create table if not exists {{ index .Options "Namespace" }}.flow_state(
        id uuid primary key,
        user_id uuid null,
        auth_code text not null,
-       code_challenge_method code_challenge_method not null,
+       code_challenge_method {{ index .Options "Namespace" }}.code_challenge_method not null,
        code_challenge text not null,
        provider_type text not null,
        provider_access_token text null,

--- a/migrations/20240427152123_add_one_time_tokens_table.up.sql
+++ b/migrations/20240427152123_add_one_time_tokens_table.up.sql
@@ -1,5 +1,5 @@
 do $$ begin
-  create type one_time_token_type as enum (
+  create type {{ index .Options "Namespace" }}.one_time_token_type as enum (
     'confirmation_token',
     'reauthentication_token',
     'recovery_token',
@@ -16,7 +16,7 @@ do $$ begin
   create table if not exists {{ index .Options "Namespace" }}.one_time_tokens (
     id uuid primary key,
     user_id uuid not null references {{ index .Options "Namespace" }}.users on delete cascade,
-    token_type one_time_token_type not null,
+    token_type {{ index .Options "Namespace" }}.one_time_token_type not null,
     token_hash text not null,
     relates_to text not null,
     created_at timestamp without time zone not null default now(),


### PR DESCRIPTION
Add support for nonstandard search path migrations

## What kind of change does this PR introduce?

Continuation of #1983 and fixes #1729

## What is the current behavior?

The current migration script assumes the search path has been set to a custom schema.

```
ALTER USER supabase_auth_admin SET search_path = '$DB_NAMESPACE';
```

If this step missed, the default schema for all migrations is `public`. This should be fine if all tables and enums are prefixed accordingly, but currently it's not. All postgres enum is not prefixed with schema.

## What is the new behavior?

All postgres enum will be prefixed with the schema. This should fixes issue #1729 where the migration is broken if search path is not set properly.

This doesn't introduce a breaking change, because if `search_path` is already set all enums stay on the former `search_path` .

## Additional context

Haven't test. Will test soon.
