### PR TITLE
fix: email-sendhook - bug in email change verification

### DIFF
--- a/internal/api/e2e_test.go
+++ b/internal/api/e2e_test.go
@@ -957,15 +957,28 @@ func TestE2EHooks(t *testing.T) {
 				// verify the new_email field in hook req
 				require.Equal(t, newEmail, hookReq.User.EmailChange)
 
+				// BUG(cstockton): verify the token is moved TokenNew -> Token
+				require.NotEmpty(t, hookReq.EmailData.Token)
+
+				// BUG(cstockton): verify that token new is empty like before
+				require.Empty(t, hookReq.EmailData.TokenNew)
+				require.Empty(t, hookReq.EmailData.TokenHashNew)
+
+				// verify otps
+				newOtpHash := crypto.GenerateTokenHash(
+					newEmail, hookReq.EmailData.Token)
+
+				// The new email is stored on fields without _new suffix.
+				//
+				// 	EmailData.TokenHash = Hash(NewEmail, EmailData.TokenNew)
+				//
+				// This check locks this behavior in to keep BC with existing hooks
+				require.Equal(t, newOtpHash, hookReq.EmailData.TokenHash)
+
 				// verify the EmailData
 				require.Equal(t, mailer.EmailChangeVerification, hookReq.EmailData.EmailActionType)
 				require.Equal(t, inst.Config.SiteURL, hookReq.EmailData.RedirectTo)
 				require.Equal(t, inst.Config.API.ExternalURL, hookReq.EmailData.SiteURL)
-
-				// BUG(cstockton): verify the bug (token new)
-				require.Empty(t, hookReq.EmailData.Token)
-				require.Empty(t, hookReq.EmailData.TokenNew)
-				require.Empty(t, hookReq.EmailData.TokenHashNew)
 			})
 		})
 
@@ -1157,15 +1170,28 @@ func TestE2EHooks(t *testing.T) {
 				// verify the new_email field in hook req
 				require.Equal(t, newEmail, hookReq.User.EmailChange)
 
+				// BUG(cstockton): verify the token is moved TokenNew -> Token
+				require.NotEmpty(t, hookReq.EmailData.Token)
+
+				// BUG(cstockton): verify that token new is empty like before
+				require.Empty(t, hookReq.EmailData.TokenNew)
+				require.Empty(t, hookReq.EmailData.TokenHashNew)
+
+				// verify otps
+				newOtpHash := crypto.GenerateTokenHash(
+					newEmail, hookReq.EmailData.Token)
+
+				// The new email is stored on fields without _new suffix.
+				//
+				// 	EmailData.TokenHash = Hash(NewEmail, EmailData.TokenNew)
+				//
+				// This check locks this behavior in to keep BC with existing hooks
+				require.Equal(t, newOtpHash, hookReq.EmailData.TokenHash)
+
 				// verify the EmailData
 				require.Equal(t, mailer.EmailChangeVerification, hookReq.EmailData.EmailActionType)
 				require.Equal(t, inst.Config.SiteURL, hookReq.EmailData.RedirectTo)
 				require.Equal(t, inst.Config.API.ExternalURL, hookReq.EmailData.SiteURL)
-
-				// BUG(cstockton): verify the bug (token new)
-				require.Empty(t, hookReq.EmailData.Token)
-				require.Empty(t, hookReq.EmailData.TokenNew)
-				require.Empty(t, hookReq.EmailData.TokenHashNew)
 			})
 		})
 	})

--- a/internal/api/mail.go
+++ b/internal/api/mail.go
@@ -639,7 +639,22 @@ func (a *API) sendEmail(r *http.Request, tx *storage.Connection, u *models.User,
 	if config.Hook.SendEmail.Enabled {
 		// When secure email change is disabled, we place the token for the new email on emailData.Token
 		if emailActionType == mail.EmailChangeVerification && !config.Mailer.SecureEmailChangeEnabled && u.GetEmail() != "" {
-			// BUG(cstockton): I view this as a bug, see e2e_test.go
+
+			// BUG(cstockton): This introduced a bug which mismatched the token
+			// and hash fields, such that:
+			//
+			// 	EmailData.TokenHashNew = Hash(CurEmail, EmailData.Token)
+			// 	EmailData.TokenHash    = Hash(NewEmail, EmailData.TokenNew)
+			//
+			// Specifically with email changes we should look to fix this
+			// behavior in a BC way to maintain that:
+			//
+			//   Token      Always contains the Token for user.email
+			//   TokenHash  Always contains the Hash for user.email
+			//
+			//   Token      Always contains the Token for user.email_new
+			//   TokenHash  Always contains the Hash for user.email_new
+			//
 			otp = otpNew
 		}
 
@@ -656,11 +671,9 @@ func (a *API) sendEmail(r *http.Request, tx *storage.Connection, u *models.User,
 				emailData.TokenHashNew = u.EmailChangeTokenCurrent
 			} else if emailData.Token == "" && u.EmailChange != "" {
 
-				// BUG(cstockton): I am fixing this bug in a way that is
-				// consistent with what I view to be the current bug. I believe
-				// for email changes token_new and token_hash_new should always
-				// contain the values for the users new_email field. This should
-				// be fixed in the future in a way that doesn't break BC.
+				// BUG(cstockton): This matches the current behavior but is not
+				// intuitive and should be changed in a future release. See the
+				// comment above for more details.
 				emailData.Token = otpNew
 			}
 		}


### PR DESCRIPTION
This change sets EmailData.Token to the new OTP when the secure email change setting is set to true.

This should fix:
https://github.com/supabase/auth/issues/1744
https://github.com/supabase/auth/issues/2042

Note:
I am fixing this bug in a way that is consistent with what I view to be the current bug. I believe for email changes token_new and token_hash_new should always contain the values for the users new_email field. This should be fixed in the future in a way that doesn't break BC.