### PR TITLE
feat: parsing & validating the new redirect url patterns

### DIFF
--- a/internal/conf/configuration.go
+++ b/internal/conf/configuration.go
@@ -19,7 +19,6 @@ import (
 	"github.com/joho/godotenv"
 	"github.com/kelseyhightower/envconfig"
 	"github.com/lestrrat-go/jwx/v2/jwk"
-	"github.com/supabase/auth/internal/redirecturi"
 	"gopkg.in/gomail.v2"
 )
 
@@ -268,7 +267,6 @@ type GlobalConfiguration struct {
 	SiteURL         string   `json:"site_url" split_words:"true" required:"true"`
 	URIAllowList    []string `json:"uri_allow_list" split_words:"true"`
 	URIAllowListMap map[string]glob.Glob
-	RedirectConfig  *redirecturi.RedirectConfig
 	Password        PasswordConfiguration    `json:"password"`
 	JWT             JWTConfiguration         `json:"jwt"`
 	Mailer          MailerConfiguration      `json:"mailer"`
@@ -1037,20 +1035,10 @@ func (config *GlobalConfiguration) ApplyDefaults() error {
 
 	if config.URIAllowList != nil {
 		config.URIAllowListMap = make(map[string]glob.Glob)
-		var patterns []redirecturi.RedirectPattern
-
 		for _, uri := range config.URIAllowList {
 			g := glob.MustCompile(uri, '.', '/')
 			config.URIAllowListMap[uri] = g
-
-			pattern, err := redirecturi.CategorizePattern(uri)
-			if err != nil {
-				continue // Skip invalid patterns
-			}
-			patterns = append(patterns, pattern)
 		}
-
-		config.RedirectConfig = redirecturi.NewRedirectConfig(patterns)
 	}
 
 	if config.Password.MinLength < defaultMinPasswordLength {

--- a/internal/conf/configuration.go
+++ b/internal/conf/configuration.go
@@ -19,6 +19,7 @@ import (
 	"github.com/joho/godotenv"
 	"github.com/kelseyhightower/envconfig"
 	"github.com/lestrrat-go/jwx/v2/jwk"
+	"github.com/supabase/auth/internal/redirecturi"
 	"gopkg.in/gomail.v2"
 )
 
@@ -267,6 +268,7 @@ type GlobalConfiguration struct {
 	SiteURL         string   `json:"site_url" split_words:"true" required:"true"`
 	URIAllowList    []string `json:"uri_allow_list" split_words:"true"`
 	URIAllowListMap map[string]glob.Glob
+	RedirectConfig  *redirecturi.RedirectConfig
 	Password        PasswordConfiguration    `json:"password"`
 	JWT             JWTConfiguration         `json:"jwt"`
 	Mailer          MailerConfiguration      `json:"mailer"`
@@ -1035,10 +1037,20 @@ func (config *GlobalConfiguration) ApplyDefaults() error {
 
 	if config.URIAllowList != nil {
 		config.URIAllowListMap = make(map[string]glob.Glob)
+		var patterns []redirecturi.RedirectPattern
+
 		for _, uri := range config.URIAllowList {
 			g := glob.MustCompile(uri, '.', '/')
 			config.URIAllowListMap[uri] = g
+
+			pattern, err := redirecturi.CategorizePattern(uri)
+			if err != nil {
+				continue // Skip invalid patterns
+			}
+			patterns = append(patterns, pattern)
 		}
+
+		config.RedirectConfig = redirecturi.NewRedirectConfig(patterns)
 	}
 
 	if config.Password.MinLength < defaultMinPasswordLength {

--- a/internal/redirecturi/patterns.go
+++ b/internal/redirecturi/patterns.go
@@ -64,7 +64,7 @@ func CategorizePattern(pattern string) (RedirectPattern, error) {
 
 	pattern = strings.TrimSpace(pattern)
 	if pattern == "" {
-		return rp, errors.New("pattern cannot be empty")
+		return rp, errors.New("redirecturi: pattern cannot be empty")
 	}
 
 	// Check if contains wildcard
@@ -81,18 +81,18 @@ func CategorizePattern(pattern string) (RedirectPattern, error) {
 				restOfUri := parts[1]
 				// Check if wildcard is in scheme - not allowed
 				if strings.Contains(scheme, "*") {
-					return rp, errors.New("invalid scheme in wildcard pattern")
+					return rp, errors.New("redirecturi: invalid scheme in wildcard pattern")
 				}
 
 				// Let url package validate the scheme part
 				testURL := scheme + "://example.com"
 				if _, err := url.Parse(testURL); err != nil {
-					return rp, fmt.Errorf("invalid scheme in wildcard pattern: %w", err)
+					return rp, fmt.Errorf("redirecturi: invalid scheme in wildcard pattern: %w", err)
 				}
 
 				// Check if wildcard is in path (not allowed)
 				if strings.Contains(restOfUri, "/") && strings.Contains(restOfUri[strings.Index(restOfUri, "/"):], "*") {
-					return rp, errors.New("wildcards are not allowed in URL paths")
+					return rp, errors.New("redirecturi: wildcards are not allowed in URL paths")
 				}
 			}
 			globPattern = pattern
@@ -104,7 +104,7 @@ func CategorizePattern(pattern string) (RedirectPattern, error) {
 		// Compile the glob pattern
 		g, err := glob.Compile(globPattern, '.')
 		if err != nil {
-			return rp, fmt.Errorf("failed to compile glob pattern: %w", err)
+			return rp, fmt.Errorf("redirecturi: failed to compile glob pattern: %w", err)
 		}
 		rp.GlobPattern = g
 		return rp, nil
@@ -115,7 +115,7 @@ func CategorizePattern(pattern string) (RedirectPattern, error) {
 		scheme := strings.TrimSuffix(pattern, "://")
 		// Use url package to validate the scheme
 		if _, err := url.Parse(scheme + "://example.com"); err != nil {
-			return rp, fmt.Errorf("invalid scheme pattern: %w", err)
+			return rp, fmt.Errorf("redirecturi: invalid scheme pattern: %w", err)
 		}
 		rp.Type = PatternTypeSchemeOnly
 		// Use ** to match across all path components
@@ -127,7 +127,7 @@ func CategorizePattern(pattern string) (RedirectPattern, error) {
 	// Try to parse as URL to validate
 	if strings.Contains(pattern, "://") {
 		if _, err := url.Parse(pattern); err != nil {
-			return rp, fmt.Errorf("invalid URL pattern: %w", err)
+			return rp, fmt.Errorf("redirecturi: invalid URL pattern: %w", err)
 		}
 		rp.Type = PatternTypeExact
 		// Exact URLs match only the exact URL specified
@@ -155,7 +155,7 @@ func CategorizePattern(pattern string) (RedirectPattern, error) {
 		return rp, nil
 	}
 
-	return rp, errors.New("invalid pattern format")
+	return rp, errors.New("redirecturi: invalid pattern format")
 }
 
 // isLocalhostDomain checks if a domain is localhost-like

--- a/internal/redirecturi/patterns.go
+++ b/internal/redirecturi/patterns.go
@@ -1,0 +1,150 @@
+package redirecturi
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/gobwas/glob"
+)
+
+// RedirectPatternType represents the type of redirect pattern
+type RedirectPatternType int
+
+const (
+	// PatternTypeExact represents an exact URL match
+	PatternTypeExact RedirectPatternType = iota
+	// PatternTypeDomainOnly represents a domain-only pattern
+	PatternTypeDomainOnly
+	// PatternTypeSchemeOnly represents a scheme-only pattern
+	PatternTypeSchemeOnly
+	// PatternTypeWildcard represents a wildcard pattern
+	PatternTypeWildcard
+)
+
+// String returns the string representation of the RedirectPatternType
+func (t RedirectPatternType) String() string {
+	switch t {
+	case PatternTypeExact:
+		return "exact"
+	case PatternTypeDomainOnly:
+		return "domain-only"
+	case PatternTypeSchemeOnly:
+		return "scheme-only"
+	case PatternTypeWildcard:
+		return "wildcard"
+	default:
+		return fmt.Sprintf("unknown(%d)", t)
+	}
+}
+
+// RedirectPattern represents a parsed redirect pattern
+type RedirectPattern struct {
+	Original    string
+	Type        RedirectPatternType
+	GlobPattern glob.Glob
+}
+
+// RedirectConfig holds the configuration for redirect patterns
+type RedirectConfig struct {
+	Patterns []RedirectPattern
+}
+
+// NewRedirectConfig creates a new RedirectConfig
+func NewRedirectConfig(patterns []RedirectPattern) *RedirectConfig {
+	return &RedirectConfig{
+		Patterns: patterns,
+	}
+}
+
+// CategorizePattern determines the type of a redirect uri and returns a RedirectPattern
+func CategorizePattern(pattern string) (RedirectPattern, error) {
+	rp := RedirectPattern{Original: pattern}
+
+	pattern = strings.TrimSpace(pattern)
+	if pattern == "" {
+		return rp, errors.New("pattern cannot be empty")
+	}
+
+	// Check if contains wildcard
+	if strings.Contains(pattern, "*") {
+		rp.Type = PatternTypeWildcard
+
+		var globPattern string
+
+		// Use Go's url package to validate wildcard patterns
+		if strings.Contains(pattern, "://") {
+			parts := strings.SplitN(pattern, "://", 2)
+			if len(parts) == 2 {
+				scheme := parts[0]
+				restOfUri := parts[1]
+				// Check if wildcard is in scheme - not allowed
+				if strings.Contains(scheme, "*") {
+					return rp, errors.New("invalid scheme in wildcard pattern")
+				}
+
+				// Let url package validate the scheme part
+				testURL := scheme + "://example.com"
+				if _, err := url.Parse(testURL); err != nil {
+					return rp, fmt.Errorf("invalid scheme in wildcard pattern: %w", err)
+				}
+
+				// Check if wildcard is in path (not allowed)
+				if strings.Contains(restOfUri, "/") && strings.Contains(restOfUri[strings.Index(restOfUri, "/"):], "*") {
+					return rp, errors.New("wildcards are not allowed in URL paths")
+				}
+			}
+			globPattern = pattern
+		} else {
+			// Domain-only wildcard pattern - add HTTPS prefix and path matching
+			globPattern = "https://" + pattern + "{,/**}"
+		}
+
+		// Compile the glob pattern
+		g, err := glob.Compile(globPattern, '.')
+		if err != nil {
+			return rp, fmt.Errorf("failed to compile glob pattern: %w", err)
+		}
+		rp.GlobPattern = g
+		return rp, nil
+	}
+
+	// Check if it's scheme-only (e.g., "myapp://")
+	if strings.HasSuffix(pattern, "://") {
+		scheme := strings.TrimSuffix(pattern, "://")
+		// Use url package to validate the scheme
+		if _, err := url.Parse(scheme + "://example.com"); err != nil {
+			return rp, fmt.Errorf("invalid scheme pattern: %w", err)
+		}
+		rp.Type = PatternTypeSchemeOnly
+		// Use ** to match across all path components
+		g, _ := glob.Compile(pattern+"**", '.')
+		rp.GlobPattern = g
+		return rp, nil
+	}
+
+	// Try to parse as URL to validate
+	if strings.Contains(pattern, "://") {
+		if _, err := url.Parse(pattern); err != nil {
+			return rp, fmt.Errorf("invalid URL pattern: %w", err)
+		}
+		rp.Type = PatternTypeExact
+		// Exact URLs match only the exact URL specified
+		g, _ := glob.Compile(pattern, '.')
+		rp.GlobPattern = g
+		return rp, nil
+	}
+
+	// Domain-only pattern (no scheme, no path)
+	if !strings.Contains(pattern, "/") {
+		rp.Type = PatternTypeDomainOnly
+		// Domain-only patterns default to HTTPS (configure explicit URLs for other schemes)
+		// Use {,/**} to match both with and without paths
+		g, _ := glob.Compile("https://"+pattern+"{,/**}", '.')
+		rp.GlobPattern = g
+		return rp, nil
+	}
+
+	return rp, errors.New("invalid pattern format")
+}

--- a/internal/redirecturi/patterns_test.go
+++ b/internal/redirecturi/patterns_test.go
@@ -680,6 +680,36 @@ func TestIsValidRedirectURL(t *testing.T) {
 			expected:    true,
 		},
 
+		// Localhost configuration
+		{
+			name:        "Localhost - allow without http scheme",
+			config:      mustConfig("localhost"),
+			redirectURL: "http://localhost",
+			siteURL:     "",
+			expected:    true,
+		},
+		{
+			name:        "Localhost - allow without https scheme",
+			config:      mustConfig("localhost"),
+			redirectURL: "https://localhost",
+			siteURL:     "",
+			expected:    true,
+		},
+		{
+			name:        "Localhost - allow without scheme different port",
+			config:      mustConfig("localhost"),
+			redirectURL: "http://localhost:3000",
+			siteURL:     "",
+			expected:    true,
+		},
+		{
+			name:        "Localhost - allow without scheme different port & path",
+			config:      mustConfig("localhost"),
+			redirectURL: "http://localhost:3000/callback",
+			siteURL:     "",
+			expected:    true,
+		},
+
 		// Localhost HTTP explicit configuration
 		{
 			name:        "Localhost HTTP - explicitly configured",

--- a/internal/redirecturi/patterns_test.go
+++ b/internal/redirecturi/patterns_test.go
@@ -213,6 +213,12 @@ func TestCategorizePattern(t *testing.T) {
 					// Should match scheme with any host/path
 					schemePrefix := tt.pattern
 					assert.True(t, result.GlobPattern.Match(schemePrefix+"host/path"))
+				case PatternTypeExact:
+					// Should match exactly
+					assert.True(t, result.GlobPattern.Match(tt.pattern))
+				case PatternTypeWildcard:
+					// Wildcard patterns should be tested individually based on their content
+					// Skip generic validation here as each wildcard has specific matching rules
 				}
 			}
 		})

--- a/internal/redirecturi/patterns_test.go
+++ b/internal/redirecturi/patterns_test.go
@@ -1,0 +1,744 @@
+package redirecturi
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Helper function to create a config with one or more patterns inline
+func mustConfig(patterns ...string) *RedirectConfig {
+	var redirectPatterns []RedirectPattern
+	for _, pattern := range patterns {
+		p, err := CategorizePattern(pattern)
+		if err != nil {
+			panic("Invalid test pattern: " + pattern + ": " + err.Error())
+		}
+		redirectPatterns = append(redirectPatterns, p)
+	}
+	return NewRedirectConfig(redirectPatterns)
+}
+
+func TestCategorizePattern(t *testing.T) {
+	tests := []struct {
+		name         string
+		pattern      string
+		expectedType RedirectPatternType
+		expectError  bool
+		errContains  string
+	}{
+		// Exact URL patterns
+		{
+			name:         "HTTPS URL with path",
+			pattern:      "https://example.com/callback",
+			expectedType: PatternTypeExact,
+			expectError:  false,
+		},
+		{
+			name:         "HTTP localhost URL",
+			pattern:      "http://localhost:3000/auth",
+			expectedType: PatternTypeExact,
+			expectError:  false,
+		},
+		{
+			name:         "HTTPS URL with query params",
+			pattern:      "https://api.example.com/auth?version=v1",
+			expectedType: PatternTypeExact,
+			expectError:  false,
+		},
+		{
+			name:         "Custom scheme URL",
+			pattern:      "myapp://auth/callback",
+			expectedType: PatternTypeExact,
+			expectError:  false,
+		},
+		{
+			name:         "Custom scheme with simple path",
+			pattern:      "myapp://login",
+			expectedType: PatternTypeExact,
+			expectError:  false,
+		},
+		{
+			name:         "Custom scheme with query params",
+			pattern:      "myapp://callback?token=abc",
+			expectedType: PatternTypeExact,
+			expectError:  false,
+		},
+
+		// Domain-only patterns
+		{
+			name:         "Simple domain",
+			pattern:      "example.com",
+			expectedType: PatternTypeDomainOnly,
+			expectError:  false,
+		},
+		{
+			name:         "Subdomain",
+			pattern:      "auth.example.com",
+			expectedType: PatternTypeDomainOnly,
+			expectError:  false,
+		},
+		{
+			name:         "Localhost domain",
+			pattern:      "localhost",
+			expectedType: PatternTypeDomainOnly,
+			expectError:  false,
+		},
+		{
+			name:         "IP address domain",
+			pattern:      "127.0.0.1",
+			expectedType: PatternTypeDomainOnly,
+			expectError:  false,
+		},
+
+		// Scheme-only patterns
+		{
+			name:         "Custom app scheme",
+			pattern:      "myapp://",
+			expectedType: PatternTypeSchemeOnly,
+			expectError:  false,
+		},
+		{
+			name:         "Another custom scheme",
+			pattern:      "com.example.app://",
+			expectedType: PatternTypeSchemeOnly,
+			expectError:  false,
+		},
+		{
+			name:         "Scheme with numbers",
+			pattern:      "app123://",
+			expectedType: PatternTypeSchemeOnly,
+			expectError:  false,
+		},
+		{
+			name:         "Scheme with hyphens",
+			pattern:      "my-app://",
+			expectedType: PatternTypeSchemeOnly,
+			expectError:  false,
+		},
+		{
+			name:         "Single letter scheme",
+			pattern:      "x://",
+			expectedType: PatternTypeSchemeOnly,
+			expectError:  false,
+		},
+
+		// Wildcard patterns
+		{
+			name:         "Subdomain wildcard",
+			pattern:      "*.example.com",
+			expectedType: PatternTypeWildcard,
+			expectError:  false,
+		},
+		{
+			name:         "Complex wildcard domain",
+			pattern:      "*-preview.example.com",
+			expectedType: PatternTypeWildcard,
+			expectError:  false,
+		},
+		{
+			name:         "Wildcard with https",
+			pattern:      "https://*.staging.example.com",
+			expectedType: PatternTypeWildcard,
+			expectError:  false,
+		},
+
+		// Error cases
+		{
+			name:        "Empty pattern",
+			pattern:     "",
+			expectError: true,
+			errContains: "pattern cannot be empty",
+		},
+		{
+			name:        "Whitespace only",
+			pattern:     "   ",
+			expectError: true,
+			errContains: "pattern cannot be empty",
+		},
+		{
+			name:        "Wildcard in path",
+			pattern:     "https://example.com/auth/*",
+			expectError: true,
+			errContains: "wildcards are not allowed in URL paths",
+		},
+		{
+			name:        "Invalid URL",
+			pattern:     "https://[invalid",
+			expectError: true,
+			errContains: "invalid URL pattern",
+		},
+		{
+			name:        "Invalid scheme in wildcard",
+			pattern:     "ht*tp://example.com",
+			expectError: true,
+			errContains: "invalid scheme in wildcard pattern",
+		},
+		{
+			name:        "Invalid scheme only pattern",
+			pattern:     "ht[tp://",
+			expectError: true,
+			errContains: "invalid scheme pattern",
+		},
+		{
+			name:        "Path in domain-only pattern",
+			pattern:     "example.com/path",
+			expectError: true,
+			errContains: "invalid pattern format",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := CategorizePattern(tt.pattern)
+
+			if tt.expectError {
+				require.Error(t, err)
+				if tt.errContains != "" {
+					assert.Contains(t, err.Error(), tt.errContains)
+				}
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.expectedType, result.Type)
+				assert.Equal(t, tt.pattern, result.Original)
+				assert.NotNil(t, result.GlobPattern)
+
+				// Verify glob pattern is actually usable
+				switch tt.expectedType {
+				case PatternTypeDomainOnly:
+					// Should match HTTPS version
+					assert.True(t, result.GlobPattern.Match("https://"+tt.pattern+"/path"))
+				case PatternTypeSchemeOnly:
+					// Should match scheme with any host/path
+					schemePrefix := tt.pattern
+					assert.True(t, result.GlobPattern.Match(schemePrefix+"host/path"))
+				}
+			}
+		})
+	}
+}
+
+func TestIsValidRedirectURL(t *testing.T) {
+
+	tests := []struct {
+		name        string
+		config      *RedirectConfig
+		siteURL     string
+		redirectURL string
+		expected    bool
+	}{
+		// Basic validation
+		{
+			name:        "Nil config returns false",
+			config:      nil,
+			redirectURL: "https://example.com",
+			siteURL:     "",
+			expected:    false,
+		},
+		{
+			name:        "Empty config returns false",
+			config:      NewRedirectConfig([]RedirectPattern{}),
+			redirectURL: "https://example.com",
+			siteURL:     "",
+			expected:    false,
+		},
+		{
+			name:        "Empty URL returns false",
+			config:      mustConfig("https://example.com/callback"),
+			redirectURL: "",
+			siteURL:     "",
+			expected:    false,
+		},
+
+		// Security checks
+		{
+			name:        "Same hostname as site",
+			config:      mustConfig("https://example.com/callback"),
+			redirectURL: "https://site.com/different-path",
+			siteURL:     "https://site.com",
+			expected:    true,
+		},
+		{
+			name:        "Decimal IP address",
+			config:      mustConfig("https://example.com/callback"),
+			redirectURL: "https://2130706433/path", // 127.0.0.1 in decimal
+			siteURL:     "https://site.com",
+			expected:    false,
+		},
+		{
+			name:        "Regular IP address",
+			config:      mustConfig("https://example.com/callback"),
+			redirectURL: "https://192.168.1.1/path",
+			siteURL:     "https://site.com",
+			expected:    false,
+		},
+		{
+			name:        "Loopback IP allowed",
+			config:      mustConfig("https://example.com/callback"),
+			redirectURL: "https://127.0.0.1/path",
+			siteURL:     "https://site.com",
+			expected:    true,
+		},
+		{
+			name:        "IPv6 loopback",
+			config:      mustConfig("https://example.com/callback"),
+			redirectURL: "https://[::1]/path",
+			siteURL:     "https://site.com",
+			expected:    true,
+		},
+		{
+			name:        "Malformed redirect URL",
+			config:      mustConfig("https://example.com/callback"),
+			redirectURL: "not-a-url",
+			siteURL:     "https://site.com",
+			expected:    false,
+		},
+
+		// Exact pattern matching
+		{
+			name:        "Exact match - valid",
+			config:      mustConfig("https://example.com/callback"),
+			redirectURL: "https://example.com/callback",
+			siteURL:     "",
+			expected:    true,
+		},
+		{
+			name:        "Exact match - different path",
+			config:      mustConfig("https://example.com/callback"),
+			redirectURL: "https://example.com/other",
+			siteURL:     "",
+			expected:    false,
+		},
+		{
+			name:        "Exact match - different scheme",
+			config:      mustConfig("https://example.com/callback"),
+			redirectURL: "http://example.com/callback",
+			siteURL:     "",
+			expected:    false,
+		},
+
+		// Domain-only pattern matching
+		{
+			name:        "Domain pattern - HTTPS with path",
+			config:      mustConfig("auth.example.com"),
+			redirectURL: "https://auth.example.com/login",
+			siteURL:     "",
+			expected:    true,
+		},
+		{
+			name:        "Domain pattern - HTTPS root",
+			config:      mustConfig("auth.example.com"),
+			redirectURL: "https://auth.example.com",
+			siteURL:     "",
+			expected:    true,
+		},
+		{
+			name:        "Domain pattern - HTTP not allowed",
+			config:      mustConfig("auth.example.com"),
+			redirectURL: "http://auth.example.com/login",
+			siteURL:     "",
+			expected:    false,
+		},
+		{
+			name:        "Domain pattern - wrong domain",
+			config:      mustConfig("auth.example.com"),
+			redirectURL: "https://other.example.com/login",
+			siteURL:     "",
+			expected:    false,
+		},
+
+		// Base domain pattern matching (example.com)
+		{
+			name:        "Base domain - HTTPS with path",
+			config:      mustConfig("example.com"),
+			redirectURL: "https://example.com/login",
+			siteURL:     "",
+			expected:    true,
+		},
+		{
+			name:        "Base domain - HTTPS root",
+			config:      mustConfig("example.com"),
+			redirectURL: "https://example.com",
+			siteURL:     "",
+			expected:    true,
+		},
+		{
+			name:        "Base domain - HTTPS with deep path",
+			config:      mustConfig("example.com"),
+			redirectURL: "https://example.com/auth/callback/success",
+			siteURL:     "",
+			expected:    true,
+		},
+		{
+			name:        "Base domain - HTTPS with query params",
+			config:      mustConfig("example.com"),
+			redirectURL: "https://example.com/login?redirect=home&token=abc",
+			siteURL:     "",
+			expected:    true,
+		},
+		{
+			name:        "Base domain - HTTP not allowed",
+			config:      mustConfig("example.com"),
+			redirectURL: "http://example.com/login",
+			siteURL:     "",
+			expected:    false,
+		},
+		{
+			name:        "Base domain - wrong domain (subdomain)",
+			config:      mustConfig("example.com"),
+			redirectURL: "https://auth.example.com/login",
+			siteURL:     "",
+			expected:    false,
+		},
+		{
+			name:        "Base domain - wrong domain (different)",
+			config:      mustConfig("example.com"),
+			redirectURL: "https://other.com/login",
+			siteURL:     "",
+			expected:    false,
+		},
+		{
+			name:        "Base domain - with fragment",
+			config:      mustConfig("example.com"),
+			redirectURL: "https://example.com/page#section",
+			siteURL:     "",
+			expected:    true,
+		},
+		{
+			name:        "Base domain - with port",
+			config:      mustConfig("example.com"),
+			redirectURL: "https://example.com:8080/login",
+			siteURL:     "",
+			expected:    false, // Port makes it different domain
+		},
+
+		// Scheme-only pattern matching
+		{
+			name:        "Scheme pattern - matches any host/path",
+			config:      mustConfig("myapp://"),
+			redirectURL: "myapp://host/path?query=value",
+			siteURL:     "",
+			expected:    true,
+		},
+		{
+			name:        "Scheme pattern - matches simple",
+			config:      mustConfig("myapp://"),
+			redirectURL: "myapp://callback",
+			siteURL:     "",
+			expected:    true,
+		},
+		{
+			name:        "Scheme pattern - matches empty path",
+			config:      mustConfig("myapp://"),
+			redirectURL: "myapp://",
+			siteURL:     "",
+			expected:    true,
+		},
+		{
+			name:        "Scheme pattern - matches complex path",
+			config:      mustConfig("myapp://"),
+			redirectURL: "myapp://auth/login/success?token=123&user=456",
+			siteURL:     "",
+			expected:    true,
+		},
+		{
+			name:        "Scheme pattern - wrong scheme",
+			config:      mustConfig("myapp://"),
+			redirectURL: "otherapp://callback",
+			siteURL:     "",
+			expected:    false,
+		},
+
+		// Scheme exact pattern matching (myapp://login)
+		{
+			name:        "Scheme exact - matches exact path",
+			config:      mustConfig("myapp://login"),
+			redirectURL: "myapp://login",
+			siteURL:     "",
+			expected:    true,
+		},
+		{
+			name:        "Scheme exact - does not match with additional path",
+			config:      mustConfig("myapp://login"),
+			redirectURL: "myapp://login/success",
+			siteURL:     "",
+			expected:    false,
+		},
+		{
+			name:        "Scheme exact - does not match with query params",
+			config:      mustConfig("myapp://login"),
+			redirectURL: "myapp://login?token=abc",
+			siteURL:     "",
+			expected:    false,
+		},
+		{
+			name:        "Scheme exact - does not match with path and query",
+			config:      mustConfig("myapp://login"),
+			redirectURL: "myapp://login/success?user=123",
+			siteURL:     "",
+			expected:    false,
+		},
+		{
+			name:        "Scheme exact - different path",
+			config:      mustConfig("myapp://login"),
+			redirectURL: "myapp://callback",
+			siteURL:     "",
+			expected:    false,
+		},
+		{
+			name:        "Scheme exact - wrong scheme",
+			config:      mustConfig("myapp://login"),
+			redirectURL: "otherapp://login",
+			siteURL:     "",
+			expected:    false,
+		},
+
+		// Scheme with query pattern matching
+		{
+			name:        "Scheme with query - exact match",
+			config:      mustConfig("myapp://callback?token=abc"),
+			redirectURL: "myapp://callback?token=abc",
+			siteURL:     "",
+			expected:    true,
+		},
+		{
+			name:        "Scheme with query - additional query params",
+			config:      mustConfig("myapp://callback?token=abc"),
+			redirectURL: "myapp://callback?token=abc&user=123",
+			siteURL:     "",
+			expected:    false, // Additional query params are not allowed for security (exact match required)
+		},
+		{
+			name:        "Scheme with query - different query value",
+			config:      mustConfig("myapp://callback?token=abc"),
+			redirectURL: "myapp://callback?token=xyz",
+			siteURL:     "",
+			expected:    false,
+		},
+		{
+			name:        "Scheme with query - missing query",
+			config:      mustConfig("myapp://callback?token=abc"),
+			redirectURL: "myapp://callback",
+			siteURL:     "",
+			expected:    false,
+		},
+
+		// Custom scheme pattern matching
+		{
+			name:        "Custom scheme - matches with path",
+			config:      mustConfig("com.example.app://"),
+			redirectURL: "com.example.app://auth/callback",
+			siteURL:     "",
+			expected:    true,
+		},
+		{
+			name:        "Custom scheme - matches simple",
+			config:      mustConfig("com.example.app://"),
+			redirectURL: "com.example.app://login",
+			siteURL:     "",
+			expected:    true,
+		},
+		{
+			name:        "Custom scheme - wrong scheme",
+			config:      mustConfig("com.example.app://"),
+			redirectURL: "com.other.app://login",
+			siteURL:     "",
+			expected:    false,
+		},
+
+		// Wildcard pattern matching
+		{
+			name:        "Wildcard - matches subdomain",
+			config:      mustConfig("*.preview.example.com"),
+			redirectURL: "https://branch-123.preview.example.com/callback",
+			siteURL:     "",
+			expected:    true,
+		},
+		{
+			name:        "Wildcard - matches another subdomain",
+			config:      mustConfig("*.preview.example.com"),
+			redirectURL: "https://staging.preview.example.com",
+			siteURL:     "",
+			expected:    true,
+		},
+		{
+			name:        "Wildcard - wrong domain",
+			config:      mustConfig("*.preview.example.com"),
+			redirectURL: "https://preview.other.com",
+			siteURL:     "",
+			expected:    false,
+		},
+
+		// Multiple patterns
+		{
+			name: "Multiple patterns - first matches",
+			config: mustConfig(
+				"https://example.com/callback",
+				"auth.example.com",
+			),
+			redirectURL: "https://example.com/callback",
+			siteURL:     "",
+			expected:    true,
+		},
+		{
+			name: "Multiple patterns - second matches",
+			config: mustConfig(
+				"https://example.com/callback",
+				"auth.example.com",
+			),
+			redirectURL: "https://auth.example.com/login",
+			siteURL:     "",
+			expected:    true,
+		},
+		{
+			name: "Multiple patterns - none match",
+			config: mustConfig(
+				"https://example.com/callback",
+				"auth.example.com",
+			),
+			redirectURL: "https://other.com/callback",
+			siteURL:     "",
+			expected:    false,
+		},
+
+		// Multiple scheme patterns
+		{
+			name: "Multiple schemes - scheme-only matches",
+			config: mustConfig(
+				"myapp://",
+				"myapp://login",
+				"com.example.app://",
+			),
+			redirectURL: "myapp://anything",
+			siteURL:     "",
+			expected:    true,
+		},
+		{
+			name: "Multiple schemes - exact scheme does not match with additional path",
+			config: mustConfig(
+				"myapp://login",
+				"com.example.app://",
+			),
+			redirectURL: "myapp://login/success",
+			siteURL:     "",
+			expected:    false,
+		},
+		{
+			name: "Multiple schemes - custom scheme matches",
+			config: mustConfig(
+				"myapp://",
+				"com.example.app://",
+			),
+			redirectURL: "com.example.app://callback",
+			siteURL:     "",
+			expected:    true,
+		},
+		{
+			name: "Multiple schemes - no match",
+			config: mustConfig(
+				"myapp://login",
+				"com.example.app://",
+			),
+			redirectURL: "differentapp://callback",
+			siteURL:     "",
+			expected:    false,
+		},
+
+		// Mixed pattern types
+		{
+			name: "Mixed patterns - HTTPS matches",
+			config: mustConfig(
+				"https://example.com/callback",
+				"myapp://",
+				"*.preview.example.com",
+			),
+			redirectURL: "https://example.com/callback",
+			siteURL:     "",
+			expected:    true,
+		},
+		{
+			name: "Mixed patterns - scheme matches",
+			config: mustConfig(
+				"https://example.com/callback",
+				"myapp://",
+				"*.preview.example.com",
+			),
+			redirectURL: "myapp://login",
+			siteURL:     "",
+			expected:    true,
+		},
+		{
+			name: "Mixed patterns - wildcard matches",
+			config: mustConfig(
+				"https://example.com/callback",
+				"myapp://",
+				"*.preview.example.com",
+			),
+			redirectURL: "https://test.preview.example.com/auth",
+			siteURL:     "",
+			expected:    true,
+		},
+
+		// Localhost HTTP explicit configuration
+		{
+			name:        "Localhost HTTP - explicitly configured",
+			config:      mustConfig("http://localhost:3000"),
+			redirectURL: "http://localhost:3000",
+			siteURL:     "",
+			expected:    true,
+		},
+		{
+			name:        "Localhost HTTP - with path does not match exact",
+			config:      mustConfig("http://localhost:3000"),
+			redirectURL: "http://localhost:3000/auth",
+			siteURL:     "",
+			expected:    false,
+		},
+
+		// Edge cases
+		{
+			name:        "Case sensitivity in URL",
+			config:      mustConfig("https://example.com/callback"),
+			redirectURL: "https://EXAMPLE.com/callback",
+			siteURL:     "",
+			expected:    false, // URLs are case sensitive in path/query but the glob pattern was created with lowercase
+		},
+		{
+			name:        "URL with fragment",
+			config:      mustConfig("https://example.com/callback"),
+			redirectURL: "https://example.com/callback#section",
+			siteURL:     "",
+			expected:    false, // Fragment makes it different
+		},
+		{
+			name:        "URL with query params",
+			config:      mustConfig("auth.example.com"),
+			redirectURL: "https://auth.example.com/login?redirect=home",
+			siteURL:     "",
+			expected:    true, // Domain patterns allow any path/query
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := IsValidRedirectURL(tt.config, tt.redirectURL, tt.siteURL)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestRunShadowModeTest(t *testing.T) {
+	// This is harder to test directly since it logs, but we can test it doesn't panic
+	redirectConfig := mustConfig("https://example.com/callback")
+
+	// Should not panic with valid inputs
+	assert.NotPanics(t, func() {
+		RunShadowModeTest(redirectConfig, "https://example.com/callback", "https://site.com", true)
+	})
+
+	// Should not panic with nil config
+	assert.NotPanics(t, func() {
+		RunShadowModeTest(nil, "https://example.com/callback", "https://site.com", true)
+	})
+}

--- a/internal/redirecturi/validator.go
+++ b/internal/redirecturi/validator.go
@@ -1,0 +1,80 @@
+package redirecturi
+
+import (
+	"net"
+	"net/url"
+	"regexp"
+
+	"github.com/sirupsen/logrus"
+)
+
+var decimalIPAddressPattern = regexp.MustCompile("^[0-9]+$")
+
+// Note: RedirectPattern and RedirectConfig types are defined in patterns.go
+
+// IsValidRedirectURL validates a redirect URL with comprehensive security checks and pattern matching
+func IsValidRedirectURL(redirectConfig *RedirectConfig, redirectURL, siteURL string) bool {
+	if redirectURL == "" {
+		return false
+	}
+
+	// Parse the redirect URL for validation
+	refurl, rerr := url.Parse(redirectURL)
+	if rerr != nil {
+		// redirect URL is invalid
+		return false
+	}
+
+	// Security checks first
+	if decimalIPAddressPattern.MatchString(refurl.Hostname()) {
+		// IP address in decimal form not allowed in redirects
+		return false
+	} else if ip := net.ParseIP(refurl.Hostname()); ip != nil {
+		// Only allow loopback IPs
+		return ip.IsLoopback()
+	}
+
+	// Site URL check for backward compatibility
+	// Keep explicit siteURL check as users may use `http://...`
+	// and it doesn't fit to domain-only pattern matching
+	if siteURL != "" {
+		base, berr := url.Parse(siteURL)
+		if berr == nil && base.Hostname() == refurl.Hostname() {
+			return true
+		}
+	}
+
+	// Check against configured patterns
+	if redirectConfig == nil || len(redirectConfig.Patterns) == 0 {
+		return false
+	}
+
+	for _, pattern := range redirectConfig.Patterns {
+		if pattern.GlobPattern.Match(redirectURL) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// RunShadowModeTest compares old vs new validation logic and logs mismatches
+// TODO(cemal) :: This will be enabled in a future release
+// to allow for gradual migration and testing of the new validation logic.
+func RunShadowModeTest(redirectConfig *RedirectConfig, redirectURL, siteURL string, originalResult bool) {
+	if redirectConfig == nil {
+		return // No patterns configured
+	}
+
+	// Test new validator using the unified function
+	newResult := IsValidRedirectURL(redirectConfig, redirectURL, siteURL)
+
+	// Log mismatch if results differ
+	if originalResult != newResult {
+		logrus.WithFields(logrus.Fields{
+			"redirect_url": redirectURL,
+			"old_result":   originalResult,
+			"new_result":   newResult,
+		}).Warn("Redirect URI validation mismatch")
+	}
+}


### PR DESCRIPTION
## Summary
Implements the new redirect URI validation system as specified in the technical specification. This introduces a cleaner, more maintainable approach to redirect URI validation with automatic pattern categorization.

## What kind of change does this PR introduce?

Feature - New redirect URI validation system with pattern categorization

## What is the current behavior?

Supabase Auth currently uses an overly permissive redirect URL system that supports dangerous wildcard patterns like `**` which create security vulnerabilities The validation logic is scattered and uses complex glob patterns that are difficult to maintain and debug.

## What is the new behavior?

Implements Phase 1 of the redirect URI security enhancement by introducing a new categorized validation system in the `internal/redirecturi` package. This lays the foundation for migrating away from dangerous wildcard patterns to a more secure, OAuth-compliant approach.

 New pattern categories:
  - Exact URLs: `https://example.com/callback` (literal matching)
  - Host-only: `example.com` (any HTTPS path on domain)
  - Wildcard subdomains: `*.preview.app` (subdomain matching only)
  - Custom schemes: `myapp://` (mobile app deep links)

## Additional context

Merging this PR won't have any affect on the existing behaviour.
The actual parsing & validating (shadow mode) will be enabled in a future PR.
