### PR TITLE
fix: new `odic.Provider` for apple with insecure issuer url context

### DIFF
--- a/internal/api/token_oidc.go
+++ b/internal/api/token_oidc.go
@@ -127,7 +127,12 @@ func (p *IdTokenGrantParams) getProvider(ctx context.Context, config *conf.Globa
 		return nil, false, "", nil, apierrors.NewBadRequestError(apierrors.ErrorCodeProviderDisabled, fmt.Sprintf("Provider (issuer %q) is not enabled", issuer))
 	}
 
-	oidcProvider, err := oidc.NewProvider(ctx, issuer)
+	oidcCtx := ctx
+	if providerType == "apple" {
+		oidcCtx = oidc.InsecureIssuerURLContext(ctx, issuer)
+	}
+
+	oidcProvider, err := oidc.NewProvider(oidcCtx, issuer)
 	if err != nil {
 		return nil, false, "", nil, err
 	}


### PR DESCRIPTION
Apple's ID tokens sometimes say `https://appleid.apple.com` but the well-known URL returns that the issuer should be `https://account.apple.com`.