### PR TITLE
fix: add missing provider info to signedup audit logs

### DIFF
--- a/internal/api/admin.go
+++ b/internal/api/admin.go
@@ -461,6 +461,7 @@ func (a *API) adminUserCreate(w http.ResponseWriter, r *http.Request) error {
 			"user_id":    user.ID,
 			"user_email": user.Email,
 			"user_phone": user.Phone,
+			"provider":   providers[0], // complying with the user.AppMetaData["provider"] field as above
 		}); terr != nil {
 			return terr
 		}

--- a/internal/api/provider_constants.go
+++ b/internal/api/provider_constants.go
@@ -1,0 +1,7 @@
+package api
+
+// Provider constants
+const (
+	EmailProvider = "email"
+	PhoneProvider = "phone"
+)

--- a/internal/api/verify.go
+++ b/internal/api/verify.go
@@ -322,7 +322,9 @@ func (a *API) signupVerify(r *http.Request, ctx context.Context, conn *storage.C
 			}
 		}
 
-		if terr = models.NewAuditLogEntry(r, tx, user, models.UserSignedUpAction, "", nil); terr != nil {
+		if terr = models.NewAuditLogEntry(r, tx, user, models.UserSignedUpAction, "", map[string]interface{}{
+			"provider": EmailProvider,
+		}); terr != nil {
 			return terr
 		}
 
@@ -357,7 +359,9 @@ func (a *API) recoverVerify(r *http.Request, conn *storage.Connection, user *mod
 			return terr
 		}
 		if !user.IsConfirmed() {
-			if terr = models.NewAuditLogEntry(r, tx, user, models.UserSignedUpAction, "", nil); terr != nil {
+			if terr = models.NewAuditLogEntry(r, tx, user, models.UserSignedUpAction, "", map[string]interface{}{
+				"provider": EmailProvider,
+			}); terr != nil {
 				return terr
 			}
 
@@ -383,7 +387,9 @@ func (a *API) smsVerify(r *http.Request, conn *storage.Connection, user *models.
 	err := conn.Transaction(func(tx *storage.Connection) error {
 
 		if params.Type == smsVerification {
-			if terr := models.NewAuditLogEntry(r, tx, user, models.UserSignedUpAction, "", nil); terr != nil {
+			if terr := models.NewAuditLogEntry(r, tx, user, models.UserSignedUpAction, "", map[string]interface{}{
+				"provider": PhoneProvider,
+			}); terr != nil {
 				return terr
 			}
 			if terr := user.ConfirmPhone(tx); terr != nil {


### PR DESCRIPTION
## What kind of change does this PR introduce?
Bug fix

## What is the current behavior?
Currently, when users complete email or phone verification flows, the sign up audit logs are missing the `provider` field.

## What is the new behavior?
- Audit logs now include the `provider` field for all signup actions
- Added provider constants to improve code maintainability and prevent hardcoded strings