### PR TITLE
fix: do not log fatal when http server successfully closes

### DIFF
--- a/cmd/serve_cmd.go
+++ b/cmd/serve_cmd.go
@@ -123,7 +123,10 @@ func serve(ctx context.Context) {
 	if err != nil {
 		log.WithError(err).Fatal("http server listen failed")
 	}
-	if err := httpSrv.Serve(listener); err != nil {
+	err = httpSrv.Serve(listener)
+	if err == http.ErrServerClosed {
+		log.Info("http server closed")
+	} else if err != nil {
 		log.WithError(err).Fatal("http server serve failed")
 	}
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

do not log fatal when http server successfully closes

