### PR TITLE
fix 36753 : make signup link expiration configurable 

### DIFF
--- a/internal/api/signup.go
+++ b/internal/api/signup.go
@@ -247,9 +247,9 @@ func (a *API) Signup(w http.ResponseWriter, r *http.Request) error {
 						return terr
 					}
 				}
-				if terr = a.sendConfirmation(r, tx, user, flowType); terr != nil {
-					return terr
-				}
+				if terr = a.sendConfirmationWithExpiry(r, tx, user, flowType, config.SignupTokenExpiry); terr != nil {
+    return terr
+}
 			}
 		} else if params.Provider == "phone" && !user.IsPhoneConfirmed() {
 			if config.Sms.Autoconfirm {

--- a/internal/conf/configuration.go
+++ b/internal/conf/configuration.go
@@ -241,7 +241,6 @@ type PasswordConfiguration struct {
 
 	HIBP HIBPConfiguration `json:"hibp"`
 }
-
 // GlobalConfiguration holds all the configuration that applies to all instances.
 type GlobalConfiguration struct {
 	API           APIConfiguration
@@ -263,6 +262,9 @@ type GlobalConfiguration struct {
 	RateLimitAnonymousUsers float64 `split_words:"true" default:"30"`
 	RateLimitOtp            float64 `split_words:"true" default:"30"`
 	RateLimitWeb3           float64 `split_words:"true" default:"30"`
+
+
+	SignupTokenExpiry time.Duration `envconfig:"SIGNUP_TOKEN_EXPIRY" default:"3600s"`
 
 	SiteURL         string   `json:"site_url" split_words:"true" required:"true"`
 	URIAllowList    []string `json:"uri_allow_list" split_words:"true"`
@@ -297,7 +299,6 @@ func (c *CORSConfiguration) AllAllowedHeaders(defaults []string) []string {
 		if !set[header] {
 			result = append(result, header)
 		}
-
 		set[header] = true
 	}
 


### PR DESCRIPTION
This PR introduces a new `SIGNUP_TOKEN_EXPIRY` environment variable to configure the expiration time for signup confirmation links. Previously, signup links defaulted to 1 hour without the ability to change it.

- Added `SignupTokenExpiry` to `GlobalConfiguration`
- Updated `sendConfirmationWithExpiry` to use the configured duration
- Default set to 3600s (1 hour)

Fixes #36753
