### PR TITLE
fix: use `appleid.apple.com` as default issuer

### DIFF
--- a/internal/api/provider/apple.go
+++ b/internal/api/provider/apple.go
@@ -15,8 +15,8 @@ import (
 	"golang.org/x/oauth2"
 )
 
-const DefaultAppleIssuer = "https://account.apple.com"
-const OtherAppleIssuer = "https://appleid.apple.com"
+const DefaultAppleIssuer = "https://appleid.apple.com"
+const OtherAppleIssuer = "https://account.apple.com"
 
 func IsAppleIssuer(issuer string) bool {
 	return issuer == DefaultAppleIssuer || issuer == OtherAppleIssuer


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Sign-in with Apple does not open the native sign-in flow (face-id + "continue" button), but rather redirects to the account.apple.com website, where users have to do a full manual sign-in. I'm pretty sure this is due to a change introduced (the change to using "account.apple.com" instead of "appleid.apple.com") while there was an outage/issue on Apple's side.

## What is the new behavior?

The native sign-in flow should be used when available (e.g. on an iOS device).

## Additional context

This should resolve the problem described by [lizbzlx (comment)](https://github.com/supabase/auth/issues/2051#issuecomment-2967028786), [obeliskgroup (comment)](https://github.com/supabase/auth/issues/2051#issuecomment-2969431447) and [bsheikh (comment)](https://github.com/supabase/auth/issues/2051#issuecomment-2991427271) in [this issue](https://github.com/supabase/auth/issues/2051).