### PR TITLE
feat: ignore `aud` claim from admin jwt (`service_role` never had one)

### DIFF
--- a/internal/api/helpers.go
+++ b/internal/api/helpers.go
@@ -40,7 +40,9 @@ func (a *API) requestAud(ctx context.Context, r *http.Request) string {
 	// Then check the token
 	claims := getClaims(ctx)
 
-	if claims != nil {
+	// ignore the JWT's aud claim if the role is admin
+	// this is because anon, service_role never had an aud claim to begin with
+	if claims != nil && !isStringInSlice(claims.Role, config.JWT.AdminRoles) {
 		aud, _ := claims.GetAudience()
 		if len(aud) != 0 && aud[0] != "" {
 			return aud[0]


### PR DESCRIPTION
There's a problem with new Secret API keys which mint a JWT where the `aud` claim is the requested resource. This is confusing list admin users in returning no users (since there's no such audience).

`service_role` never had an `aud` claim in it, so this is the proper place to fix this.