### PR TITLE
feat: fallback to jwt secret if alg is `HS256` and the `kid` is not recognized

### DIFF
--- a/internal/conf/jwk.go
+++ b/internal/conf/jwk.go
@@ -168,5 +168,7 @@ func FindPublicKeyByKid(kid string, config *JWTConfiguration) (any, error) {
 	if kid == config.KeyID {
 		return []byte(config.Secret), nil
 	}
-	return nil, fmt.Errorf("invalid kid: %s", kid)
+
+	// don't return error, as a fallback key might be used
+	return nil, nil
 }

--- a/internal/conf/jwk_test.go
+++ b/internal/conf/jwk_test.go
@@ -241,8 +241,7 @@ func TestJwtKeys(t *testing.T) {
 		}
 		got, err := FindPublicKeyByKid("abc", jwtConfig)
 		require.Nil(t, got)
-		require.Error(t, err)
-		require.Equal(t, "invalid kid: abc", err.Error())
+		require.Nil(t, err)
 	}
 
 	// FindPublicKeyByKid - GetSigningKey success


### PR DESCRIPTION
Some customers may be using JWTs signed with the JWT secret but they may be advertising a `kid` claim for their own purposes. Auth should try to reasonably accept those JWTs.