### PR TITLE
fix: use `split_words` config option for `AuditLog`

### DIFF
--- a/internal/conf/configuration.go
+++ b/internal/conf/configuration.go
@@ -257,7 +257,7 @@ type GlobalConfiguration struct {
 	Tracing       TracingConfig
 	Metrics       MetricsConfig
 	SMTP          SMTPConfiguration
-	AuditLog      AuditLogConfiguration
+	AuditLog      AuditLogConfiguration `split_words:"true"`
 
 	RateLimitHeader         string  `split_words:"true"`
 	RateLimitEmailSent      Rate    `split_words:"true" default:"30"`


### PR DESCRIPTION
Without this the config should be `GOTRUE_AUDITLOG_DISABLE_POSTGRES` instead (no underscore).