### PR TITLE
fix(auditlog): keep writing to logs even postgres is disabled

### DIFF
--- a/internal/models/audit_log_entry.go
+++ b/internal/models/audit_log_entry.go
@@ -117,16 +117,16 @@ func NewAuditLogEntry(config conf.AuditLogConfiguration, r *http.Request, tx *st
 		"auth_event": logrus.Fields(payload),
 	})
 
-	if config.DisablePostgres {
-		return nil
-	}
-
 	if name, ok := actor.UserMetaData["full_name"]; ok {
 		l.Payload["actor_name"] = name
 	}
 
 	if traits != nil {
 		l.Payload["traits"] = traits
+	}
+
+	if config.DisablePostgres {
+		return nil
 	}
 
 	if err := tx.Create(&l); err != nil {


### PR DESCRIPTION
move `DisablePostgres` check after payload mutation to ensure auth_event logs have the same data prior to introduce of the `DisablePostgres` config
