### PR TITLE
feat: skip nonce check for Facebook Limited Login auth

### DIFF
--- a/internal/api/token_oidc.go
+++ b/internal/api/token_oidc.go
@@ -78,6 +78,8 @@ func (p *IdTokenGrantParams) getProvider(ctx context.Context, config *conf.Globa
 
 	case p.Provider == "facebook" || p.Issuer == provider.IssuerFacebook:
 		cfg = &config.External.Facebook
+		// Facebook (Limited Login) nonce check is not supported
+		cfg.SkipNonceCheck = true
 		providerType = "facebook"
 		issuer = provider.IssuerFacebook
 		acceptableClientIDs = append(acceptableClientIDs, config.External.Facebook.ClientID...)


### PR DESCRIPTION
## What kind of change does this PR introduce?

nonce matching isn't supported for facebook limited login, skipping it during OIDC login