### PR TITLE
fix: preserve user metadata when email_confirm=true in Confirm function

### DIFF
--- a/internal/models/user.go
+++ b/internal/models/user.go
@@ -449,9 +449,24 @@ func (u *User) Confirm(tx *storage.Connection) error {
 		return err
 	}
 
-	if err := u.UpdateUserMetaData(tx, map[string]interface{}{
-		"email_verified": true,
-	}); err != nil {
+	// 1. Reload the user state from the database to get the most recent
+	// metadata, including any changes made by database triggers.
+	latestUser, err := FindUserByID(tx, u.ID)
+	if err != nil {
+		return err
+	}
+
+	// 2. Prepare the metadata for update. Start with the fresh data from the database.
+	metaDataToUpdate := latestUser.UserMetaData
+	if metaDataToUpdate == nil {
+		metaDataToUpdate = make(map[string]interface{})
+	}
+	metaDataToUpdate["email_verified"] = true
+
+	// 3. Now, call the existing UpdateUserMetaData function.
+	// This will correctly update the user's metadata without data loss,
+	// and it also updates the in-memory user object 'u' for consistency.
+	if err := u.UpdateUserMetaData(tx, metaDataToUpdate); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

When creating a user with `email_confirm: true`, the `Confirm` function in `internal/models/user.go` overwrites the user's existing metadata instead of merging the `email_verified: true` flag with it.

#2088 

## Root cause

The current implementation calls `UpdateUserMetaData` with only `{"email_verified": true}`, which replaces the entire metadata object instead of merging with existing data.

### Example of data loss
```json
// Before email confirmation
{
  "user_metadata": {
    "name": "John Doe",
    "age": 25,
    "preferences": {
      "theme": "dark",
      "language": "en"
    }
  }
}

// After email confirmation (BROKEN - data lost!)
{
  "user_metadata": {
    "email_verified": true
  }
}
```

## What is the new behavior?

The `Confirm` function now properly preserves existing user metadata by:
1. Reloading the user's latest state from the database to get the most recent metadata
2. Merging the `email_verified: true` flag with existing metadata
3. Using the existing `UpdateUserMetaData` function to properly update without data loss

### Example of correct behaviour:

```json
// Before email confirmation
{
  "user_metadata": {
    "name": "John Doe",
    "age": 25,
    "preferences": {
      "theme": "dark",
      "language": "en"
    }
  }
}

// After email confirmation (FIXED - data preserved!)
{
  "user_metadata": {
    "name": "John Doe",
    "age": 25,
    "email_verified": true,
    "preferences": {
      "theme": "dark",
      "language": "en"
    }
  }
}
```
