### PR TITLE
chore: make it more clear which rate limiters use the OTP limit

### DIFF
--- a/internal/api/options.go
+++ b/internal/api/options.go
@@ -56,11 +56,6 @@ func NewLimiterOptions(gc *conf.GlobalConfiguration) *LimiterOptions {
 			DefaultExpirationTTL: time.Hour,
 		}).SetBurst(30)
 
-	o.User = tollbooth.NewLimiter(gc.RateLimitOtp/(60*5),
-		&limiter.ExpirableOptions{
-			DefaultExpirationTTL: time.Hour,
-		}).SetBurst(30)
-
 	o.FactorVerify = tollbooth.NewLimiter(gc.MFA.RateLimitChallengeAndVerify/60,
 		&limiter.ExpirableOptions{
 			DefaultExpirationTTL: time.Minute,
@@ -81,11 +76,6 @@ func NewLimiterOptions(gc *conf.GlobalConfiguration) *LimiterOptions {
 			DefaultExpirationTTL: time.Hour,
 		}).SetBurst(30)
 
-	o.Signups = tollbooth.NewLimiter(gc.RateLimitOtp/(60*5),
-		&limiter.ExpirableOptions{
-			DefaultExpirationTTL: time.Hour,
-		}).SetBurst(30)
-
 	o.Web3 = tollbooth.NewLimiter(gc.RateLimitWeb3/(60*5),
 		&limiter.ExpirableOptions{
 			DefaultExpirationTTL: time.Hour,
@@ -96,6 +86,8 @@ func NewLimiterOptions(gc *conf.GlobalConfiguration) *LimiterOptions {
 	o.Resend = newLimiterPer5mOver1h(gc.RateLimitOtp)
 	o.MagicLink = newLimiterPer5mOver1h(gc.RateLimitOtp)
 	o.Otp = newLimiterPer5mOver1h(gc.RateLimitOtp)
+	o.User = newLimiterPer5mOver1h(gc.RateLimitOtp)
+	o.Signups = newLimiterPer5mOver1h(gc.RateLimitOtp)
 	return o
 }
 


### PR DESCRIPTION
In the supabase dashboard the rate limits are declared as:

  - `RATE_LIMIT_OTP` Rate limit for sign ups and sign ins Number of sign up and sign-in requests that can be made in a 5 minute interval per IP address

  - `RATE_LIMIT_VERIFY` Rate limit for token verifications Number of OTP/Magic link verifications that can be made in a 5 minute interval per IP address

This does not exactly translate to the rate limit usage in the auth server. But it isn't something we may change, so for now I'm just making this usage more clear and documenting it.