### PR TITLE
feat: implement link identity with oidc / native sign in

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -204,7 +204,7 @@ func NewAPIWithVersion(globalConfig *conf.GlobalConfiguration, db *storage.Conne
 			With(api.verifyCaptcha).Post("/otp", api.Otp)
 
 		// rate limiting applied in handler
-		r.With(api.verifyCaptcha).With(api.oauthClientAuth).Post("/token", api.Token)
+		r.With(api.verifyCaptcha).With(api.oauthClientAuth).With(api.loadAuthentication).Post("/token", api.Token)
 
 		r.With(api.limitHandler(api.limiterOpts.Verify)).Route("/verify", func(r *router) {
 			r.Get("/", api.Verify)

--- a/internal/api/auth.go
+++ b/internal/api/auth.go
@@ -33,6 +33,15 @@ func (a *API) requireAuthentication(w http.ResponseWriter, r *http.Request) (con
 	return ctx, err
 }
 
+// loadAuthentication is similar to requireAuthentication, but it only loads the user authentication if there is an Authorization header. If there is none, it does nothing. If there is one but has invalid claims, it rejects.
+func (a *API) loadAuthentication(w http.ResponseWriter, r *http.Request) (context.Context, error) {
+	if value := r.Header.Get("Authorization"); value != "" {
+		return a.requireAuthentication(w, r)
+	}
+
+	return r.Context(), nil
+}
+
 func (a *API) requireNotAnonymous(w http.ResponseWriter, r *http.Request) (context.Context, error) {
 	ctx := r.Context()
 	claims := getClaims(ctx)
@@ -63,7 +72,7 @@ func (a *API) extractBearerToken(r *http.Request) (string, error) {
 	authHeader := r.Header.Get("Authorization")
 	matches := bearerRegexp.FindStringSubmatch(authHeader)
 	if len(matches) != 2 {
-		return "", apierrors.NewHTTPError(http.StatusUnauthorized, apierrors.ErrorCodeNoAuthorization, "This endpoint requires a Bearer token")
+		return "", apierrors.NewHTTPError(http.StatusUnauthorized, apierrors.ErrorCodeNoAuthorization, "This endpoint requires a valid Bearer token")
 	}
 
 	return matches[1], nil

--- a/internal/api/token_oidc.go
+++ b/internal/api/token_oidc.go
@@ -18,12 +18,13 @@ import (
 
 // IdTokenGrantParams are the parameters the IdTokenGrant method accepts
 type IdTokenGrantParams struct {
-	IdToken     string `json:"id_token"`
-	AccessToken string `json:"access_token"`
-	Nonce       string `json:"nonce"`
-	Provider    string `json:"provider"`
-	ClientID    string `json:"client_id"`
-	Issuer      string `json:"issuer"`
+	IdToken      string `json:"id_token"`
+	AccessToken  string `json:"access_token"`
+	Nonce        string `json:"nonce"`
+	Provider     string `json:"provider"`
+	ClientID     string `json:"client_id"`
+	Issuer       string `json:"issuer"`
+	LinkIdentity bool   `json:"link_identity"`
 }
 
 func (p *IdTokenGrantParams) getProvider(ctx context.Context, config *conf.GlobalConfiguration, r *http.Request) (*oidc.Provider, bool, string, []string, error) {
@@ -163,6 +164,20 @@ func (a *API) IdTokenGrant(ctx context.Context, w http.ResponseWriter, r *http.R
 		return apierrors.NewOAuthError("invalid request", "provider or client_id and issuer required")
 	}
 
+	if params.LinkIdentity {
+		// this API endpoint uses loadAuthentication which will set the
+		// calling user on the context if and only if the Authorization
+		// header was passed, which is required for LinkIdentity
+
+		targetUser := getUser(ctx)
+		if targetUser == nil {
+			return apierrors.NewOAuthError("invalid request", "Linking requires a valid user authentication")
+		}
+
+		// set it so linkIdentityToUser works below
+		ctx = withTargetUser(ctx, targetUser)
+	}
+
 	oidcProvider, skipNonceCheck, providerType, acceptableClientIDs, err := params.getProvider(ctx, config, r)
 	if err != nil {
 		return err
@@ -253,15 +268,21 @@ func (a *API) IdTokenGrant(ctx context.Context, w http.ResponseWriter, r *http.R
 
 	grantParams.FillGrantParams(r)
 
-	if err := a.triggerBeforeUserCreatedExternal(r, db, userData, providerType); err != nil {
-		return err
+	if !params.LinkIdentity {
+		if err := a.triggerBeforeUserCreatedExternal(r, db, userData, providerType); err != nil {
+			return err
+		}
 	}
 
 	if err := db.Transaction(func(tx *storage.Connection) error {
 		var user *models.User
 		var terr error
 
-		user, terr = a.createAccountFromExternalIdentity(tx, r, userData, providerType)
+		if params.LinkIdentity {
+			user, terr = a.linkIdentityToUser(r, ctx, tx, userData, providerType)
+		} else {
+			user, terr = a.createAccountFromExternalIdentity(tx, r, userData, providerType)
+		}
 		if terr != nil {
 			return terr
 		}


### PR DESCRIPTION
Implements linking an OIDC identity to a user. It works by modifying the existing `/token?grant_type=id_token` endpoint by allowing a `link_identity` body parameter.

If it's set, the `Authorization` header must be set to a valid JWT representing a user. This user will be the user to which the ID token's identity will be linked to.