### PR TITLE
Added handling of optional Email field for snapchat OAuth2 provider

### DIFF
--- a/internal/api/external_snapchat_test.go
+++ b/internal/api/external_snapchat_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	snapchatUser = `{"data":{"me":{"externalId":"snapchatTestId","displayName":"Snapchat Test","bitmoji":{"avatar":"http://example.com/bitmoji"}}}}`
+	snapchatUser = `{"data":{"me":{"email":"snapchattestid@snapchat.id","externalId":"snapchatTestId","displayName":"Snapchat Test","bitmoji":{"avatar":"http://example.com/bitmoji"}}}}`
 )
 
 func (ts *ExternalTestSuite) TestSignupExternalSnapchat() {

--- a/internal/api/provider/snapchat.go
+++ b/internal/api/provider/snapchat.go
@@ -30,6 +30,7 @@ type snapchatUser struct {
 			Bitmoji     struct {
 				Avatar string `json:"avatar"`
 			} `json:"bitmoji"`
+			Email string `json:"email"`
 		} `json:"me"`
 	} `json:"data"`
 }
@@ -93,12 +94,13 @@ func (p snapchatProvider) GetUserData(ctx context.Context, tok *oauth2.Token) (*
 
 	data := &UserProvidedData{}
 
-	// Snapchat doesn't provide email by default, additional scopes needed
-	data.Emails = []Email{{
-		Email:    strings.ToLower(u.Data.Me.ExternalID) + "@snapchat.id", // TODO: Create a pseudo-email using the external ID
-		Verified: true,
-		Primary:  true,
-	}}
+	if u.Data.Me.Email != "" {
+		data.Emails = []Email{{
+			Email:    u.Data.Me.Email,
+			Verified: true,
+			Primary:  true,
+		}}
+	}
 
 	data.Metadata = &Claims{
 		Issuer:  IssuerSnapchat,


### PR DESCRIPTION
## What kind of change does this PR introduce?
This is an update to the existing Snapchat OAuth provider, which was previously not capable of Email field. Now if Email field is present in the response, it is handled accordingly

## What is the current behavior?
Current behaviour is that Email field is never handled in the Snapchat provider

## What is the new behavior?
New behaviour is that if Email is present in the response - it is set to claims accordingly
