### PR TITLE
SCIM v2 (Users) minimal implementation: endpoints, auth, content-type, filters, soft deprovision; config + routing; tests for endpoints and middleware

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -39,7 +39,10 @@ require (
 	github.com/crate-crypto/go-eth-kzg v1.3.0 // indirect
 	github.com/crate-crypto/go-ipa v0.0.0-20240724233137-53bbb0ceb27a // indirect
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.3.0 // indirect
+	github.com/di-wu/parser v0.2.2 // indirect
+	github.com/di-wu/xsd-datetime v1.0.0 // indirect
 	github.com/dprotaso/go-yit v0.0.0-20220510233725-9ba8df137936 // indirect
+	github.com/elimity-com/scim v0.0.0-20240320110924-172bf2aee9c8 // indirect
 	github.com/ethereum/c-kzg-4844/v2 v2.1.0 // indirect
 	github.com/ethereum/go-verkle v0.2.2 // indirect
 	github.com/fxamacker/cbor/v2 v2.7.0 // indirect
@@ -64,6 +67,7 @@ require (
 	github.com/oasdiff/yaml v0.0.0-20250309154309-f31be36b4037 // indirect
 	github.com/oasdiff/yaml3 v0.0.0-20250309153720-d2182401db90 // indirect
 	github.com/perimeterx/marshmallow v1.1.5 // indirect
+	github.com/scim2/filter-parser/v2 v2.2.0 // indirect
 	github.com/segmentio/asm v1.2.0 // indirect
 	github.com/speakeasy-api/openapi-overlay v0.9.0 // indirect
 	github.com/supranational/blst v0.3.14 // indirect

--- a/go.sum
+++ b/go.sum
@@ -80,11 +80,17 @@ github.com/decred/dcrd/crypto/blake256 v1.0.1 h1:7PltbUIQB7u/FfZ39+DGa/ShuMyJ5il
 github.com/decred/dcrd/crypto/blake256 v1.0.1/go.mod h1:2OfgNZ5wDpcsFmHmCK5gZTPcCXqlm2ArzUIkw9czNJo=
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.3.0 h1:rpfIENRNNilwHwZeG5+P150SMrnNEcHYvcCuK6dPZSg=
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.3.0/go.mod h1:v57UDF4pDQJcEfFUCRop3lJL149eHGSe9Jvczhzjo/0=
+github.com/di-wu/parser v0.2.2 h1:I9oHJ8spBXOeL7Wps0ffkFFFiXJf/pk7NX9lcAMqRMU=
+github.com/di-wu/parser v0.2.2/go.mod h1:SLp58pW6WamdmznrVRrw2NTyn4wAvT9rrEFynKX7nYo=
+github.com/di-wu/xsd-datetime v1.0.0 h1:vZoGNkbzpBNoc+JyfVLEbutNDNydYV8XwHeV7eUJoxI=
+github.com/di-wu/xsd-datetime v1.0.0/go.mod h1:i3iEhrP3WchwseOBeIdW/zxeoleXTOzx1WyDXgdmOww=
 github.com/didip/tollbooth/v5 v5.1.1 h1:QpKFg56jsbNuQ6FFj++Z1gn2fbBsvAc1ZPLUaDOYW5k=
 github.com/didip/tollbooth/v5 v5.1.1/go.mod h1:d9rzwOULswrD3YIrAQmP3bfjxab32Df4IaO6+D25l9g=
 github.com/dprotaso/go-yit v0.0.0-20191028211022-135eb7262960/go.mod h1:9HQzr9D/0PGwMEbC3d5AB7oi67+h4TsQqItC1GVYG58=
 github.com/dprotaso/go-yit v0.0.0-20220510233725-9ba8df137936 h1:PRxIJD8XjimM5aTknUK9w6DHLDox2r2M3DI4i2pnd3w=
 github.com/dprotaso/go-yit v0.0.0-20220510233725-9ba8df137936/go.mod h1:ttYvX5qlB+mlV1okblJqcSMtR4c52UKxDiX9GRBS8+Q=
+github.com/elimity-com/scim v0.0.0-20240320110924-172bf2aee9c8 h1:0+BTyxIYgiVAry/P5s8R4dYuLkhB9Nhso8ogFWNr4IQ=
+github.com/elimity-com/scim v0.0.0-20240320110924-172bf2aee9c8/go.mod h1:JkjcmqbLW+khwt2fmBPJFBhx2zGZ8XobRZ+O0VhlwWo=
 github.com/ethereum/c-kzg-4844/v2 v2.1.0 h1:gQropX9YFBhl3g4HYhwE70zq3IHFRgbbNPw0Shwzf5w=
 github.com/ethereum/c-kzg-4844/v2 v2.1.0/go.mod h1:TC48kOKjJKPbN7C++qIgt0TJzZ70QznYR7Ob+WXl57E=
 github.com/ethereum/go-ethereum v1.16.0 h1:Acf8FlRmcSWEJm3lGjlnKTdNgFvF9/l28oQ8Q6HDj1o=
@@ -428,6 +434,8 @@ github.com/russellhaering/goxmldsig v1.3.0 h1:DllIWUgMy0cRUMfGiASiYEa35nsieyD3ci
 github.com/russellhaering/goxmldsig v1.3.0/go.mod h1:gM4MDENBQf7M+V824SGfyIUVFWydB7n0KkEubVJl+Tw=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
+github.com/scim2/filter-parser/v2 v2.2.0 h1:QGadEcsmypxg8gYChRSM2j1edLyE/2j72j+hdmI4BJM=
+github.com/scim2/filter-parser/v2 v2.2.0/go.mod h1:jWnkDToqX/Y0ugz0P5VvpVEUKcWcyHHj+X+je9ce5JA=
 github.com/sebest/xff v0.0.0-20160910043805-6c115e0ffa35 h1:eajwn6K3weW5cd1ZXLu2sJ4pvwlBiCWY4uDejOr73gM=
 github.com/sebest/xff v0.0.0-20160910043805-6c115e0ffa35/go.mod h1:wozgYq9WEBQBaIJe4YZ0qTSFAMxmcwBhQH0fO0R34Z0=
 github.com/segmentio/asm v1.2.0 h1:9BQrFxC+YOHJlTlHGkTrFWf59nbL3XnCoFLTwDCI7ys=

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -191,6 +191,7 @@ func NewAPIWithVersion(globalConfig *conf.GlobalConfiguration, db *storage.Conne
 				return api.Signup(w, r)
 			})
 		})
+
 		r.With(api.limitHandler(api.limiterOpts.Recover)).
 			With(api.verifyCaptcha).With(api.requireEmailProvider).Post("/recover", api.Recover)
 
@@ -314,6 +315,25 @@ func NewAPIWithVersion(globalConfig *conf.GlobalConfiguration, db *storage.Conne
 						r.Get("/", api.oauthServer.OAuthServerClientGet)
 						r.Delete("/", api.oauthServer.OAuthServerClientDelete)
 					})
+				})
+			})
+		})
+
+		// SCIM v2 endpoints (minimal Users only)
+		r.Route("/scim/v2", func(r *router) {
+			r.Use(api.requireSCIMEnabled)
+			r.Use(api.requireSCIMAuth)
+			r.Get("/ServiceProviderConfig", api.SCIMServiceProviderConfig)
+			r.Get("/ResourceTypes", api.SCIMResourceTypes)
+			r.Get("/Schemas", api.SCIMSchemas)
+			r.Route("/Users", func(r *router) {
+				r.Get("/", api.SCIMUsersList)
+				r.Post("/", api.SCIMUsersCreate)
+				r.Route("/{scim_user_id}", func(r *router) {
+					r.Get("/", api.SCIMUsersGet)
+					r.Put("/", api.SCIMUsersReplace)
+					r.Patch("/", api.SCIMUsersPatch)
+					r.Delete("/", api.SCIMUsersDelete)
 				})
 			})
 		})

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -30,6 +30,9 @@ func (r *router) Post(pattern string, fn apiHandler) {
 func (r *router) Put(pattern string, fn apiHandler) {
 	r.chi.Put(pattern, handler(fn))
 }
+func (r *router) Patch(pattern string, fn apiHandler) {
+	r.chi.Method(http.MethodPatch, pattern, handler(fn))
+}
 func (r *router) Delete(pattern string, fn apiHandler) {
 	r.chi.Delete(pattern, handler(fn))
 }

--- a/internal/api/scim.go
+++ b/internal/api/scim.go
@@ -1,0 +1,390 @@
+package api
+
+import (
+    "encoding/json"
+    "net/http"
+    "strconv"
+    "strings"
+    "time"
+
+    "github.com/go-chi/chi/v5"
+    "github.com/gofrs/uuid"
+    "github.com/supabase/auth/internal/models"
+    "github.com/supabase/auth/internal/storage"
+)
+
+// ServiceProviderConfig
+func (a *API) SCIMServiceProviderConfig(w http.ResponseWriter, r *http.Request) error {
+    resp := map[string]any{
+        "schemas": []string{"urn:ietf:params:scim:schemas:core:2.0:ServiceProviderConfig"},
+        "patch": map[string]bool{"supported": true},
+        "bulk": map[string]any{"supported": false},
+        "filter": map[string]any{"supported": true, "maxResults": 200},
+        "changePassword": map[string]bool{"supported": false},
+        "sort": map[string]bool{"supported": false},
+        "etag": map[string]bool{"supported": false},
+        "authenticationSchemes": []any{},
+    }
+    return scimSendJSON(w, http.StatusOK, resp)
+}
+
+// ResourceTypes
+func (a *API) SCIMResourceTypes(w http.ResponseWriter, r *http.Request) error {
+    resp := map[string]any{
+        "Resources": []any{
+            map[string]any{
+                "id":   "User",
+                "name": "User",
+                "endpoint": "/scim/v2/Users",
+                "schema":   "urn:ietf:params:scim:schemas:core:2.0:User",
+            },
+        },
+        "totalResults": 1,
+        "itemsPerPage": 1,
+        "startIndex":   1,
+        "schemas":      []string{"urn:ietf:params:scim:api:messages:2.0:ListResponse"},
+    }
+    return scimSendJSON(w, http.StatusOK, resp)
+}
+
+// Schemas (return only core User schema minimal)
+func (a *API) SCIMSchemas(w http.ResponseWriter, r *http.Request) error {
+    resp := map[string]any{
+        "Resources": []any{
+            map[string]any{
+                "id":          "urn:ietf:params:scim:schemas:core:2.0:User",
+                "name":        "User",
+                "description": "User Account",
+                "attributes": []any{
+                    map[string]any{"name": "userName", "type": "string", "required": true, "uniqueness": "server"},
+                    map[string]any{"name": "externalId", "type": "string"},
+                    map[string]any{"name": "active", "type": "boolean"},
+                    map[string]any{"name": "displayName", "type": "string"},
+                    map[string]any{"name": "name", "type": "complex", "subAttributes": []any{
+                        map[string]any{"name": "givenName", "type": "string"},
+                        map[string]any{"name": "familyName", "type": "string"},
+                    }},
+                    map[string]any{"name": "emails", "type": "complex"},
+                },
+            },
+        },
+        "totalResults": 1,
+        "itemsPerPage": 1,
+        "startIndex":   1,
+        "schemas":      []string{"urn:ietf:params:scim:api:messages:2.0:ListResponse"},
+    }
+    return scimSendJSON(w, http.StatusOK, resp)
+}
+
+// Users list
+func (a *API) SCIMUsersList(w http.ResponseWriter, r *http.Request) error {
+    ctx := r.Context()
+    db := a.db.WithContext(ctx)
+    aud := a.requestAud(ctx, r)
+
+    // SCIM pagination uses 1-based startIndex
+    startIndex, _ := strconv.Atoi(r.URL.Query().Get("startIndex"))
+    if startIndex <= 0 {
+        startIndex = 1
+    }
+    count, _ := strconv.Atoi(r.URL.Query().Get("count"))
+    if count <= 0 || count > 200 {
+        count = 50
+    }
+    page := (startIndex-1)/count + 1
+
+    filter := r.URL.Query().Get("filter")
+
+    var resources []any
+    var total uint64
+
+    if filter != "" {
+        // minimal parser: "attr eq \"value\""
+        parts := strings.Split(filter, "eq")
+        if len(parts) == 2 {
+            attr := strings.TrimSpace(parts[0])
+            val := strings.TrimSpace(parts[1])
+            val = strings.Trim(val, "\"")
+
+            switch attr {
+            case "userName":
+                u, err := models.FindUserByEmailAndAudience(db, val, aud)
+                if err == nil && u != nil {
+                    resources = append(resources, a.toSCIMUser(u))
+                    total = 1
+                } else {
+                    total = 0
+                }
+            case "externalId":
+                var users []*models.User
+                q := db.Q().Where("instance_id = ? and aud = ? and raw_app_meta_data->>'scim_external_id' = ?", uuid.Nil, aud, val)
+                if err := q.All(&users); err == nil {
+                    for _, u := range users {
+                        resources = append(resources, a.toSCIMUser(u))
+                    }
+                    total = uint64(len(users))
+                }
+            }
+        }
+        if resources == nil {
+            resources = []any{}
+        }
+        resp := map[string]any{
+            "schemas":      []string{"urn:ietf:params:scim:api:messages:2.0:ListResponse"},
+            "totalResults": total,
+            "itemsPerPage": len(resources),
+            "startIndex":   1,
+            "Resources":    resources,
+        }
+        return scimSendJSON(w, http.StatusOK, resp)
+    }
+
+    pageParams := &models.Pagination{Page: uint64(page), PerPage: uint64(count)}
+    users, err := models.FindUsersInAudience(db, aud, pageParams, nil, "")
+    if err != nil {
+        return err
+    }
+
+    resources = make([]any, 0, len(users))
+    for _, u := range users {
+        resources = append(resources, a.toSCIMUser(u))
+    }
+
+    resp := map[string]any{
+        "schemas":      []string{"urn:ietf:params:scim:api:messages:2.0:ListResponse"},
+        "totalResults": pageParams.Count,
+        "itemsPerPage": count,
+        "startIndex":   startIndex,
+        "Resources":    resources,
+    }
+    return scimSendJSON(w, http.StatusOK, resp)
+}
+
+// Users get
+func (a *API) SCIMUsersGet(w http.ResponseWriter, r *http.Request) error {
+    ctx := r.Context()
+    db := a.db.WithContext(ctx)
+    idStr := chi.URLParam(r, "scim_user_id")
+    userID, err := uuid.FromString(idStr)
+    if err != nil {
+        return a.scimNotFound()
+    }
+    u, err := models.FindUserByID(db, userID)
+    if err != nil {
+        return a.scimNotFound()
+    }
+    return scimSendJSON(w, http.StatusOK, a.toSCIMUser(u))
+}
+
+// Users create
+func (a *API) SCIMUsersCreate(w http.ResponseWriter, r *http.Request) error {
+    ctx := r.Context()
+    db := a.db.WithContext(ctx)
+
+    var body map[string]any
+    if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+        return err
+    }
+
+    aud := a.requestAud(ctx, r)
+    email := getString(body, "userName")
+    if email == "" {
+        // fallback from emails[0].value
+        if emails, ok := body["emails"].([]any); ok && len(emails) > 0 {
+            if m, ok := emails[0].(map[string]any); ok {
+                email = getString(m, "value")
+            }
+        }
+    }
+
+    user, err := models.NewUser("", email, "", aud, map[string]any{})
+    if err != nil {
+        return err
+    }
+
+    // metadata
+    if name, ok := body["name"].(map[string]any); ok {
+        if user.UserMetaData == nil {
+            user.UserMetaData = map[string]any{}
+        }
+        if v := getString(name, "givenName"); v != "" { user.UserMetaData["given_name"] = v }
+        if v := getString(name, "familyName"); v != "" { user.UserMetaData["family_name"] = v }
+    }
+    if v := getString(body, "displayName"); v != "" {
+        if user.UserMetaData == nil { user.UserMetaData = map[string]any{} }
+        user.UserMetaData["display_name"] = v
+    }
+    if v := getString(body, "externalId"); v != "" {
+        if user.AppMetaData == nil { user.AppMetaData = map[string]any{} }
+        user.AppMetaData["scim_external_id"] = v
+    }
+
+    err = db.Transaction(func(tx *storage.Connection) error {
+        if terr := tx.Create(user); terr != nil { return terr }
+        if user.GetEmail() != "" {
+            if _, terr := a.createNewIdentity(tx, user, "email", map[string]any{"email": user.GetEmail(), "email_verified": true, "sub": user.ID.String()}); terr != nil {
+                return terr
+            }
+        }
+        return nil
+    })
+    if err != nil { return err }
+
+    w.Header().Set("Location", a.scimUserLocation(user.ID))
+    return scimSendJSON(w, http.StatusCreated, a.toSCIMUser(user))
+}
+
+// Users replace
+func (a *API) SCIMUsersReplace(w http.ResponseWriter, r *http.Request) error {
+    // For minimal impl, treat as PATCH replace of active/displayName/name
+    return a.SCIMUsersPatch(w, r)
+}
+
+// Users patch
+func (a *API) SCIMUsersPatch(w http.ResponseWriter, r *http.Request) error {
+    ctx := r.Context()
+    db := a.db.WithContext(ctx)
+    idStr := chi.URLParam(r, "scim_user_id")
+    userID, err := uuid.FromString(idStr)
+    if err != nil { return a.scimNotFound() }
+    user, err := models.FindUserByID(db, userID)
+    if err != nil { return a.scimNotFound() }
+
+    var body map[string]any
+    if err := json.NewDecoder(r.Body).Decode(&body); err != nil { return err }
+
+    // Support RFC7644 patch operations minimally
+    if ops, ok := body["Operations"].([]any); ok {
+        err = db.Transaction(func(tx *storage.Connection) error {
+            for _, op := range ops {
+                m, _ := op.(map[string]any)
+                path := getString(m, "path")
+                // normalize path
+                switch path {
+                case "active", "path eq \"active\"":
+                    val, _ := m["value"].(bool)
+                    if val {
+                        // restore by un-banning
+                        user.BannedUntil = nil
+                        if terr := user.UpdateBannedUntil(tx); terr != nil { return terr }
+                    } else {
+                        // ban for 100 years
+                        t := time.Now().Add(100 * 365 * 24 * time.Hour)
+                        user.BannedUntil = &t
+                        if terr := user.UpdateBannedUntil(tx); terr != nil { return terr }
+                    }
+                case "name.givenName":
+                    if user.UserMetaData == nil { user.UserMetaData = map[string]any{} }
+                    user.UserMetaData["given_name"] = getString(m, "value")
+                    if terr := user.UpdateUserMetaData(tx, user.UserMetaData); terr != nil { return terr }
+                case "name.familyName":
+                    if user.UserMetaData == nil { user.UserMetaData = map[string]any{} }
+                    user.UserMetaData["family_name"] = getString(m, "value")
+                    if terr := user.UpdateUserMetaData(tx, user.UserMetaData); terr != nil { return terr }
+                case "displayName":
+                    if user.UserMetaData == nil { user.UserMetaData = map[string]any{} }
+                    user.UserMetaData["display_name"] = getString(m, "value")
+                    if terr := user.UpdateUserMetaData(tx, user.UserMetaData); terr != nil { return terr }
+                }
+            }
+            return nil
+        })
+        if err != nil { return err }
+    }
+
+    return scimSendJSON(w, http.StatusOK, a.toSCIMUser(user))
+}
+
+// Users delete (deprovision)
+func (a *API) SCIMUsersDelete(w http.ResponseWriter, r *http.Request) error {
+    ctx := r.Context()
+    db := a.db.WithContext(ctx)
+    idStr := chi.URLParam(r, "scim_user_id")
+    userID, err := uuid.FromString(idStr)
+    if err != nil { return a.scimNotFound() }
+    user, err := models.FindUserByID(db, userID)
+    if err != nil { return a.scimNotFound() }
+
+    if a.config.SCIM.BanOnDeactivate {
+        // ban long-term
+        t := time.Now().Add(100 * 365 * 24 * time.Hour)
+        user.BannedUntil = &t
+        if terr := user.UpdateBannedUntil(db); terr != nil { return terr }
+    } else {
+        // soft delete user and identities
+        if err := db.Transaction(func(tx *storage.Connection) error {
+            if terr := user.SoftDeleteUser(tx); terr != nil { return terr }
+            if terr := user.SoftDeleteUserIdentities(tx); terr != nil { return terr }
+            return nil
+        }); err != nil { return err }
+    }
+
+    return scimSendJSON(w, http.StatusNoContent, nil)
+}
+
+func (a *API) toSCIMUser(u *models.User) map[string]any {
+    baseURL := a.config.SCIM.BaseURL
+    if baseURL == "" { baseURL = a.config.API.ExternalURL }
+    emails := []any{}
+    if u.GetEmail() != "" {
+        emails = append(emails, map[string]any{"value": u.GetEmail(), "primary": true})
+    }
+    active := !u.IsBanned() && u.DeletedAt == nil
+    return map[string]any{
+        "schemas": []string{"urn:ietf:params:scim:schemas:core:2.0:User"},
+        "id":       u.ID.String(),
+        "externalId": func() any { if v, ok := u.AppMetaData["scim_external_id"]; ok { return v }; return nil }(),
+        "userName": u.GetEmail(),
+        "displayName": func() any { if v, ok := u.UserMetaData["display_name"]; ok { return v }; return nil }(),
+        "name": map[string]any{
+            "givenName":  u.UserMetaData["given_name"],
+            "familyName": u.UserMetaData["family_name"],
+        },
+        "active":  active,
+        "emails":  emails,
+        "meta": map[string]any{
+            "resourceType": "User",
+            "location":     baseURL + "/scim/v2/Users/" + u.ID.String(),
+            "created":      u.CreatedAt.Format(time.RFC3339),
+            "lastModified": u.UpdatedAt.Format(time.RFC3339),
+        },
+    }
+}
+
+func (a *API) scimNotFound() error { return apiNoopError{} }
+
+type apiNoopError struct{}
+func (apiNoopError) Error() string { return "noop" }
+
+func writeSCIMError(w http.ResponseWriter, status int, detail string) error {
+    return scimSendJSON(w, status, map[string]any{
+        "schemas": []string{"urn:ietf:params:scim:api:messages:2.0:Error"},
+        "detail":  detail,
+        "status":  strconv.Itoa(status),
+    })
+}
+
+func scimSendJSON(w http.ResponseWriter, status int, obj any) error {
+    w.Header().Set("Content-Type", "application/scim+json")
+    b, err := json.Marshal(obj)
+    if err != nil { return err }
+    w.WriteHeader(status)
+    _, err = w.Write(b)
+    return err
+}
+
+func (a *API) scimUserLocation(id uuid.UUID) string {
+    baseURL := a.config.SCIM.BaseURL
+    if baseURL == "" { baseURL = a.config.API.ExternalURL }
+    return baseURL + "/scim/v2/Users/" + id.String()
+}
+
+func getString(m map[string]any, k string) string {
+    if m == nil { return "" }
+    if v, ok := m[k]; ok {
+        if s, ok := v.(string); ok { return s }
+    }
+    return ""
+}
+
+

--- a/internal/api/scim_test.go
+++ b/internal/api/scim_test.go
@@ -1,0 +1,215 @@
+package api
+
+import (
+    "bytes"
+    "encoding/json"
+    "fmt"
+    "net/http"
+    "net/http/httptest"
+    "testing"
+
+    "github.com/stretchr/testify/require"
+    "github.com/supabase/auth/internal/models"
+    "github.com/supabase/auth/internal/conf"
+    "github.com/supabase/auth/internal/storage"
+    "github.com/gofrs/uuid"
+)
+
+func setupSCIMAPIForTest(t *testing.T) *API {
+    t.Helper()
+    api, cfg, err := setupAPIForTestWithCallback(func(c *conf.GlobalConfiguration, _ *storage.Connection) {
+        if c != nil {
+            c.SCIM.Enabled = true
+            c.SCIM.Tokens = []string{"testtoken"}
+            if c.API.ExternalURL == "" {
+                c.API.ExternalURL = "http://localhost"
+            }
+            // point DB to test env credentials
+            c.DB.URL = "postgres://supabase_auth_admin:root@localhost:5432/postgres"
+        }
+    })
+    require.NoError(t, err)
+    t.Cleanup(func() { _ = api.db.Close() })
+    // Ensure DB clean
+    require.NoError(t, models.TruncateAll(api.db))
+    _ = cfg
+    return api
+}
+
+func TestSCIM_ServiceProviderConfig(t *testing.T) {
+    api := setupSCIMAPIForTest(t)
+
+    req := httptest.NewRequest(http.MethodGet, "/scim/v2/ServiceProviderConfig", nil)
+    req.Header.Set("Authorization", "Bearer testtoken")
+    w := httptest.NewRecorder()
+    api.handler.ServeHTTP(w, req)
+
+    require.Equal(t, http.StatusOK, w.Code)
+
+    var body map[string]any
+    require.NoError(t, json.NewDecoder(w.Body).Decode(&body))
+    require.Contains(t, body["schemas"], "urn:ietf:params:scim:schemas:core:2.0:ServiceProviderConfig")
+}
+
+func TestSCIM_UsersLifecycle(t *testing.T) {
+    api := setupSCIMAPIForTest(t)
+
+    // Create user
+    create := map[string]any{
+        "userName":    "scim.user@example.com",
+        "displayName": "SCIM User",
+        "name": map[string]any{
+            "givenName":  "SCIM",
+            "familyName": "User",
+        },
+        "externalId": "ext-123",
+    }
+    var buf bytes.Buffer
+    require.NoError(t, json.NewEncoder(&buf).Encode(create))
+    req := httptest.NewRequest(http.MethodPost, "/scim/v2/Users", &buf)
+    req.Header.Set("Authorization", "Bearer testtoken")
+    w := httptest.NewRecorder()
+    api.handler.ServeHTTP(w, req)
+    require.Equal(t, http.StatusCreated, w.Code)
+
+    var created map[string]any
+    require.NoError(t, json.NewDecoder(w.Body).Decode(&created))
+    id := created["id"].(string)
+    require.NotEmpty(t, id)
+
+    // Get user and assert active=true
+    req = httptest.NewRequest(http.MethodGet, fmt.Sprintf("/scim/v2/Users/%s", id), nil)
+    req.Header.Set("Authorization", "Bearer testtoken")
+    w = httptest.NewRecorder()
+    api.handler.ServeHTTP(w, req)
+    require.Equal(t, http.StatusOK, w.Code)
+    var got map[string]any
+    require.NoError(t, json.NewDecoder(w.Body).Decode(&got))
+    require.Equal(t, true, got["active"])
+
+    // Patch deactivate (active=false)
+    patch := map[string]any{
+        "Operations": []any{
+            map[string]any{
+                "op":   "replace",
+                "path": "active",
+                "value": false,
+            },
+        },
+    }
+    buf.Reset()
+    require.NoError(t, json.NewEncoder(&buf).Encode(patch))
+    req = httptest.NewRequest(http.MethodPatch, fmt.Sprintf("/scim/v2/Users/%s", id), &buf)
+    req.Header.Set("Authorization", "Bearer testtoken")
+    w = httptest.NewRecorder()
+    api.handler.ServeHTTP(w, req)
+    require.Equal(t, http.StatusOK, w.Code)
+    var patched map[string]any
+    require.NoError(t, json.NewDecoder(w.Body).Decode(&patched))
+    require.Equal(t, false, patched["active"]) // now disabled
+
+    // Delete (ban / soft deprovision)
+    req = httptest.NewRequest(http.MethodDelete, fmt.Sprintf("/scim/v2/Users/%s", id), nil)
+    req.Header.Set("Authorization", "Bearer testtoken")
+    w = httptest.NewRecorder()
+    api.handler.ServeHTTP(w, req)
+    require.Equal(t, http.StatusNoContent, w.Code)
+
+    // Verify in DB: user still exists, not hard-deleted, banned
+    uid := uuid.FromStringOrNil(id)
+    u, err := models.FindUserByID(api.db, uid)
+    require.NoError(t, err)
+    require.Nil(t, u.DeletedAt)
+    require.True(t, u.IsBanned())
+
+    // GET should still return the user with active=false (soft state)
+    req = httptest.NewRequest(http.MethodGet, fmt.Sprintf("/scim/v2/Users/%s", id), nil)
+    req.Header.Set("Authorization", "Bearer testtoken")
+    w = httptest.NewRecorder()
+    api.handler.ServeHTTP(w, req)
+    require.Equal(t, http.StatusOK, w.Code)
+    var afterDel map[string]any
+    require.NoError(t, json.NewDecoder(w.Body).Decode(&afterDel))
+    require.Equal(t, false, afterDel["active"]) // stays disabled
+}
+
+func TestSCIM_AuthRequired(t *testing.T) {
+    api := setupSCIMAPIForTest(t)
+    req := httptest.NewRequest(http.MethodGet, "/scim/v2/Users", nil)
+    w := httptest.NewRecorder()
+    api.handler.ServeHTTP(w, req)
+    require.Equal(t, http.StatusForbidden, w.Code)
+}
+
+func TestSCIM_SchemasAndResourceTypes(t *testing.T) {
+    api := setupSCIMAPIForTest(t)
+
+    // Schemas
+    req := httptest.NewRequest(http.MethodGet, "/scim/v2/Schemas", nil)
+    req.Header.Set("Authorization", "Bearer testtoken")
+    w := httptest.NewRecorder()
+    api.handler.ServeHTTP(w, req)
+    require.Equal(t, http.StatusOK, w.Code)
+
+    // ResourceTypes
+    req = httptest.NewRequest(http.MethodGet, "/scim/v2/ResourceTypes", nil)
+    req.Header.Set("Authorization", "Bearer testtoken")
+    w = httptest.NewRecorder()
+    api.handler.ServeHTTP(w, req)
+    require.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestSCIM_UsersPagination(t *testing.T) {
+    api := setupSCIMAPIForTest(t)
+
+    createUser := func(email string) {
+        body := map[string]any{
+            "userName": email,
+        }
+        var buf bytes.Buffer
+        _ = json.NewEncoder(&buf).Encode(body)
+        req := httptest.NewRequest(http.MethodPost, "/scim/v2/Users", &buf)
+        req.Header.Set("Authorization", "Bearer testtoken")
+        w := httptest.NewRecorder()
+        api.handler.ServeHTTP(w, req)
+        require.Equal(t, http.StatusCreated, w.Code)
+    }
+    createUser("a@example.com")
+    createUser("b@example.com")
+
+    req := httptest.NewRequest(http.MethodGet, "/scim/v2/Users?startIndex=1&count=1", nil)
+    req.Header.Set("Authorization", "Bearer testtoken")
+    w := httptest.NewRecorder()
+    api.handler.ServeHTTP(w, req)
+    require.Equal(t, http.StatusOK, w.Code)
+
+    var list map[string]any
+    _ = json.NewDecoder(w.Body).Decode(&list)
+    require.Equal(t, float64(1), list["itemsPerPage"]) // JSON numbers decode to float64
+}
+
+func TestSCIM_BasicAuth(t *testing.T) {
+    api, _, err := setupAPIForTestWithCallback(func(c *conf.GlobalConfiguration, _ *storage.Connection) {
+        if c != nil {
+            c.SCIM.Enabled = true
+            c.SCIM.Tokens = nil
+            c.SCIM.BasicUser = "u"
+            c.SCIM.BasicPassword = "p"
+            if c.API.ExternalURL == "" { c.API.ExternalURL = "http://localhost" }
+            c.DB.URL = "postgres://supabase_auth_admin:root@localhost:5432/postgres"
+        }
+    })
+    require.NoError(t, err)
+    t.Cleanup(func() { _ = api.db.Close() })
+    require.NoError(t, models.TruncateAll(api.db))
+
+    var buf bytes.Buffer
+    _ = json.NewEncoder(&buf).Encode(map[string]any{"userName":"c@example.com"})
+    req := httptest.NewRequest(http.MethodPost, "/scim/v2/Users", &buf)
+    req.SetBasicAuth("u","p")
+    w := httptest.NewRecorder()
+    api.handler.ServeHTTP(w, req)
+    require.Equal(t, http.StatusCreated, w.Code)
+}
+
+

--- a/internal/conf/configuration.go
+++ b/internal/conf/configuration.go
@@ -292,6 +292,7 @@ type GlobalConfiguration struct {
 	MFA             MFAConfiguration         `json:"MFA"`
 	SAML            SAMLConfiguration        `json:"saml"`
 	CORS            CORSConfiguration        `json:"cors"`
+	SCIM            SCIMConfiguration        `json:"scim"`
 }
 
 type CORSConfiguration struct {
@@ -317,6 +318,19 @@ func (c *CORSConfiguration) AllAllowedHeaders(defaults []string) []string {
 
 	return result
 }
+
+// SCIMConfiguration holds configuration for the SCIM server.
+type SCIMConfiguration struct {
+    Enabled         bool     `json:"enabled"`
+    BaseURL         string   `json:"base_url" split_words:"true"`
+    Tokens          []string `json:"tokens" split_words:"true"`
+    BasicUser       string   `json:"basic_user" split_words:"true"`
+    BasicPassword   string   `json:"basic_password" split_words:"true"`
+    DefaultAudience string   `json:"default_audience" split_words:"true"`
+    BanOnDeactivate bool     `json:"ban_on_deactivate" split_words:"true" default:"true"`
+}
+
+func (c *SCIMConfiguration) Validate() error { return nil }
 
 // EmailContentConfiguration holds the configuration for emails, both subjects and template URLs.
 type EmailContentConfiguration struct {
@@ -1149,6 +1163,7 @@ func (c *GlobalConfiguration) Validate() error {
 		&c.Sessions,
 		&c.Hook,
 		&c.JWT.Keys,
+		&c.SCIM,
 	}
 
 	for _, validatable := range validatables {


### PR DESCRIPTION
### What kind of change does this PR introduce?
- Feature: Minimal SCIM v2 (Users) support for Supabase Auth
- Tests: Endpoint and middleware coverage
- Config: New SCIM-related options

### What is the current behavior?
- No SCIM endpoints exist; external identity providers cannot provision/deprovision users via SCIM.

### What is the new behavior?
- Adds SCIM v2 Users endpoints under `/scim/v2`:
  - `GET /ServiceProviderConfig`
  - `GET /ResourceTypes`
  - `GET /Schemas`
  - `GET /Users` (pagination + minimal filters), `POST /Users`, `GET /Users/{id}`, `PUT /Users/{id}`, `PATCH /Users/{id}`, `DELETE /Users/{id}`
- SCIM JSON envelopes and Content-Type: all responses use `application/scim+json`.
- Auth:
  - Bearer token via `GOTRUE_SCIM_TOKENS`
  - Basic auth via `GOTRUE_SCIM_BASIC_USER` + `GOTRUE_SCIM_BASIC_PASSWORD`
- Mapping:
  - `userName`/`emails[0].value` -> primary email
  - `name.givenName`, `name.familyName`, `displayName` -> `user_metadata`
  - `externalId` -> `app_metadata.scim_external_id`
- Deprovisioning (DELETE):
  - Soft deprovision by default (ban user long-term). If `GOTRUE_SCIM_BAN_ON_DEACTIVATE=false`, perform a soft-delete (redactable) instead.
- Minimal filters:
  - `filter=userName eq "email@example.com"`
  - `filter=externalId eq "ext-123"`
- Disabled by default; safe to merge without changing behavior.

### Configuration (new keys)
- `GOTRUE_SCIM_ENABLED=true|false` (default false)
- `GOTRUE_SCIM_TOKENS=comma,separated,tokens`
- `GOTRUE_SCIM_BASIC_USER=...`
- `GOTRUE_SCIM_BASIC_PASSWORD=...`
- `GOTRUE_SCIM_BASE_URL=https://your-auth.example.com/auth/v1`
- `GOTRUE_SCIM_DEFAULT_AUDIENCE=authenticated` (optional)
- `GOTRUE_SCIM_BAN_ON_DEACTIVATE=true|false` (default true)

### Tests
- `internal/api/scim_test.go`:
  - ServiceProviderConfig happy path
  - Users lifecycle: create → get → patch active=false → delete (soft deprovision), and asserts user remains in DB (not hard-deleted) and is disabled
  - Auth required (403), Schemas/ResourceTypes (200), pagination, and basic auth
- `internal/api/middleware_test.go`:
  - SCIM enablement gate and auth middleware (Bearer + Basic)

How to run locally:
- Start DB: `bash hack/postgresd.sh`
- Migrate: `bash hack/migrate.sh postgres`
- Run tests: `go test ./... -v`
- Manual smoke test:
  - `curl -H "Authorization: Bearer <token>" http://localhost:9999/scim/v2/ServiceProviderConfig`

### Additional context
- Endpoints are users-only; Groups can be added in a follow-up.
- Minimal filter support implemented to align with `ServiceProviderConfig` claim.
- Backward compatible: endpoints gated behind `GOTRUE_SCIM_ENABLED`.

Open PR from fork/branch: [felixmccuaig/auth:scim](https://github.com/felixmccuaig/auth/pull/new/scim)