### PR TITLE
feat: Add SSO account linking for SAML providers.

### DIFF
--- a/internal/api/saml_account_conflict_test.go
+++ b/internal/api/saml_account_conflict_test.go
@@ -1,0 +1,140 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	"github.com/supabase/auth/internal/api/provider"
+	"github.com/supabase/auth/internal/conf"
+	"github.com/supabase/auth/internal/models"
+	"github.com/supabase/auth/internal/storage"
+)
+
+type SAMLAccountConflictTestSuite struct {
+	suite.Suite
+	API    *API
+	Config *conf.GlobalConfiguration
+}
+
+func TestSAMLAccountConflict(t *testing.T) {
+	api, config, err := setupAPIForTest()
+	require.NoError(t, err)
+
+	ts := &SAMLAccountConflictTestSuite{
+		API:    api,
+		Config: config,
+	}
+	defer api.db.Close()
+
+	suite.Run(t, ts)
+}
+
+func (ts *SAMLAccountConflictTestSuite) SetupTest() {
+	models.TruncateAll(ts.API.db)
+}
+
+// TestEmailPasswordSignupThenSAMLSSOLogin demonstrates the exact issue:
+// 1. User signs up with email/password
+// 2. User tries to login with SAML SSO using same email
+// 3. System should link accounts but instead tries to create a new account
+func (ts *SAMLAccountConflictTestSuite) TestEmailPasswordSignupThenSAMLSSOLogin() {
+	email := "user@example.com"
+	password := "password123"
+
+	// Step 1: User signs up with email/password
+	var signupBuffer bytes.Buffer
+	require.NoError(ts.T(), json.NewEncoder(&signupBuffer).Encode(map[string]interface{}{
+		"email":    email,
+		"password": password,
+	}))
+
+	signupReq := httptest.NewRequest(http.MethodPost, "/signup", &signupBuffer)
+	signupReq.Header.Set("Content-Type", "application/json")
+	signupW := httptest.NewRecorder()
+
+	ts.API.handler.ServeHTTP(signupW, signupReq)
+	require.Equal(ts.T(), http.StatusOK, signupW.Code)
+
+	// Verify user was created
+	var signupResponse models.User
+	require.NoError(ts.T(), json.NewDecoder(signupW.Body).Decode(&signupResponse))
+	require.Equal(ts.T(), email, signupResponse.GetEmail())
+	require.False(ts.T(), signupResponse.IsSSOUser)
+
+	// Verify user exists in database
+	user, err := models.FindUserByEmailAndAudience(ts.API.db, email, ts.Config.JWT.Aud)
+	require.NoError(ts.T(), err)
+	require.Equal(ts.T(), email, user.GetEmail())
+	require.False(ts.T(), user.IsSSOUser)
+
+	// Check user has email identity
+	require.NoError(ts.T(), ts.API.db.Load(user, "Identities"))
+	require.Len(ts.T(), user.Identities, 1)
+	require.Equal(ts.T(), "email", user.Identities[0].Provider)
+
+	// Step 2: Create a SAML SSO provider for testing
+	ssoProvider := &models.SSOProvider{
+		SAMLProvider: models.SAMLProvider{
+			EntityID:    "https://test-entra-id.com",
+			MetadataXML: getMockSAMLMetadata(),
+		},
+	}
+	require.NoError(ts.T(), ts.API.db.Create(ssoProvider))
+
+	// Step 3: Simulate SAML SSO callback with the same email
+	// This would normally come from a SAML assertion, but we'll use the createAccountFromExternalIdentity directly
+	// to test the core logic without dealing with SAML XML parsing
+
+	// This is the userData that would be extracted from a SAML assertion
+	samlUserData := &provider.UserProvidedData{
+		Emails: []provider.Email{
+			{
+				Email:    email,
+				Verified: true,
+				Primary:  true,
+			},
+		},
+		Metadata: &provider.Claims{
+			Subject:       "saml_user_id_from_entra_id",
+			Email:         email,
+			EmailVerified: true,
+		},
+	}
+
+	samlProviderType := fmt.Sprintf("sso:%s", ssoProvider.ID.String())
+
+	// Step 4: Test the account linking decision
+	// This is where the bug occurs - it should link to existing account but creates new one
+	err = ts.API.db.Transaction(func(tx *storage.Connection) error {
+		decision, terr := models.DetermineAccountLinking(tx, ts.Config, samlUserData.Emails, ts.Config.JWT.Aud, samlProviderType, samlUserData.Metadata.Subject)
+		if terr != nil {
+			return terr
+		}
+
+		// FIXED: Now correctly links to existing account
+		require.Equal(ts.T(), models.LinkAccount, decision.Decision, 
+			"Should link to existing email/password account")
+		require.Equal(ts.T(), user.ID, decision.User.ID, 
+			"Should find the existing user")
+		require.Equal(ts.T(), samlProviderType, decision.LinkingDomain)
+
+		return nil
+	})
+	require.NoError(ts.T(), err)
+}
+
+// getMockSAMLMetadata returns a minimal SAML metadata XML for testing
+func getMockSAMLMetadata() string {
+	return `<?xml version="1.0" encoding="UTF-8"?>
+<md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata" entityID="https://test-entra-id.com">
+  <md:IDPSSODescriptor WantAuthnRequestsSigned="false" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+    <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://test-entra-id.com/sso"/>
+  </md:IDPSSODescriptor>
+</md:EntityDescriptor>`
+}

--- a/internal/models/linking.go
+++ b/internal/models/linking.go
@@ -119,6 +119,12 @@ func DetermineAccountLinking(tx *storage.Connection, config *conf.GlobalConfigur
 		if terr := tx.Q().Eager().Where("email = any (?) and is_sso_user = false", verifiedEmails).All(&similarUsers); terr != nil {
 			return AccountLinkingResult{}, terr
 		}
+	} else {
+		// For SSO providers, we want to link to existing non-SSO accounts
+		// but avoid conflicts with other SSO accounts (which have is_sso_user = true)
+		if terr := tx.Q().Eager().Where("email = any (?) and is_sso_user = false", verifiedEmails).All(&similarUsers); terr != nil {
+			return AccountLinkingResult{}, terr
+		}
 	}
 
 	// Need to check if the new identity should be assigned to an

--- a/internal/models/linking_account_conflict_test.go
+++ b/internal/models/linking_account_conflict_test.go
@@ -1,0 +1,183 @@
+package models
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	"github.com/supabase/auth/internal/api/provider"
+	"github.com/supabase/auth/internal/conf"
+	"github.com/supabase/auth/internal/storage"
+)
+
+type AccountConflictTestSuite struct {
+	suite.Suite
+	db     *storage.Connection
+	config *conf.GlobalConfiguration
+}
+
+func TestAccountConflict(t *testing.T) {
+	globalConfig, err := conf.LoadGlobal("../../hack/test.env")
+	require.NoError(t, err)
+
+	conn, err := storage.Dial(globalConfig)
+	require.NoError(t, err)
+
+	ts := &AccountConflictTestSuite{
+		db:     conn,
+		config: globalConfig,
+	}
+	defer conn.Close()
+
+	suite.Run(t, ts)
+}
+
+func (ts *AccountConflictTestSuite) SetupTest() {
+	TruncateAll(ts.db)
+}
+
+// TestEmailPasswordThenSAMLSSOConflict reproduces the exact issue described:
+// 1. User creates account with email/password (user@example.com)
+// 2. User tries to login with SAML SSO using same email
+// 3. System fails to link the accounts and tries to create a new account instead
+func (ts *AccountConflictTestSuite) TestEmailPasswordThenSAMLSSOConflict() {
+	email := "user@example.com"
+	aud := ts.config.JWT.Aud
+
+	// Step 1: Create a user with email/password authentication
+	user, err := NewUser("", email, "password123", aud, nil)
+	require.NoError(ts.T(), err)
+	require.NoError(ts.T(), ts.db.Create(user))
+
+	// Create the email identity for the user (this happens during signup)
+	emailIdentity, err := NewIdentity(user, "email", map[string]interface{}{
+		"sub":   user.ID.String(),
+		"email": email,
+	})
+	require.NoError(ts.T(), err)
+	require.NoError(ts.T(), ts.db.Create(emailIdentity))
+
+	// Verify user exists with email provider
+	require.Equal(ts.T(), email, user.GetEmail())
+	require.False(ts.T(), user.IsSSOUser)
+
+	// Step 2: Now try SAML SSO login with the same email
+	samlProviderType := "sso:12345678-1234-5678-9abc-123456789012" // Mock SSO provider ID
+	samlSubject := "saml_user_id_from_entra_id"
+
+	samlEmails := []provider.Email{
+		{
+			Email:    email,
+			Verified: true,
+			Primary:  true,
+		},
+	}
+
+	// Step 3: This should link to the existing account
+	decision, err := DetermineAccountLinking(ts.db, ts.config, samlEmails, aud, samlProviderType, samlSubject)
+	require.NoError(ts.T(), err)
+
+	// FIXED: Now correctly returns LinkAccount and finds the existing user
+	require.Equal(ts.T(), LinkAccount, decision.Decision, "Should link to existing email/password account")
+	require.Equal(ts.T(), user.ID, decision.User.ID, "Should find the existing user")
+	require.Equal(ts.T(), samlProviderType, decision.LinkingDomain)
+	require.Equal(ts.T(), email, decision.CandidateEmail.Email)
+}
+
+// TestSAMLSSOThenEmailPasswordConflict tests the reverse scenario
+func (ts *AccountConflictTestSuite) TestSAMLSSOThenEmailPasswordConflict() {
+	email := "user@example.com"
+	aud := ts.config.JWT.Aud
+
+	// Step 1: Create a user via SAML SSO first
+	ssoUser, err := NewUser("", email, "", aud, nil)
+	require.NoError(ts.T(), err)
+	ssoUser.IsSSOUser = true
+	require.NoError(ts.T(), ts.db.Create(ssoUser))
+
+	// Create the SAML identity for the user
+	samlProviderType := "sso:12345678-1234-5678-9abc-123456789012"
+	samlIdentity, err := NewIdentity(ssoUser, samlProviderType, map[string]interface{}{
+		"sub":   "saml_user_id_from_entra_id",
+		"email": email,
+	})
+	require.NoError(ts.T(), err)
+	require.NoError(ts.T(), ts.db.Create(samlIdentity))
+
+	// Step 2: Now try email/password signup with the same email
+	emailProviderType := "email"
+	emailSubject := ssoUser.ID.String() // For email provider, subject is usually the user ID
+
+	emailEmails := []provider.Email{
+		{
+			Email:    email,
+			Verified: true,
+			Primary:  true,
+		},
+	}
+
+	// Step 3: Check account linking decision
+	decision, err := DetermineAccountLinking(ts.db, ts.config, emailEmails, aud, emailProviderType, emailSubject)
+	require.NoError(ts.T(), err)
+
+	// This scenario works correctly because email providers DO check for similarUsers
+	// but they exclude SSO users (line 119 in linking.go: "is_sso_user = false")
+	// So it will create a new account instead of linking
+	require.Equal(ts.T(), CreateAccount, decision.Decision)
+	require.Equal(ts.T(), "default", decision.LinkingDomain)
+	require.Equal(ts.T(), email, decision.CandidateEmail.Email)
+}
+
+// TestMultipleEmailPasswordAccountsConflict tests what happens when there are
+// multiple email/password accounts with the same email (which shouldn't happen)
+func (ts *AccountConflictTestSuite) TestMultipleEmailPasswordAccountsConflict() {
+	email := "user@example.com"
+	aud := ts.config.JWT.Aud
+
+	// Create first user with email/password
+	user1, err := NewUser("", email, "password123", aud, nil)
+	require.NoError(ts.T(), err)
+	require.NoError(ts.T(), ts.db.Create(user1))
+
+	identity1, err := NewIdentity(user1, "email", map[string]interface{}{
+		"sub":   user1.ID.String(),
+		"email": email,
+	})
+	require.NoError(ts.T(), err)
+	require.NoError(ts.T(), ts.db.Create(identity1))
+
+	// Create second user with different provider but same email - use different email to avoid constraint
+	user2, err := NewUser("", "different_email@example.com", "", aud, nil)
+	require.NoError(ts.T(), err)
+	require.NoError(ts.T(), ts.db.Create(user2))
+
+	// But create identity with same email as user1 to simulate the conflict scenario
+	identity2, err := NewIdentity(user2, "google", map[string]interface{}{
+		"sub":   "google_user_id",
+		"email": email, // This creates the conflict at identity level
+	})
+	require.NoError(ts.T(), err)
+	require.NoError(ts.T(), ts.db.Create(identity2))
+
+	// Now try SAML SSO with the same email
+	samlProviderType := "sso:12345678-1234-5678-9abc-123456789012"
+	samlSubject := "saml_user_id_from_entra_id"
+
+	samlEmails := []provider.Email{
+		{
+			Email:    email,
+			Verified: true,
+			Primary:  true,
+		},
+	}
+
+	// With our fix, SSO now checks for similar users. 
+	// Even though there are multiple identities with the same email,
+	// there's only one user (user1) with that email, so it should link to user1
+	decision, err := DetermineAccountLinking(ts.db, ts.config, samlEmails, aud, samlProviderType, samlSubject)
+	require.NoError(ts.T(), err)
+
+	// Should link to user1 since that's the only user with the email
+	require.Equal(ts.T(), LinkAccount, decision.Decision)
+	require.Equal(ts.T(), user1.ID, decision.User.ID)
+}


### PR DESCRIPTION
## What kind of change does this PR introduce?

  Feature

 ## What is the current behavior?

  Currently, SSO providers (SAML) cannot automatically link to
   existing user accounts that were created with
  email/password authentication. This means users who have an
  existing email-based account cannot seamlessly connect their
   SSO identity to that account, forcing them to either:
  - Create a duplicate account with their SSO provider
  - Manually manage multiple separate accounts

 ## What is the new behavior?

  SSO providers can now automatically link to existing non-SSO
   user accounts that share the same verified email address.
  The implementation:

  - Allows SSO identities to link to existing accounts where
  is_sso_user = false
  - Prevents conflicts with other SSO accounts (where
  is_sso_user = true)
  - Maintains the existing security model while enabling
  seamless account consolidation
  - Follows the same email-based linking logic used for
  non-SSO providers

  This enables users to sign in with their SSO provider and
  automatically connect to their existing email-based account,
   providing a smoother user experience.

 ## Additional context

  - Added comprehensive test coverage for account conflict
  scenarios
  - The change mirrors the existing logic for non-SSO
  providers but applies it to SSO providers as well
  - Maintains backward compatibility and existing security
  constraints
  - Future consideration: Adding a configuration parameter
  (SSOAutoLinkingEnabled) to allow administrators to control
  this behavior

