### PR TITLE
feat: experimental own linking domains per provider

### DIFF
--- a/cmd/admin_cmd.go
+++ b/cmd/admin_cmd.go
@@ -66,7 +66,7 @@ func adminCreateUser(config *conf.GlobalConfiguration, args []string) {
 	defer db.Close()
 
 	aud := getAudience(config)
-	if user, err := models.IsDuplicatedEmail(db, args[0], aud, nil); user != nil {
+	if user, err := models.IsDuplicatedEmail(db, args[0], aud, nil, config.Experimental.ProvidersWithOwnLinkingDomain); user != nil {
 		logrus.Fatalf("Error creating new user: user already exists")
 	} else if err != nil {
 		logrus.Fatalf("Error checking user email: %+v", err)

--- a/internal/api/admin.go
+++ b/internal/api/admin.go
@@ -348,7 +348,7 @@ func (a *API) adminUserCreate(w http.ResponseWriter, r *http.Request) error {
 		if err != nil {
 			return err
 		}
-		if user, err := models.IsDuplicatedEmail(db, params.Email, aud, nil); err != nil {
+		if user, err := models.IsDuplicatedEmail(db, params.Email, aud, nil, config.Experimental.ProvidersWithOwnLinkingDomain); err != nil {
 			return apierrors.NewInternalServerError("Database error checking email").WithInternalError(err)
 		} else if user != nil {
 			return apierrors.NewUnprocessableEntityError(apierrors.ErrorCodeEmailExists, DuplicateEmailMsg)

--- a/internal/api/mail.go
+++ b/internal/api/mail.go
@@ -239,7 +239,7 @@ func (a *API) adminGenerateLink(w http.ResponseWriter, r *http.Request) error {
 			if terr != nil {
 				return terr
 			}
-			if duplicateUser, terr := models.IsDuplicatedEmail(tx, params.NewEmail, user.Aud, user); terr != nil {
+			if duplicateUser, terr := models.IsDuplicatedEmail(tx, params.NewEmail, user.Aud, user, config.Experimental.ProvidersWithOwnLinkingDomain); terr != nil {
 				return apierrors.NewInternalServerError("Database error checking email").WithInternalError(terr)
 			} else if duplicateUser != nil {
 				return apierrors.NewUnprocessableEntityError(apierrors.ErrorCodeEmailExists, DuplicateEmailMsg)

--- a/internal/api/signup.go
+++ b/internal/api/signup.go
@@ -146,7 +146,7 @@ func (a *API) Signup(w http.ResponseWriter, r *http.Request) error {
 		if err != nil {
 			return err
 		}
-		user, err = models.IsDuplicatedEmail(db, params.Email, params.Aud, nil)
+		user, err = models.IsDuplicatedEmail(db, params.Email, params.Aud, nil, config.Experimental.ProvidersWithOwnLinkingDomain)
 	case "phone":
 		if !config.External.Phone.Enabled {
 			return apierrors.NewBadRequestError(apierrors.ErrorCodePhoneProviderDisabled, "Phone signups are disabled")

--- a/internal/api/user.go
+++ b/internal/api/user.go
@@ -115,6 +115,7 @@ func (a *API) UserUpdate(w http.ResponseWriter, r *http.Request) error {
 		}
 	}
 
+	// TODO: Check if a user is SSO via rows in identities table, not via this flag.
 	if user.IsSSOUser {
 		updatingForbiddenFields := false
 

--- a/internal/api/user.go
+++ b/internal/api/user.go
@@ -130,7 +130,7 @@ func (a *API) UserUpdate(w http.ResponseWriter, r *http.Request) error {
 	}
 
 	if params.Email != "" && user.GetEmail() != params.Email {
-		if duplicateUser, err := models.IsDuplicatedEmail(db, params.Email, aud, user); err != nil {
+		if duplicateUser, err := models.IsDuplicatedEmail(db, params.Email, aud, user, config.Experimental.ProvidersWithOwnLinkingDomain); err != nil {
 			return apierrors.NewInternalServerError("Database error checking email").WithInternalError(err)
 		} else if duplicateUser != nil {
 			return apierrors.NewUnprocessableEntityError(apierrors.ErrorCodeEmailExists, DuplicateEmailMsg)

--- a/internal/conf/configuration.go
+++ b/internal/conf/configuration.go
@@ -254,6 +254,13 @@ type AuditLogConfiguration struct {
 	DisablePostgres bool `split_words:"true" default:"false"`
 }
 
+type ExperimentalConfiguration struct {
+	// Names of providers (e.g. "google") which have their own identity
+	// linking domain, meaning that the ones listed here _will not
+	// participate_ in email similarity linking with other accounts.
+	ProvidersWithOwnLinkingDomain []string `split_words:"true"`
+}
+
 // GlobalConfiguration holds all the configuration that applies to all instances.
 type GlobalConfiguration struct {
 	API           APIConfiguration
@@ -293,6 +300,8 @@ type GlobalConfiguration struct {
 	MFA             MFAConfiguration         `json:"MFA"`
 	SAML            SAMLConfiguration        `json:"saml"`
 	CORS            CORSConfiguration        `json:"cors"`
+
+	Experimental ExperimentalConfiguration `json:"experimental"`
 }
 
 type CORSConfiguration struct {

--- a/internal/models/linking.go
+++ b/internal/models/linking.go
@@ -1,6 +1,7 @@
 package models
 
 import (
+	"slices"
 	"strings"
 
 	"github.com/supabase/auth/internal/api/provider"
@@ -13,8 +14,8 @@ import (
 // _should_ generally fall under the same User entity. It's just a runtime
 // string, and is not typically persisted in the database. This value can vary
 // across time.
-func GetAccountLinkingDomain(provider string) string {
-	if strings.HasPrefix(provider, "sso:") {
+func GetAccountLinkingDomain(provider string, ownLinkingDomains []string) string {
+	if strings.HasPrefix(provider, "sso:") || slices.Contains(ownLinkingDomains, provider) {
 		// when the provider ID is a SSO provider, then the linking
 		// domain is the provider itself i.e. there can only be one
 		// user + identity per identity provider
@@ -63,6 +64,9 @@ func DetermineAccountLinking(tx *storage.Connection, config *conf.GlobalConfigur
 		}
 	}
 
+	// this is the linking domain for the new identity
+	candidateLinkingDomain := GetAccountLinkingDomain(providerName, config.Experimental.ProvidersWithOwnLinkingDomain)
+
 	if identity, terr := FindIdentityByIdAndProvider(tx, sub, providerName); terr == nil {
 		// account exists
 
@@ -78,7 +82,7 @@ func DetermineAccountLinking(tx *storage.Connection, config *conf.GlobalConfigur
 			Decision:       AccountExists,
 			User:           user,
 			Identities:     []*Identity{identity},
-			LinkingDomain:  GetAccountLinkingDomain(providerName),
+			LinkingDomain:  candidateLinkingDomain,
 			CandidateEmail: candidateEmail,
 		}, nil
 	} else if !IsNotFoundError(terr) {
@@ -87,9 +91,6 @@ func DetermineAccountLinking(tx *storage.Connection, config *conf.GlobalConfigur
 
 	// the identity does not exist, so we need to check if we should create a new account
 	// or link to an existing one
-
-	// this is the linking domain for the new identity
-	candidateLinkingDomain := GetAccountLinkingDomain(providerName)
 	if len(verifiedEmails) == 0 {
 		// if there are no verified emails, we always decide to create a new account
 		user, terr := IsDuplicatedEmail(tx, candidateEmail.Email, aud, nil)
@@ -108,12 +109,13 @@ func DetermineAccountLinking(tx *storage.Connection, config *conf.GlobalConfigur
 
 	var similarIdentities []*Identity
 	var similarUsers []*User
+
 	// look for similar identities and users based on email
 	if terr := tx.Q().Eager().Where("email = any (?)", verifiedEmails).All(&similarIdentities); terr != nil {
 		return AccountLinkingResult{}, terr
 	}
 
-	if !strings.HasPrefix(providerName, "sso:") {
+	if candidateLinkingDomain == "default" {
 		// there can be multiple user accounts with the same email when is_sso_user is true
 		// so we just do not consider those similar user accounts
 		if terr := tx.Q().Eager().Where("email = any (?) and is_sso_user = false", verifiedEmails).All(&similarUsers); terr != nil {
@@ -129,7 +131,7 @@ func DetermineAccountLinking(tx *storage.Connection, config *conf.GlobalConfigur
 	// now let's see if there are any existing and similar identities in
 	// the same linking domain
 	for _, identity := range similarIdentities {
-		if GetAccountLinkingDomain(identity.Provider) == candidateLinkingDomain {
+		if GetAccountLinkingDomain(identity.Provider, config.Experimental.ProvidersWithOwnLinkingDomain) == candidateLinkingDomain {
 			linkingIdentities = append(linkingIdentities, identity)
 		}
 	}

--- a/internal/models/linking.go
+++ b/internal/models/linking.go
@@ -93,7 +93,7 @@ func DetermineAccountLinking(tx *storage.Connection, config *conf.GlobalConfigur
 	// or link to an existing one
 	if len(verifiedEmails) == 0 {
 		// if there are no verified emails, we always decide to create a new account
-		user, terr := IsDuplicatedEmail(tx, candidateEmail.Email, aud, nil)
+		user, terr := IsDuplicatedEmail(tx, candidateEmail.Email, aud, nil, config.Experimental.ProvidersWithOwnLinkingDomain)
 		if terr != nil {
 			return AccountLinkingResult{}, terr
 		}

--- a/internal/models/user.go
+++ b/internal/models/user.go
@@ -734,7 +734,7 @@ func IsDuplicatedEmail(tx *storage.Connection, email, aud string, currentUser *U
 	userIDs := make(map[string]uuid.UUID)
 	for _, identity := range identities {
 		if _, ok := userIDs[identity.UserID.String()]; !ok {
-			if GetAccountLinkingDomain(identity.ProviderID, ownDomainProviders) == "default" {
+			if GetAccountLinkingDomain(identity.Provider, ownDomainProviders) == "default" {
 				userIDs[identity.UserID.String()] = identity.UserID
 			}
 		}

--- a/internal/models/user_test.go
+++ b/internal/models/user_test.go
@@ -163,19 +163,19 @@ func (ts *UserTestSuite) TestFindUserWithRefreshToken() {
 func (ts *UserTestSuite) TestIsDuplicatedEmail() {
 	_ = ts.createUserWithEmail("david.calavera@netlify.com")
 
-	e, err := IsDuplicatedEmail(ts.db, "david.calavera@netlify.com", "test", nil)
+	e, err := IsDuplicatedEmail(ts.db, "david.calavera@netlify.com", "test", nil, nil)
 	require.NoError(ts.T(), err)
 	require.NotNil(ts.T(), e, "expected email to be duplicated")
 
-	e, err = IsDuplicatedEmail(ts.db, "davidcalavera@netlify.com", "test", nil)
+	e, err = IsDuplicatedEmail(ts.db, "davidcalavera@netlify.com", "test", nil, nil)
 	require.NoError(ts.T(), err)
-	require.Nil(ts.T(), e, "expected email to not be duplicated", nil)
+	require.Nil(ts.T(), e, "expected email to not be duplicated", nil, nil)
 
-	e, err = IsDuplicatedEmail(ts.db, "david@netlify.com", "test", nil)
+	e, err = IsDuplicatedEmail(ts.db, "david@netlify.com", "test", nil, nil)
 	require.NoError(ts.T(), err)
-	require.Nil(ts.T(), e, "expected same email to not be duplicated", nil)
+	require.Nil(ts.T(), e, "expected same email to not be duplicated", nil, nil)
 
-	e, err = IsDuplicatedEmail(ts.db, "david.calavera@netlify.com", "other-aud", nil)
+	e, err = IsDuplicatedEmail(ts.db, "david.calavera@netlify.com", "other-aud", nil, nil)
 	require.NoError(ts.T(), err)
 	require.Nil(ts.T(), e, "expected same email to not be duplicated")
 }


### PR DESCRIPTION
Experimental feature internal to Supabase. Don't use outside of Supabase.

Adds the ability to specify providers e.g. `google`, `apple`, whose identities will not participate in the `default` email-similarity identity linking algorithm but be on its own. You can do this by setting

```
GOTRUE_EXPERIMENTAL_PROVIDERS_WITH_OWN_LINKING_DOMAIN="google,apple,..."
```

This has the effect of setting the `is_sso_user` column on `auth.users` to true, which is the only mechanism that allows the same email address to appear in different linking domains. The column cannot be renamed as that requires re-creating a partial index, which is not on the table for this change. It will be revised in the future.