### PR TITLE
ci: rm explicit container name & obselete version attr

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -1,7 +1,5 @@
-version: "3.9"
 services:
   auth:
-    container_name: auth
     depends_on:
       - postgres
     build:
@@ -19,7 +17,6 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.postgres.dev
-    container_name: auth_postgres
     ports:
       - '5432:5432'
     volumes:


### PR DESCRIPTION
## What kind of change does this PR introduce?

Having explicit `container_name` defined in the docker compose prevents utilizing [git worktrees](https://git-scm.com/docs/git-worktree). By removing, each container name will be prefixed with the current working directory, hence preventing any name collisions.

Also removing the `version` attribute per the warning:
```
the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion
```

