### PR TITLE
feat: introduce memory backed background workers & async mail sending

### DIFF
--- a/internal/api/options.go
+++ b/internal/api/options.go
@@ -6,12 +6,19 @@ import (
 	"github.com/didip/tollbooth/v5"
 	"github.com/didip/tollbooth/v5/limiter"
 	"github.com/supabase/auth/internal/conf"
+	"github.com/supabase/auth/internal/mailer"
 	"github.com/supabase/auth/internal/ratelimit"
 )
 
 type Option interface {
 	apply(*API)
 }
+
+type MailerOptions struct {
+	MailerClientFunc func() mailer.MailClient
+}
+
+func (mo *MailerOptions) apply(a *API) { a.mailerClientFunc = mo.MailerClientFunc }
 
 type LimiterOptions struct {
 	Email ratelimit.Limiter

--- a/internal/api/worker/worker.go
+++ b/internal/api/worker/worker.go
@@ -1,0 +1,275 @@
+package worker
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"runtime"
+	"sync"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"github.com/supabase/auth/internal/conf"
+	"github.com/supabase/auth/internal/mailer"
+	"github.com/supabase/auth/internal/observability"
+	"golang.org/x/sync/errgroup"
+)
+
+// Task is implemented by objects which may be handled by the worker.
+type Task interface {
+
+	// Type return a basic name for a task. It is not expected to be consistent
+	// with the underlying type, but it should be low cardinality.
+	Type() string
+}
+
+// job carries *Task along with a logEntry related to the initiating request
+// and a createdAt time used to print the duration the task took to process.
+type job struct {
+	task      Task
+	createdAt time.Time
+	logEntry  *logrus.Entry
+}
+
+func newJob(ctx context.Context, task Task) *job {
+	le := observability.GetLogEntryFromContext(ctx).Entry
+	return &job{
+		task:      task,
+		logEntry:  le,
+		createdAt: time.Now(),
+	}
+}
+
+func (o *job) result(err error) {
+
+	// TODO(cstockton): Carrying the log entry from the request gives the
+	// ability to correlate failed tasks with a request. The downside is that
+	// the log entry is fairly heavy, as large as the "auth_event" task done
+	// at the end of the request. This could have a measurable impact on log
+	// volume.
+	duration := time.Since(o.createdAt)
+	le := o.logEntry.WithFields(logrus.Fields{
+		"action":    "worker_task",
+		"task_type": o.task.Type(),
+		"success":   err == nil,
+		"duration":  duration,
+	})
+
+	logFn := le.Infof
+	if err != nil {
+		logFn = le.WithError(err).Errorf
+	}
+	logFn("worker task complete for: %v", o.task.Type())
+}
+
+// Worker is a simple background work for async tasks. It has an internal
+// channel jobs are sent to which are later picked up by a 1 or more workers.
+type Worker struct {
+
+	// must be held for calls to Work, prevents potential double Work() calls
+	// to ensure the max per cpu worker count holds true.
+	workMu sync.Mutex
+
+	cfg   *conf.GlobalConfiguration
+	log   *logrus.Entry
+	jobCh chan *job
+
+	mailerHandler *mailerHandler
+}
+
+func New(
+	cfg *conf.GlobalConfiguration,
+	log *logrus.Entry,
+) *Worker {
+	wrk := &Worker{
+		cfg:   cfg,
+		jobCh: make(chan *job),
+		log:   log,
+	}
+
+	wrk.mailerHandler = newMailerHandler(cfg, wrk)
+	return wrk
+}
+
+// workerState carries state shared across workers.
+type workerState struct {
+	eg      *errgroup.Group
+	workCtx context.Context
+}
+
+// Work starts the worker using the given workCtx for executing jobs. It will
+// run until the ctx is finished. The assumption here is that the inbound ctx
+// will be tied to the baseCtx used in the api http requests. This is important
+// as it ensures no http request will hold down the shutdown process due to the
+// worker exiting before the http server.
+//
+// In short, ctx must:
+//
+//   - NEVER be done BEFORE the httpSrv is shutdown
+//   - ALWAYS be done AFTER the httpSrv is shutdown
+func (o *Worker) Work(ctx context.Context) error {
+	if ok := o.workMu.TryLock(); !ok {
+		return errors.New("multiple calls to Work are invalid")
+	}
+	defer o.workMu.Unlock()
+
+	eg := new(errgroup.Group)
+	ws := &workerState{
+		eg:      eg,
+		workCtx: ctx,
+	}
+
+	workerCount := max(runtime.NumCPU(), 1) * o.cfg.Worker.CountPerCPU
+	for i := range workerCount {
+		eg.Go(func() error { return o.worker(ws, i+1) })
+	}
+
+	started := time.Now()
+	o.log.WithFields(logrus.Fields{
+		"action": "worker_main_start",
+	})
+
+	var err error
+	defer func() {
+		o.log.WithFields(logrus.Fields{
+			"action":   "worker_main_stop",
+			"duration": time.Since(started),
+		})
+	}()
+
+	// Wait for all in-flight jobs to finish. This is bound to
+	err = eg.Wait()
+	return err
+}
+
+// worker selects jobs and calls dispatch until ws.workCtx is done.
+func (o *Worker) worker(ws *workerState, workerNum int) error {
+	le := o.log.WithField("worker_num", workerNum)
+	pfx := fmt.Sprintf("worker #%.04d:", workerNum)
+
+	le.Infof("%v started", pfx)
+	defer le.Infof("%v exited", pfx)
+
+	// Pulls job and calls dispatch until the exitCtx is done.
+	for {
+		select {
+		case <-ws.workCtx.Done():
+			return nil
+
+		case job := <-o.jobCh:
+			le.Infof("%v received task type %v", pfx, job.task.Type())
+			o.dispatch(ws, job)
+		}
+	}
+}
+
+func unknownTaskError(task Task) error {
+	return fmt.Errorf("worker: unknown implementation of Task: %T", task)
+}
+
+// dispatch will send a job to an appropriate handler.
+func (o *Worker) dispatch(ws *workerState, job *job) {
+	switch task := job.task.(type) {
+	case *MailerTask:
+		var err error
+		defer func() { job.result(err) }()
+
+		err = o.mailerHandler.Handle(ws.workCtx, task)
+	default:
+		panic(unknownTaskError(task))
+	}
+}
+
+// Enqueue will attempt to send a task to the internal job queue for up to
+// the worker shutdown duration.
+func (o *Worker) Enqueue(ctx context.Context, task Task) error {
+	ctx, cancel := context.WithTimeout(ctx, o.cfg.Worker.ShutdownDuration)
+	defer cancel()
+
+	job := newJob(ctx, task)
+	select {
+	case o.jobCh <- job:
+		return nil
+	case <-ctx.Done():
+
+		// If the workCtx becomes done it means the worker shutdown duration
+		// was exceed. To prevent blocking the shutdown sequence we attempt
+		// for up to 10 seconds to finish work.
+		switch task := job.task.(type) {
+		case *MailerTask:
+			return fmt.Errorf("mail server request timed out")
+		default:
+			panic(unknownTaskError(task))
+		}
+	}
+}
+
+func (o *Worker) GetMailerFunc() mailer.MailClient { return o.mailerHandler }
+
+// MailerTask holds a mail pending delivery by the mailerHandler.
+type MailerTask struct {
+	To              string              `json:"to"`
+	SubjectTemplate string              `json:"subject_template"`
+	TemplateURL     string              `json:"template_url"`
+	DefaultTemplate string              `json:"default_template"`
+	TemplateData    map[string]any      `json:"template_data"`
+	Headers         map[string][]string `json:"headers"`
+	Typ             string              `json:"typ"`
+}
+
+// Type implements worker.Type by returning the task Typ with a "mailer." pfx.
+func (o *MailerTask) Type() string { return fmt.Sprintf("mailer.%v", o.Typ) }
+
+// mailerHandler is the task handler for mailer tasks.
+type mailerHandler struct {
+	cfg *conf.GlobalConfiguration
+	wrk *Worker
+}
+
+func newMailerHandler(
+	cfg *conf.GlobalConfiguration,
+	wrk *Worker,
+) *mailerHandler {
+	return &mailerHandler{
+		cfg: cfg,
+		wrk: wrk,
+	}
+}
+
+// Handle implements worker.Handle for mailer tasks.
+func (o *mailerHandler) Handle(ctx context.Context, tk *MailerTask) error {
+	mc := mailer.NewMailClient(o.cfg)
+	return mc.Mail(
+		ctx,
+		tk.To,
+		tk.SubjectTemplate,
+		tk.TemplateURL,
+		tk.DefaultTemplate,
+		tk.TemplateData,
+		tk.Headers,
+		tk.Typ)
+}
+
+// Mail implements mailer.MailClient interface by creating a background task
+// to later be sent using the mailer.MailmeMailer implementation.
+func (o *mailerHandler) Mail(
+	ctx context.Context,
+	to string,
+	subjectTemplate string,
+	templateURL string,
+	defaultTemplate string,
+	templateData map[string]any,
+	headers map[string][]string,
+	typ string,
+) error {
+	tk := &MailerTask{
+		to,
+		subjectTemplate,
+		templateURL,
+		defaultTemplate,
+		templateData,
+		headers,
+		typ,
+	}
+	return o.wrk.Enqueue(ctx, tk)
+}

--- a/internal/api/worker/worker_test.go
+++ b/internal/api/worker/worker_test.go
@@ -1,0 +1,1 @@
+package worker

--- a/internal/conf/configuration.go
+++ b/internal/conf/configuration.go
@@ -274,6 +274,7 @@ type GlobalConfiguration struct {
 	Metrics       MetricsConfig
 	SMTP          SMTPConfiguration
 	AuditLog      AuditLogConfiguration `split_words:"true"`
+	Worker        WorkerConfiguration   `split_words:"true"`
 
 	RateLimitHeader                     string  `split_words:"true"`
 	RateLimitEmailSent                  Rate    `split_words:"true" default:"30"`
@@ -1159,6 +1160,7 @@ func (c *GlobalConfiguration) Validate() error {
 		&c.Sessions,
 		&c.Hook,
 		&c.JWT.Keys,
+		&c.Worker,
 	}
 
 	for _, validatable := range validatables {

--- a/internal/conf/worker.go
+++ b/internal/conf/worker.go
@@ -1,0 +1,39 @@
+package conf
+
+import (
+	"time"
+)
+
+// Upper bounds for goroutines to prevent a bad config value from taking down
+// the server.
+var workerMaxCountPerCPU = 128
+
+type WorkerConfiguration struct {
+
+	// When set to true (default: false) workers will be started to handle
+	// blocking tasks. If disabled no workers are started and blocking tasks
+	// continue to work as they did before.
+	Enabled bool `json:"enabled,omitempty" split_words:"true" default:"false"`
+
+	// How many workers are started per CPU (runtime.NumCPU()), 32 by default.
+	CountPerCPU      int           `split_words:"true" default:"32"`
+	ShutdownDuration time.Duration `split_words:"true" default:"10s"`
+
+	// TODO(cstockton): As we add more background tasks we may want to add:
+	//
+	//   Tasks TasksConfiguration `split_words:"true"
+	//
+	// Since some tasks such as sending Email or SMS may be more important than
+	// others, so a way to configure a minimum worker pool size will help slow
+	// but less important tasks from dominating important paths such as signup.
+}
+
+func (o *WorkerConfiguration) Validate() error {
+	if o.CountPerCPU <= 0 {
+		o.CountPerCPU = 1
+	}
+	if o.CountPerCPU > workerMaxCountPerCPU {
+		o.CountPerCPU = workerMaxCountPerCPU
+	}
+	return nil
+}

--- a/internal/mailer/mailme.go
+++ b/internal/mailer/mailme.go
@@ -25,18 +25,17 @@ const TemplateExpiration = 10 * time.Second
 
 // MailmeMailer lets MailMe send templated mails
 type MailmeMailer struct {
-	From           string
-	Host           string
-	Port           int
-	User           string
-	Pass           string
-	BaseURL        string
-	LocalName      string
-	FuncMap        template.FuncMap
-	cache          *TemplateCache
-	Logger         logrus.FieldLogger
-	MailLogging    bool
-	EmailValidator *EmailValidator
+	From        string
+	Host        string
+	Port        int
+	User        string
+	Pass        string
+	BaseURL     string
+	LocalName   string
+	FuncMap     template.FuncMap
+	cache       *TemplateCache
+	Logger      logrus.FieldLogger
+	MailLogging bool
 }
 
 // Mail sends a templated mail. It will try to load the template from a URL, and
@@ -56,12 +55,6 @@ func (m *MailmeMailer) Mail(
 			templates: map[string]*MailTemplate{},
 			funcMap:   m.FuncMap,
 			logger:    m.Logger,
-		}
-	}
-
-	if m.EmailValidator != nil {
-		if err := m.EmailValidator.Validate(ctx, to); err != nil {
-			return err
 		}
 	}
 


### PR DESCRIPTION
## Summary

Initial draft PR to introduce a small, in-process background worker subsystem and moves mail sending off the request/transaction path. Instead of SMTP in the hot path, API code asks the worker for a mail client that enqueues and executes the work out-of-band. The goal is to reduce request latency and free Postgres connections sooner while keeping the implementation minimal and reversible.

I will follow up with unit tests once the team has had an opportunity to review.

* **Server wiring (`cmd/serve_cmd.go`)**

  * Construct worker on startup when `config.Worker.Enabled` is true.
  * Run worker in a goroutine with `sync.WaitGroup` and a dedicated `component=workers` logger.
  * Pass `api.MailerOptions{MailerClientFunc: (*worker.Worker).GetMailerFunc}` into API options so handlers can obtain a backgrounding mail client.
    * This was a function to preserve the current semantics of mail client usage today. A follow up PR will clean some of this up.
  * Adjust shutdown ordering: cancel base context **after** the HTTP server exits to avoid blocking in-flight requests.

* **API integration**

  * New `api.MailerOptions` and `MailerClientFunc` stored on the `API`.
  * `API.Mailer()` now returns `mailer.NewMailerWithClient(config, a.mailerClientFunc())`.

* **Mailer**

  * `emailValidatorMailClient` added so it may be used as a `MailClient`.
    * This is a no-op when email validation is disabled, see `email_validation_extended_*`
  * `NewMailClient` added to remove coupling between the `Mailer` and `MailClient`
  * `NewMailerWithClient` added to allow specifying a specific client.
    * wraps the provided `MailClient` with `emailValidatorMailClient` so existing validation semantics remain intact.
  * `worker.Handler` implements `MailClient` by calling `worker.Enqueue`.

* **Configuration**

  * New `GlobalConfiguration.Worker` with envs:
    * `GOTRUE_WORKER_ENABLED` (def `false`) - on/off switch.
    * `GOTRUE_WORKER_SHUTDOWN_DURATION` (def `10s`) - drain window for graceful shutdown.
      * No call to `Enqueue` may exceed this value.
    * `GOTRUE_WORKER_COUNT_PER_CPU` (def: `32`, min: `1`, max: `128`) controls concurrency by CPU, rather than a fixed total count.
      * This sets worker pool size to  (`runtime.NumCPU() * GOTRUE_WORKER_COUNT_PER_CPU`)
