### PR TITLE
fix: fail email sending if email address is empty

### DIFF
--- a/internal/api/external.go
+++ b/internal/api/external.go
@@ -416,6 +416,9 @@ func (a *API) createAccountFromExternalIdentity(tx *storage.Connection, r *http.
 					return nil, terr
 				}
 				emailConfirmationSent = true
+			} else {
+				// empty email address is regarded as not verified
+				return nil, apierrors.NewUnprocessableEntityError(apierrors.ErrorCodeEmailNotConfirmed, "No email address provided by %v. Please add a verified email address to your account at %v and try again.", providerType, providerType)
 			}
 
 			if !config.Mailer.AllowUnverifiedEmailSignIns {

--- a/internal/api/identity.go
+++ b/internal/api/identity.go
@@ -133,6 +133,11 @@ func (a *API) linkIdentityToUser(r *http.Request, ctx context.Context, tx *stora
 			return nil, terr
 		}
 		if !userData.Metadata.EmailVerified {
+			if targetUser.GetEmail() == "" {
+				// empty email address is regarded as not verified
+				return nil, apierrors.NewUnprocessableEntityError(apierrors.ErrorCodeEmailNotConfirmed, "No email address provided by %v. Please add a verified email address to your account at %v and try again.", providerType, providerType)
+			}
+
 			if terr := a.sendConfirmation(r, tx, targetUser, models.ImplicitFlow); terr != nil {
 				return nil, terr
 			}

--- a/internal/api/mail.go
+++ b/internal/api/mail.go
@@ -594,10 +594,18 @@ func (a *API) sendEmail(r *http.Request, tx *storage.Connection, u *models.User,
 	externalURL := getExternalHost(ctx)
 
 	if emailActionType != mail.EmailChangeVerification {
-		if u.GetEmail() != "" && !a.checkEmailAddressAuthorization(u.GetEmail()) {
+		if u.GetEmail() == "" {
+			return apierrors.NewInternalServerError("Unable to send email to a user with an empty email address")
+		}
+
+		if !a.checkEmailAddressAuthorization(u.GetEmail()) {
 			return apierrors.NewBadRequestError(apierrors.ErrorCodeEmailAddressNotAuthorized, "Email address %q cannot be used as it is not authorized", u.GetEmail())
 		}
 	} else {
+		if u.EmailChange == "" {
+			return apierrors.NewInternalServerError("Unable to change email address of user to an empty value")
+		}
+
 		// first check that the user can update their address to the
 		// new one in u.EmailChange
 		if u.EmailChange != "" && !a.checkEmailAddressAuthorization(u.EmailChange) {


### PR DESCRIPTION
Sad but true. Empty email address "send" was considered successful.