### PR TITLE
mailer: refactor mail client wiring and add validation wrapper

### DIFF
--- a/internal/mailer/mailme.go
+++ b/internal/mailer/mailme.go
@@ -25,18 +25,17 @@ const TemplateExpiration = 10 * time.Second
 
 // MailmeMailer lets MailMe send templated mails
 type MailmeMailer struct {
-	From           string
-	Host           string
-	Port           int
-	User           string
-	Pass           string
-	BaseURL        string
-	LocalName      string
-	FuncMap        template.FuncMap
-	cache          *TemplateCache
-	Logger         logrus.FieldLogger
-	MailLogging    bool
-	EmailValidator *EmailValidator
+	From        string
+	Host        string
+	Port        int
+	User        string
+	Pass        string
+	BaseURL     string
+	LocalName   string
+	FuncMap     template.FuncMap
+	cache       *TemplateCache
+	Logger      logrus.FieldLogger
+	MailLogging bool
 }
 
 // Mail sends a templated mail. It will try to load the template from a URL, and
@@ -56,12 +55,6 @@ func (m *MailmeMailer) Mail(
 			templates: map[string]*MailTemplate{},
 			funcMap:   m.FuncMap,
 			logger:    m.Logger,
-		}
-	}
-
-	if m.EmailValidator != nil {
-		if err := m.EmailValidator.Validate(ctx, to); err != nil {
-			return err
 		}
 	}
 

--- a/internal/mailer/template.go
+++ b/internal/mailer/template.go
@@ -36,9 +36,9 @@ type MailClient interface {
 
 // TemplateMailer will send mail and use templates from the site for easy mail styling
 type TemplateMailer struct {
-	SiteURL string
-	Config  *conf.GlobalConfiguration
-	Mailer  MailClient
+	SiteURL    string
+	Config     *conf.GlobalConfiguration
+	MailClient MailClient
 }
 
 func encodeRedirectURL(referrerURL string) string {
@@ -157,7 +157,7 @@ func (m *TemplateMailer) InviteMail(r *http.Request, user *models.User, otp, ref
 		"RedirectTo":      referrerURL,
 	}
 
-	return m.Mailer.Mail(
+	return m.MailClient.Mail(
 		r.Context(),
 		user.GetEmail(),
 		withDefault(m.Config.Mailer.Subjects.Invite, "You have been invited"),
@@ -190,7 +190,7 @@ func (m *TemplateMailer) ConfirmationMail(r *http.Request, user *models.User, ot
 		"RedirectTo":      referrerURL,
 	}
 
-	return m.Mailer.Mail(
+	return m.MailClient.Mail(
 		r.Context(),
 		user.GetEmail(),
 		withDefault(m.Config.Mailer.Subjects.Confirmation, "Confirm Your Email"),
@@ -211,7 +211,7 @@ func (m *TemplateMailer) ReauthenticateMail(r *http.Request, user *models.User, 
 		"Data":    user.UserMetaData,
 	}
 
-	return m.Mailer.Mail(
+	return m.MailClient.Mail(
 		r.Context(),
 		user.GetEmail(),
 		withDefault(m.Config.Mailer.Subjects.Reauthentication, "Confirm reauthentication"),
@@ -281,7 +281,7 @@ func (m *TemplateMailer) EmailChangeMail(r *http.Request, user *models.User, otp
 				"Data":            user.UserMetaData,
 				"RedirectTo":      referrerURL,
 			}
-			errors <- m.Mailer.Mail(
+			errors <- m.MailClient.Mail(
 				ctx,
 				address,
 				withDefault(m.Config.Mailer.Subjects.EmailChange, "Confirm Email Change"),
@@ -323,7 +323,7 @@ func (m *TemplateMailer) RecoveryMail(r *http.Request, user *models.User, otp, r
 		"RedirectTo":      referrerURL,
 	}
 
-	return m.Mailer.Mail(
+	return m.MailClient.Mail(
 		r.Context(),
 		user.GetEmail(),
 		withDefault(m.Config.Mailer.Subjects.Recovery, "Reset Your Password"),
@@ -356,7 +356,7 @@ func (m *TemplateMailer) MagicLinkMail(r *http.Request, user *models.User, otp, 
 		"RedirectTo":      referrerURL,
 	}
 
-	return m.Mailer.Mail(
+	return m.MailClient.Mail(
 		r.Context(),
 		user.GetEmail(),
 		withDefault(m.Config.Mailer.Subjects.MagicLink, "Your Magic Link"),


### PR DESCRIPTION
This change simplifies how MailClient instances are constructed and used:

- Introduce `NewMailClient` to encapsulate creation of the default `MailmeMailer` or `noopMailClient` based on configuration.
- Add `NewMailerWithClient` to allow injecting a custom `MailClient`.
- Extract email validation into `emailValidatorMailClient`, which wraps another `MailClient` and ensures `Validate` is always called before sending. Removed inline validation logic from `MailmeMailer`.
- Update `TemplateMailer` to consistently use `MailClient` instead of the previous `Mailer` field.
- Extend `noopMailClient` with an optional `Delay` field to simulate latency in tests.
- Clean up struct definitions by removing redundant `EmailValidator` from `MailmeMailer`.

Together, these changes make the mailer package easier to extend, improve separation of concerns, and provide hooks for testing latency and swapping in custom mail clients.