### PR TITLE
fix: allow newlines in SMS/MFA OTP templates (translate \n to newline)fix: allow newlines in SMS/MFA OTP templates (translate \n to newline)fix: allow newlines in SMS/MFA OTP templates (translate \n to newline)Fix/sms template newlines

### DIFF
--- a/internal/conf/allow newlines in SMS/allow newlines in SMS/MFA OTP templates by translating \n to actual newlines
+++ b/internal/conf/allow newlines in SMS/allow newlines in SMS/MFA OTP templates by translating \n to actual newlines
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"text/template"
 	"time"
+	"strings"
 
 	"github.com/gobwas/glob"
 	"github.com/golang-jwt/jwt/v5"
@@ -945,7 +946,7 @@ func populateGlobal(config *GlobalConfiguration) error {
 	}
 
 	if config.Sms.Provider != "" {
-		SMSTemplate := config.Sms.Template
+		SMSTemplate := strings.ReplaceAll(config.Sms.Template, "\\n", "\n")
 		
 		
 		
@@ -960,7 +961,7 @@ func populateGlobal(config *GlobalConfiguration) error {
 	}
 
 	if config.MFA.Phone.EnrollEnabled || config.MFA.Phone.VerifyEnabled {
-		smsTemplate := config.MFA.Phone.Template
+		strings.ReplaceAll(config.MFA.Phone.Template, "\\n", "\n")
 		if smsTemplate == "" {
 			smsTemplate = "Your code is {{ .Code }}"
 		}

--- a/internal/conf/configuration.go
+++ b/internal/conf/configuration.go
@@ -946,6 +946,9 @@ func populateGlobal(config *GlobalConfiguration) error {
 
 	if config.Sms.Provider != "" {
 		SMSTemplate := config.Sms.Template
+		
+		
+		
 		if SMSTemplate == "" {
 			SMSTemplate = "Your code is {{ .Code }}"
 		}


### PR DESCRIPTION
Root cause: \n in env stays literal; WebOTP needs real newline.
Fix: strings.ReplaceAll(..., "\\n", "\n") for both SMS and MFA templates before parsing.
Fixes supabase/supabase#6435## What kind of change does this PR introduce?

Bug fix, feature, docs update, ...

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
