### PR TITLE
fix: allow newlines in SMS/MFA OTP templates

### DIFF
--- a/internal/conf/configuration.go
+++ b/internal/conf/configuration.go
@@ -945,28 +945,28 @@ func populateGlobal(config *GlobalConfiguration) error {
 	}
 
 	if config.Sms.Provider != "" {
-		SMSTemplate := config.Sms.Template
-		if SMSTemplate == "" {
-			SMSTemplate = "Your code is {{ .Code }}"
-		}
-		template, err := template.New("").Parse(SMSTemplate)
-		if err != nil {
-			return err
-		}
-		config.Sms.SMSTemplate = template
-	}
+	SMSTemplate := strings.ReplaceAll(config.Sms.Template, "\\n", "\n")
+if SMSTemplate == "" {
+    SMSTemplate = "Your code is {{ .Code }}"
+}
+template, err := template.New("").Parse(SMSTemplate)
+if err != nil {
+    return err
+}
+config.Sms.SMSTemplate = template
 
-	if config.MFA.Phone.EnrollEnabled || config.MFA.Phone.VerifyEnabled {
-		smsTemplate := config.MFA.Phone.Template
-		if smsTemplate == "" {
-			smsTemplate = "Your code is {{ .Code }}"
-		}
-		template, err := template.New("").Parse(smsTemplate)
-		if err != nil {
-			return err
-		}
-		config.MFA.Phone.SMSTemplate = template
-	}
+if config.MFA.Phone.EnrollEnabled || config.MFA.Phone.VerifyEnabled {
+    smsTemplate := strings.ReplaceAll(config.MFA.Phone.Template, "\\n", "\n")
+    if smsTemplate == "" {
+        smsTemplate = "Your code is {{ .Code }}"
+    }
+    template, err := template.New("").Parse(smsTemplate)
+    if err != nil {
+        return err
+    }
+    config.MFA.Phone.SMSTemplate = template
+}
+
 
 	return nil
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix - Allows newlines (\n) in SMS and MFA OTP templates to be properly converted to actual newlines in the template parsing.

## What is the current behavior?

Currently, when users include `\n` in SMS or MFA phone OTP templates expecting newlines, these escaped newline characters are not converted to actual newlines. This means multi-line SMS templates don't work as expected.

## What is the new behavior?

The fix adds `strings.ReplaceAll(template, "\\n", "\n")` processing for both SMS and MFA phone templates before parsing. This allows users to include `\n` in their template configuration and have it properly converted to actual newlines in the final SMS message.

## Additional context

This change affects both:
- Regular SMS templates (`config.Sms.Template`) 
- MFA phone templates (`config.MFA.Phone.Template`)

## What kind of change does this PR introduce?

Bug fix - Allows newlines (\n) in SMS and MFA OTP templates to be properly converted to actual newlines in the template parsing.

## What is the current behavior?

Currently, when users include `\n` in SMS or MFA phone OTP templates expecting newlines, these escaped newline characters are not converted to actual newlines. This means multi-line SMS templates don't work as expected.

## What is the new behavior?

The fix adds `strings.ReplaceAll(template, "\\n", "\n")` processing for both SMS and MFA phone templates before parsing. This allows users to include `\n` in their template configuration and have it properly converted to actual newlines in the final SMS message.

## Additional context

This change affects both:
- Regular SMS templates (`config.Sms.Template`) 
- MFA phone templates (`config.MFA.Phone.Template`)

## What kind of change does this PR introduce?

Bug fix - Allows newlines (\n) in SMS and MFA OTP templates to be properly converted to actual newlines.

## What is the current behavior?

Currently, when users include `\n` in SMS or MFA phone OTP templates expecting newlines, these escaped newline characters are not converted to actual newlines. This means multi-line SMS templates don't work as expected.

## What is the new behavior?

This fix adds `strings.ReplaceAll(template, "\\n", "\n")` processing for both SMS and MFA phone templates before parsing. This allows users to include `\n` in their template configuration and have it properly converted to actual newlines in the final SMS message.

## Additional context

This change affects both regular SMS templates (`config.Sms.Template`) and MFA phone templates (`config.MFA.Phone.Template`). The fix is applied consistently to both template processing paths in the `populateGlobal` function within `internal/conf/configuration.go`.The fix is applied consistently to both template processing paths in the `populateGlobal` function within `internal/conf/configuration.go`.The fix is applied consistently to both template processing paths in the `populateGlobal` function within `internal/conf/configuration.go`.## What kind of change does this PR introduce?

Bug fix, feature, docs update, ...

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
