### PR TITLE
feat: add xz-compressed release artifacts and stripped binary build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,11 +90,13 @@ jobs:
           set -ex
 
           RELEASE_VERSION=$RELEASE_VERSION make deps
-          RELEASE_VERSION=$RELEASE_VERSION make all
+          RELEASE_VERSION=$RELEASE_VERSION make all build-strip
           ln -s auth gotrue
           tar -czvf auth-v$RELEASE_VERSION-x86.tar.gz auth gotrue migrations/
           mv auth-arm64 auth
           tar -czvf auth-v$RELEASE_VERSION-arm64.tar.gz auth gotrue migrations/
+          mv auth-arm64 auth
+          tar -cf - auth gotrue migrations/ | xz -T0 -9e -C crc64 > auth-v$RELEASE_VERSION-arm64.tar.xz
 
       - name: Generate checksums
         if: ${{ steps.release.outputs.release_created == 'true' || steps.release.outputs.prs_created == 'true' }}
@@ -105,7 +107,7 @@ jobs:
             local hash_type=$1
             local hash_cmd=$2
             echo "### ${hash_type}" >> checksums.txt
-            for file in auth-v$RELEASE_VERSION*.tar.gz; do
+            for file in auth-v$RELEASE_VERSION*.tar.{gz,xz}; do
               echo "\`$file\`:" >> checksums.txt
               echo "\`\`\`" >> checksums.txt
               $hash_cmd "$file" | awk '{print $1}' >> checksums.txt
@@ -187,8 +189,11 @@ jobs:
 
           GH_TOKEN='${{ github.token }}' gh release upload $RELEASE_NAME ./auth-v$RELEASE_VERSION-x86.tar.gz ./auth-v$RELEASE_VERSION-arm64.tar.gz
 
+          GH_TOKEN='${{ github.token }}' gh release upload $RELEASE_NAME ./auth-v$RELEASE_VERSION-x86.tar.xz ./auth-v$RELEASE_VERSION-arm64.tar.xz
+
           aws s3 cp ./auth-v$RELEASE_VERSION-arm64.tar.gz s3://supabase-internal-artifacts/auth/$RELEASE_VERSION/
           aws s3 cp ./auth-v$RELEASE_VERSION-x86.tar.gz s3://supabase-internal-artifacts/auth/$RELEASE_VERSION/
+          aws s3 cp ./auth-v$RELEASE_VERSION-x86.tar.xz s3://supabase-internal-artifacts/auth/$RELEASE_VERSION/
 
   publish:
     needs:

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,10 @@ build: deps ## Build the binary.
 	CGO_ENABLED=0 go build $(FLAGS)
 	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build $(FLAGS) -o auth-arm64
 
+build-strip: deps ## Build a stripped binary.
+	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build \
+		$(FLAGS) -ldflags "-s -w" -o auth-arm64-strip
+
 dev-deps: ## Install developer dependencies
 	@go install github.com/gobuffalo/pop/soda@latest
 	@go install github.com/securego/gosec/v2/cmd/gosec@latest


### PR DESCRIPTION
- Add `build-strip` target to Makefile to produce stripped binaries
- Update release workflow to:
  - build both regular and stripped binaries
  - generate `.tar.xz` artifacts alongside existing `.tar.gz`
  - include `.xz` files in checksum generation
  - upload `.xz` artifacts to GitHub Releases and S3

This reduces binary size for distribution while keeping compatibility with gzip.

Savings breakdown:
- 38,788,564 auth-arm64
- 26,738,840 auth-arm64 (stripped)
- 18,970,510 auth-arm64.tar.gz
-  9,657,140 auth-arm64.tar.gz (stripped)
-  6,794,836 auth-arm64.tar.xz (stripped, xz -9e)

Decompress xz with:
`tar -xvJf auth-arm64.tar.xz -C /path/to/dir`
