### PR TITLE
fix: stripped binary now includes version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ gotrue-arm64
 gotrue.exe
 auth
 auth-arm64
+auth-arm64-strip
 auth.exe
 
 coverage.out


### PR DESCRIPTION
Stripping removed the symbol encoding the version. Now the stripped binary rewrites the version file before build.