### PR TITLE
feat: background template reloading p2 - mailer template cache & interface refactor

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -42,6 +42,7 @@ type API struct {
 	hibpClient   *hibp.PwnedClient
 	oauthServer  *oauthserver.Server
 	tokenService *tokens.Service
+	mailer       mailer.Mailer
 
 	// overrideTime can be used to override the clock used by handlers. Should only be used in tests!
 	overrideTime func() time.Time
@@ -52,6 +53,7 @@ type API struct {
 func (a *API) GetConfig() *conf.GlobalConfiguration { return a.config }
 func (a *API) GetDB() *storage.Connection           { return a.db }
 func (a *API) GetTokenService() *tokens.Service     { return a.tokenService }
+func (a *API) Mailer() mailer.Mailer                { return a.mailer }
 
 func (a *API) Version() string {
 	return a.version
@@ -108,6 +110,9 @@ func NewAPIWithVersion(globalConfig *conf.GlobalConfiguration, db *storage.Conne
 	// Initialize token service if not provided via options
 	if api.tokenService == nil {
 		api.tokenService = tokens.NewService(globalConfig, api.hooksMgr)
+	}
+	if api.mailer == nil {
+		api.mailer = newMailer(globalConfig)
 	}
 
 	// Connect token service to API's time function (supports test overrides)
@@ -366,11 +371,6 @@ func (a *API) HealthCheck(w http.ResponseWriter, r *http.Request) error {
 		Name:        "GoTrue",
 		Description: "GoTrue is a user registration and authentication API",
 	})
-}
-
-// Mailer returns NewMailer with the current tenant config
-func (a *API) Mailer() mailer.Mailer {
-	return newMailer(a.config)
 }
 
 // ServeHTTP implements the http.Handler interface by passing the request along

--- a/internal/api/mail.go
+++ b/internal/api/mail.go
@@ -31,7 +31,7 @@ import (
 )
 
 // newMailer returns a new gotrue mailer
-func newMailer(globalConfig *conf.GlobalConfiguration) *templatemailer.TemplateMailer {
+func newMailer(globalConfig *conf.GlobalConfiguration) *templatemailer.Mailer {
 	var mc mail.Client
 	if globalConfig.SMTP.Host == "" {
 		logrus.Infof("Noop mail client being used for %v", globalConfig.SiteURL)

--- a/internal/api/options.go
+++ b/internal/api/options.go
@@ -6,12 +6,29 @@ import (
 	"github.com/didip/tollbooth/v5"
 	"github.com/didip/tollbooth/v5/limiter"
 	"github.com/supabase/auth/internal/conf"
+	"github.com/supabase/auth/internal/mailer"
 	"github.com/supabase/auth/internal/ratelimit"
 	"github.com/supabase/auth/internal/tokens"
 )
 
 type Option interface {
 	apply(*API)
+}
+
+type optionFunc func(*API)
+
+func (f optionFunc) apply(a *API) { f(a) }
+
+func WithMailer(m mailer.Mailer) Option {
+	return optionFunc(func(a *API) {
+		a.mailer = m
+	})
+}
+
+func WithTokenService(service *tokens.Service) Option {
+	return optionFunc(func(a *API) {
+		a.tokenService = service
+	})
 }
 
 type LimiterOptions struct {
@@ -36,19 +53,6 @@ type LimiterOptions struct {
 }
 
 func (lo *LimiterOptions) apply(a *API) { a.limiterOpts = lo }
-
-// TokenServiceOption allows injecting a custom token service
-type TokenServiceOption struct {
-	service *tokens.Service
-}
-
-func WithTokenService(service *tokens.Service) *TokenServiceOption {
-	return &TokenServiceOption{service: service}
-}
-
-func (tso *TokenServiceOption) apply(a *API) {
-	a.tokenService = tso.service
-}
 
 func NewLimiterOptions(gc *conf.GlobalConfiguration) *LimiterOptions {
 	o := &LimiterOptions{}

--- a/internal/mailer/mailer.go
+++ b/internal/mailer/mailer.go
@@ -31,14 +31,13 @@ type Mailer interface {
 	GetEmailActionLink(user *models.User, actionType, referrerURL string, externalURL *url.URL) (string, error)
 }
 
+// TODO(cstockton): Mail(...) -> Mail(Email{...}) ?
 type Client interface {
 	Mail(
 		ctx context.Context,
 		to string,
-		subjectTemplate string,
-		templateURL string,
-		defaultTemplate string,
-		templateData map[string]any,
+		subject string,
+		body string,
 		headers map[string][]string,
 		typ string,
 	) error

--- a/internal/mailer/mailmeclient/mailmeclient.go
+++ b/internal/mailer/mailmeclient/mailmeclient.go
@@ -3,17 +3,8 @@
 package mailmeclient
 
 import (
-	"bytes"
 	"context"
-	"errors"
-	"html/template"
-	"io"
-	"log"
-	"net/http"
 	"net/url"
-	"strings"
-	"sync"
-	"time"
 
 	"gopkg.in/gomail.v2"
 
@@ -21,26 +12,17 @@ import (
 	"github.com/supabase/auth/internal/conf"
 )
 
-// templateRetries is the amount of time MailMe will try to fetch a URL before giving up
-const templateRetries = 3
-
-// templateExpiration is the time period that the template will be cached for
-const templateExpiration = 10 * time.Second
-
 // Client lets MailMe send templated mails
 type Client struct {
-	From        string
-	Host        string
-	Port        int
-	User        string
-	Pass        string
-	BaseURL     string
-	LocalName   string
-	FuncMap     template.FuncMap
+	From      string
+	Host      string
+	Port      int
+	User      string
+	Pass      string
+	LocalName string
+
 	Logger      logrus.FieldLogger
 	MailLogging bool
-
-	cache *templateCache
 }
 
 // New returns a new *Mailer based on the given configuration.
@@ -54,7 +36,6 @@ func New(globalConfig *conf.GlobalConfiguration) *Client {
 		Pass:        globalConfig.SMTP.Pass,
 		LocalName:   u.Hostname(),
 		From:        from,
-		BaseURL:     globalConfig.SiteURL,
 		Logger:      logrus.StandardLogger(),
 		MailLogging: globalConfig.SMTP.LoggingEnabled,
 	}
@@ -64,42 +45,16 @@ func New(globalConfig *conf.GlobalConfiguration) *Client {
 // otherwise fall back to the default
 func (m *Client) Mail(
 	ctx context.Context,
-	to, subjectTemplate, templateURL, defaultTemplate string,
-	templateData map[string]any,
+	to string,
+	subject string,
+	body string,
 	headers map[string][]string,
 	typ string,
 ) error {
-	if m.FuncMap == nil {
-		m.FuncMap = map[string]any{}
-	}
-	if m.cache == nil {
-		m.cache = &templateCache{
-			templates: map[string]*mailTemplate{},
-			funcMap:   m.FuncMap,
-			logger:    m.Logger,
-		}
-	}
-
-	tmp, err := template.New("Subject").Funcs(template.FuncMap(m.FuncMap)).Parse(subjectTemplate)
-	if err != nil {
-		return err
-	}
-
-	subject := &bytes.Buffer{}
-	err = tmp.Execute(subject, templateData)
-	if err != nil {
-		return err
-	}
-
-	body, err := m.mailBody(templateURL, defaultTemplate, templateData)
-	if err != nil {
-		return err
-	}
-
 	mail := gomail.NewMessage()
 	mail.SetHeader("From", m.From)
 	mail.SetHeader("To", to)
-	mail.SetHeader("Subject", subject.String())
+	mail.SetHeader("Subject", subject)
 
 	for k, v := range headers {
 		if v != nil {
@@ -129,117 +84,4 @@ func (m *Client) Mail(
 		return err
 	}
 	return nil
-}
-
-type mailTemplate struct {
-	tmp       *template.Template
-	expiresAt time.Time
-}
-
-type templateCache struct {
-	templates map[string]*mailTemplate
-	mutex     sync.Mutex
-	funcMap   template.FuncMap
-	logger    logrus.FieldLogger
-}
-
-func (t *templateCache) Get(url string) (*template.Template, error) {
-	cached, ok := t.templates[url]
-	if ok && (cached.expiresAt.Before(time.Now())) {
-		return cached.tmp, nil
-	}
-	data, err := t.fetchTemplate(url, templateRetries)
-	if err != nil {
-		return nil, err
-	}
-	return t.Set(url, data, templateExpiration)
-}
-
-func (t *templateCache) Set(key, value string, expirationTime time.Duration) (*template.Template, error) {
-	parsed, err := template.New(key).Funcs(t.funcMap).Parse(value)
-	if err != nil {
-		return nil, err
-	}
-
-	cached := &mailTemplate{
-		tmp:       parsed,
-		expiresAt: time.Now().Add(expirationTime),
-	}
-	t.mutex.Lock()
-	t.templates[key] = cached
-	t.mutex.Unlock()
-	return parsed, nil
-}
-
-func (t *templateCache) fetchTemplate(url string, triesLeft int) (string, error) {
-	client := &http.Client{
-		Timeout: 10 * time.Second,
-	}
-
-	resp, err := client.Get(url)
-	if err != nil && triesLeft > 0 {
-		return t.fetchTemplate(url, triesLeft-1)
-	}
-	if err != nil {
-		return "", err
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode == 200 { // OK
-		bodyBytes, err := io.ReadAll(resp.Body)
-		if err != nil && triesLeft > 0 {
-			return t.fetchTemplate(url, triesLeft-1)
-		}
-		if err != nil {
-			return "", err
-		}
-		return string(bodyBytes), err
-	}
-	if triesLeft > 0 {
-		return t.fetchTemplate(url, triesLeft-1)
-	}
-	return "", errors.New("mailer: unable to fetch mail template")
-}
-
-func (m *Client) mailBody(url string, defaultTemplate string, data map[string]any) (string, error) {
-	if m.FuncMap == nil {
-		m.FuncMap = map[string]any{}
-	}
-	if m.cache == nil {
-		m.cache = &templateCache{templates: map[string]*mailTemplate{}, funcMap: m.FuncMap}
-	}
-
-	var temp *template.Template
-	var err error
-
-	if url != "" {
-		var absoluteURL string
-		if strings.HasPrefix(url, "http") {
-			absoluteURL = url
-		} else {
-			absoluteURL = m.BaseURL + url
-		}
-		temp, err = m.cache.Get(absoluteURL)
-		if err != nil {
-			log.Printf("Error loading template from %v: %v\n", url, err)
-		}
-	}
-
-	if temp == nil {
-		cached, ok := m.cache.templates[url]
-		if ok {
-			temp = cached.tmp
-		} else {
-			temp, err = m.cache.Set(url, defaultTemplate, 0)
-			if err != nil {
-				return "", err
-			}
-		}
-	}
-
-	buf := &bytes.Buffer{}
-	err = temp.Execute(buf, data)
-	if err != nil {
-		return "", err
-	}
-	return buf.String(), nil
 }

--- a/internal/mailer/noopclient/noopclient.go
+++ b/internal/mailer/noopclient/noopclient.go
@@ -18,8 +18,9 @@ func New() *Client {
 
 func (m *Client) Mail(
 	ctx context.Context,
-	to, subjectTemplate, templateURL, defaultTemplate string,
-	templateData map[string]any,
+	to string,
+	subject string,
+	body string,
 	headers map[string][]string,
 	typ string,
 ) error {

--- a/internal/mailer/taskclient/taskclient.go
+++ b/internal/mailer/taskclient/taskclient.go
@@ -27,13 +27,11 @@ func New(globalConfig *conf.GlobalConfiguration, mc mailer.Client) mailer.Client
 type Task struct {
 	mc mailer.Client
 
-	To              string              `json:"to"`
-	SubjectTemplate string              `json:"subject_template"`
-	TemplateURL     string              `json:"template_url"`
-	DefaultTemplate string              `json:"default_template"`
-	TemplateData    map[string]any      `json:"template_data"`
-	Headers         map[string][]string `json:"headers"`
-	Typ             string              `json:"typ"`
+	To      string              `json:"to"`
+	Subject string              `json:"subject"`
+	Body    string              `json:"body"`
+	Headers map[string][]string `json:"headers"`
+	Typ     string              `json:"typ"`
 }
 
 // Run implements the Type method of the apitask.Task interface by returning
@@ -46,10 +44,8 @@ func (o *Task) Run(ctx context.Context) error {
 	return o.mc.Mail(
 		ctx,
 		o.To,
-		o.SubjectTemplate,
-		o.TemplateURL,
-		o.DefaultTemplate,
-		o.TemplateData,
+		o.Subject,
+		o.Body,
 		o.Headers,
 		o.Typ)
 }
@@ -63,22 +59,18 @@ type backgroundMailClient struct {
 func (o *backgroundMailClient) Mail(
 	ctx context.Context,
 	to string,
-	subjectTemplate string,
-	templateURL string,
-	defaultTemplate string,
-	templateData map[string]any,
+	subject string,
+	body string,
 	headers map[string][]string,
 	typ string,
 ) error {
 	tk := &Task{
-		mc:              o.mc,
-		To:              to,
-		SubjectTemplate: subjectTemplate,
-		TemplateURL:     templateURL,
-		DefaultTemplate: defaultTemplate,
-		TemplateData:    templateData,
-		Headers:         headers,
-		Typ:             typ,
+		mc:      o.mc,
+		To:      to,
+		Subject: subject,
+		Body:    body,
+		Headers: headers,
+		Typ:     typ,
 	}
 	return apitask.Run(ctx, tk)
 }

--- a/internal/mailer/templatemailer/template.go
+++ b/internal/mailer/templatemailer/template.go
@@ -1,0 +1,458 @@
+package templatemailer
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"html/template"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"github.com/supabase/auth/internal/conf"
+	"github.com/supabase/auth/internal/mailer"
+	"github.com/supabase/auth/internal/observability"
+	"golang.org/x/sync/singleflight"
+)
+
+func init() {
+	// Ensure every TemplateType has a default subject & body.
+	if err := checkDefaults(); err != nil {
+		panic(err)
+	}
+}
+
+const (
+	maxTemplateSize = 10_000_000
+	maxTemplateAge  = time.Second * 10
+	maxTemplateIval = maxTemplateAge / 4
+)
+
+// Mailer will send mail and use templates from the site for easy mail styling
+type Mailer struct {
+	cfg *conf.GlobalConfiguration
+	tc  *tplCache
+	mc  mailer.Client
+}
+
+// New will return a *TemplateMailer backed by the given mailer.Client.
+func New(globalConfig *conf.GlobalConfiguration, mc mailer.Client) *Mailer {
+	return &Mailer{
+		cfg: globalConfig,
+		tc:  newTplCache(globalConfig),
+		mc:  mc,
+	}
+}
+
+func (m *Mailer) mail(
+	ctx context.Context,
+	tpl string,
+	to string,
+	data map[string]any,
+) error {
+	if _, ok := lookupEmailContentConfig(&m.cfg.Mailer.Subjects, tpl); !ok {
+		return fmt.Errorf("templatemailer: template type: %s is invalid", tpl)
+	}
+
+	// This is to match the previous behavior, which sent a "reauthenticate"
+	// header instead of the same name as template.
+	typ := tpl
+	if typ == ReauthenticationTemplate {
+		typ = "reauthenticate"
+	}
+	headers := m.Headers(typ)
+
+	ent, err := m.tc.get(ctx, tpl)
+	if err != nil {
+		return err
+	}
+
+	var buf bytes.Buffer
+	subject, body, err := ent.execute(&buf, data)
+	if err != nil {
+		return err
+	}
+	return m.mc.Mail(
+		ctx,
+		to,
+		subject,
+		body,
+		headers,
+		typ,
+	)
+}
+
+type tplCacheEntry struct {
+	createdAt time.Time
+	checkedAt time.Time
+	typ       string
+	subject   *template.Template
+	body      *template.Template
+}
+
+func newTplCacheEntry(
+	at time.Time,
+	typ string,
+	subject, body *template.Template,
+) *tplCacheEntry {
+	return &tplCacheEntry{
+		createdAt: at,
+		checkedAt: at,
+		typ:       typ,
+		body:      subject,
+		subject:   body,
+	}
+}
+
+func (ent *tplCacheEntry) copy() *tplCacheEntry {
+	cpy := *ent
+	return &cpy
+}
+
+func (ent *tplCacheEntry) execute(
+	buf *bytes.Buffer,
+	data map[string]any,
+) (subject string, body string, err error) {
+	if err = ent.subject.Execute(buf, data); err != nil {
+		return "", "", err
+	}
+	subject = buf.String()
+
+	buf.Reset()
+	if err = ent.body.Execute(buf, data); err != nil {
+		return "", "", err
+	}
+	body = buf.String()
+	return subject, body, nil
+}
+
+type tplCache struct {
+	cfg *conf.GlobalConfiguration
+	sf  singleflight.Group
+	now func() time.Time
+
+	maxSize int
+	maxAge  time.Duration
+	maxIval time.Duration
+
+	// Must hold mu for below field access
+	mu sync.Mutex
+	m  map[string]*tplCacheEntry
+}
+
+func newTplCache(cfg *conf.GlobalConfiguration) *tplCache {
+	return &tplCache{
+		cfg:     cfg,
+		m:       make(map[string]*tplCacheEntry),
+		now:     time.Now,
+		maxSize: maxTemplateSize,
+		maxAge:  maxTemplateAge,
+		maxIval: maxTemplateIval,
+	}
+}
+
+func (o *tplCache) getEntry(typ string) (*tplCacheEntry, bool) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	v, ok := o.m[typ]
+	return v, ok
+}
+
+func (o *tplCache) putEntry(typ string, ent *tplCacheEntry) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	o.m[typ] = ent
+}
+
+// get is the method called to fetch an entry from the cache.
+func (o *tplCache) get(
+	ctx context.Context,
+	typ string,
+) (*tplCacheEntry, error) {
+	ent, ok := o.getEntry(typ)
+	if !ok {
+		// Cache miss, straight to load with no current entry.
+		return o.load(ctx, typ, nil)
+	}
+
+	now := o.now()
+	if now.Sub(ent.createdAt) < o.maxAge {
+		// Cache hit and the entry is not expired, return it.
+		return ent, nil
+	}
+
+	// Entry is expired, we check if the entry is ready for reloading. We do
+	// as much as we can outside of load to prevent synchronization on o.sf.
+	if now.Sub(ent.checkedAt) < o.maxIval {
+		// Entry was checked within maxIval, return it.
+		return ent, nil
+	}
+
+	// Call load with our most recent entry.
+	return o.load(ctx, typ, ent)
+}
+
+// load is what happens when "get" has a cache miss, the hit has expired or
+// the a previously failed check has elapsed the ival.
+func (o *tplCache) load(
+	ctx context.Context,
+	typ string,
+	cur *tplCacheEntry,
+) (*tplCacheEntry, error) {
+
+	// Before load returns, forget the most recent result of sf. Because we
+	// write our cache result in Do we guarantee that the next call to SF
+	// after this function returns will be a cache hit.
+	defer o.sf.Forget(typ)
+
+	// We prevent a recently restarted auth server from sending multiple
+	// concurrent requests to the templating endpoint with pkg singleflight.
+	v, err, _ := o.sf.Do(typ, func() (any, error) {
+
+		// First try to load a fresh entry.
+		ent, err := o.loadEntry(ctx, typ)
+		if err == nil {
+			// No error fetching fresh entry, put in cache & return it.
+			o.putEntry(typ, ent)
+			return ent, nil
+		}
+
+		// We had an err loading a fresh entry. Check if we had a current entry
+		// and return a copy of that with a last checked time.
+		if cur != nil {
+			cpy := ent.copy()
+			cpy.checkedAt = o.now()
+
+			o.putEntry(typ, cpy)
+			return cpy, nil
+		}
+
+		// We have no previous entry and no fresh entry, we will load the
+		// default templates so the user can continue serving requests.
+		//
+		// TODO(cstockton): These should be checked more eagerly than a cache hit
+		ent = o.loadEntryDefault(typ)
+		o.putEntry(typ, ent)
+		return ent, nil
+	})
+	if err != nil {
+		// I don't believe SF returns an error unless the fn it calls does, so
+		// this is mostly a defensive check.
+		err = wrapError(ctx, typ, "internal_error", err)
+		return nil, err
+	}
+
+	// v is always a *tplCacheEntry
+	return v.(*tplCacheEntry), nil
+}
+
+// loadEntry returns the
+func (o *tplCache) loadEntry(
+	ctx context.Context,
+	typ string,
+) (*tplCacheEntry, error) {
+	subjectTemp, err := o.loadEntrySubject(ctx, typ)
+	if err != nil {
+		return nil, err
+	}
+
+	bodyTemp, err := o.loadEntryBody(ctx, typ)
+	if err != nil {
+		return nil, err
+	}
+
+	now := o.now()
+	ent := newTplCacheEntry(now, typ, subjectTemp, bodyTemp)
+	return ent, nil
+}
+
+// loadEntryDefault will never fail due to the checkDefaults() in init().
+func (o *tplCache) loadEntryDefault(
+	typ string,
+) *tplCacheEntry {
+	subjectStr := getEmailContentConfig(defaultTemplateSubjects, typ, "")
+	subjectTemp := template.Must(template.New("").Parse(subjectStr))
+
+	bodyStr := getEmailContentConfig(defaultTemplateBodies, typ, "")
+	bodyTemp := template.Must(template.New("").Parse(bodyStr))
+
+	now := o.now()
+	ent := newTplCacheEntry(now, typ, subjectTemp, bodyTemp)
+	return ent
+}
+
+func (o *tplCache) loadEntrySubject(
+	ctx context.Context,
+	typ string,
+) (*template.Template, error) {
+
+	// This matches the existing behavior, which allow for a potential double
+	// parse of the default but it's a minor cost for clean control flow.
+	tempStr := getEmailContentConfig(
+		&o.cfg.Mailer.Subjects,
+		typ,
+		getEmailContentConfig(defaultTemplateSubjects, typ, ""))
+
+	temp, err := template.New("Subject").Parse(tempStr)
+	if err != nil {
+		err = wrapError(ctx, typ, "template_subject_parse_error", err)
+		return nil, err
+	}
+	return temp, nil
+}
+
+func (o *tplCache) loadEntryBody(
+	ctx context.Context,
+	typ string,
+) (*template.Template, error) {
+	url := getEmailContentConfig(&o.cfg.Mailer.Templates, typ, "")
+	if url == "" {
+
+		// We preserve the previous behavior of returning the default.
+		tempStr := getEmailContentConfig(defaultTemplateBodies, typ, "")
+		temp := template.Must(template.New("").Parse(tempStr))
+		return temp, nil
+	}
+	if !strings.HasPrefix(url, "http") {
+		url = o.cfg.SiteURL + url
+	}
+
+	tempStr, err := o.fetch(ctx, url)
+	if err != nil {
+		err = wrapError(ctx, typ, "template_body_http_error", err)
+		return nil, err
+	}
+
+	temp, err := template.New(url).Parse(tempStr)
+	if err != nil {
+		err = wrapError(ctx, typ, "template_body_parse_error", err)
+		return nil, err
+	}
+	return temp, nil
+}
+
+func (m *tplCache) fetch(ctx context.Context, url string) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return "", err
+	}
+
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer res.Body.Close()
+
+	rdr := io.LimitReader(res.Body, maxTemplateSize)
+	data, err := io.ReadAll(rdr)
+	if err != nil {
+		return "", err
+	}
+
+	body := string(data)
+	return body, nil
+}
+
+func wrapError(ctx context.Context, typ, label string, err error) error {
+	if err == nil {
+		return nil
+	}
+
+	err = fmt.Errorf(
+		"templatemailer: template type %q: %w", typ, err)
+	le := observability.GetLogEntryFromContext(ctx).Entry
+	le.WithFields(logrus.Fields{
+		"event":     "templatemailer_" + label,
+		"mail_type": typ,
+	}).WithError(err).Error(err)
+	return err
+}
+
+func lookupEmailContentConfig(
+	cfg *conf.EmailContentConfiguration,
+	tpl string,
+) (string, bool) {
+	switch tpl {
+	default:
+		return "", false
+	case InviteTemplate:
+		return cfg.Invite, true
+	case ConfirmationTemplate:
+		return cfg.Confirmation, true
+	case RecoveryTemplate:
+		return cfg.Recovery, true
+	case EmailChangeTemplate:
+		return cfg.EmailChange, true
+	case ReauthenticationTemplate:
+		return cfg.Reauthentication, true
+	case MagicLinkTemplate:
+		return cfg.MagicLink, true
+	}
+}
+
+func getEmailContentConfig(
+	cfg *conf.EmailContentConfiguration,
+	tpl string,
+	def string,
+) string {
+	// This matches behavior of old withDefault ("" != v)
+	if v, ok := lookupEmailContentConfig(cfg, tpl); ok && v != "" {
+		return v
+	}
+	return def
+}
+
+func checkDefaults() error {
+	seen := make(map[string]bool)
+	data := map[string]any{
+		"ConfirmationURL": "ConfirmationURL",
+		"Data":            "Data",
+		"Email":           "Email",
+		"NewEmail":        "NewEmail",
+		"RedirectTo":      "RedirectTo",
+		"SendingTo":       "SendingTo",
+		"SiteURL":         "SiteURL",
+		"Token":           "Token",
+		"TokenHash":       "TokenHash",
+	}
+
+	buf := new(bytes.Buffer)
+	check := func(cfg *conf.EmailContentConfiguration, typ string) error {
+		defer buf.Reset()
+
+		tempStr, ok := lookupEmailContentConfig(cfg, typ)
+		if !ok {
+			return fmt.Errorf(
+				"templatemailer: template type %q: missing default body template", typ)
+		}
+
+		temp, err := template.New(typ).Parse(tempStr)
+		if err != nil {
+			return err
+		}
+
+		if err := temp.Execute(buf, data); err != nil {
+			return err
+		}
+		return nil
+	}
+
+	for _, typ := range templateTypes {
+		if seen[typ] {
+			return fmt.Errorf(
+				"templatemailer: template type %q: duplicate found", typ)
+		}
+		seen[typ] = true
+
+		if err := check(defaultTemplateSubjects, typ); err != nil {
+			return err
+		}
+		if err := check(defaultTemplateBodies, typ); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/mailer/templatemailer/templatemailer_test.go
+++ b/internal/mailer/templatemailer/templatemailer_test.go
@@ -50,14 +50,14 @@ func TestTemplateHeaders(t *testing.T) {
 		},
 	}
 	for _, tc := range cases {
-		mailer := TemplateMailer{
-			Config: &conf.GlobalConfiguration{
+		mailer := Mailer{
+			cfg: &conf.GlobalConfiguration{
 				SMTP: conf.SMTPConfiguration{
 					Headers: tc.from,
 				},
 			},
 		}
-		require.NoError(t, mailer.Config.SMTP.Validate())
+		require.NoError(t, mailer.cfg.SMTP.Validate())
 
 		hdrs := mailer.Headers(tc.typ)
 		require.Equal(t, hdrs, tc.exp)

--- a/internal/mailer/validateclient/validateclient.go
+++ b/internal/mailer/validateclient/validateclient.go
@@ -101,10 +101,8 @@ type emailValidatorMailClient struct {
 func (o *emailValidatorMailClient) Mail(
 	ctx context.Context,
 	to string,
-	subjectTemplate string,
-	templateURL string,
-	defaultTemplate string,
-	templateData map[string]any,
+	subject string,
+	body string,
 	headers map[string][]string,
 	typ string,
 ) error {
@@ -114,10 +112,8 @@ func (o *emailValidatorMailClient) Mail(
 	return o.mc.Mail(
 		ctx,
 		to,
-		subjectTemplate,
-		templateURL,
-		defaultTemplate,
-		templateData,
+		subject,
+		body,
 		headers,
 		typ,
 	)


### PR DESCRIPTION
**Summary**
This PR builds on [auth#2148](https://github.com/supabase/auth/pull/2148) to deliver phase 2, a robust template cache plus a simplified mail client interface. Templates are now rendered once per type, cached with controlled refresh, and then delivered via clients that only send pre-rendered subject/body. This reduces latency and removes templating logic from SMTP clients while preserving current behavior. It will also pave the way for alternative Mailer implementations.

**Template cache + interface refactor**
* Replace `TemplateMailer` with `templatemailer.Mailer` that owns all templating and a shared cache. Entries have a TTL and a shorter “recheck interval”; on fetch/parse errors we serve the last good or fall back to built-in defaults.
* Centralize default subjects/bodies and validate them at init. Typed template keys are: `invite`, `confirmation, recovery`, `email_change`, `magic_link`, `reauthentication`.
* Move headers logic into the mailer; keep `$messageType` substitution and the legacy “reauthenticate” header name for compatibility.
* Change `mailer.Client.Mail` to `(ctx, to, subject, body, headers, typ)` and update all clients accordingly (SMTP/Noop/Validate/Tasks).
* Persist a single mailer instance in `API`; add `WithMailer` for DI; remove on-demand construction.
