### PR TITLE
feat(oauth2): use `id` field as the public client_id

### DIFF
--- a/internal/api/oauthserver/client_auth_test.go
+++ b/internal/api/oauthserver/client_auth_test.go
@@ -298,7 +298,6 @@ func TestValidateClientAuthentication(t *testing.T) {
 	// Create test clients
 	publicClient := &models.OAuthServerClient{
 		ID:         uuid.Must(uuid.NewV4()),
-		ClientID:   "public_client",
 		ClientType: models.OAuthServerClientTypePublic,
 		// No client secret hash for public clients
 	}
@@ -307,7 +306,6 @@ func TestValidateClientAuthentication(t *testing.T) {
 	secretHash, _ := hashClientSecret("test_secret")
 	confidentialClient := &models.OAuthServerClient{
 		ID:               uuid.Must(uuid.NewV4()),
-		ClientID:         "confidential_client",
 		ClientType:       models.OAuthServerClientTypeConfidential,
 		ClientSecretHash: secretHash,
 	}

--- a/internal/api/oauthserver/handlers_test.go
+++ b/internal/api/oauthserver/handlers_test.go
@@ -167,7 +167,7 @@ func (ts *OAuthClientTestSuite) TestOAuthServerClientDynamicRegisterDisabled() {
 func (ts *OAuthClientTestSuite) TestOAuthServerClientGetHandler() {
 	client, _ := ts.createTestOAuthClient()
 
-	req := httptest.NewRequest(http.MethodGet, "/admin/oauth/clients/"+client.ClientID, nil)
+	req := httptest.NewRequest(http.MethodGet, "/admin/oauth/clients/"+client.ID.String(), nil)
 
 	ctx := WithOAuthServerClient(req.Context(), client)
 	req = req.WithContext(ctx)
@@ -183,7 +183,7 @@ func (ts *OAuthClientTestSuite) TestOAuthServerClientGetHandler() {
 	err = json.Unmarshal(w.Body.Bytes(), &response)
 	require.NoError(ts.T(), err)
 
-	assert.Equal(ts.T(), client.ClientID, response.ClientID)
+	assert.Equal(ts.T(), client.ID.String(), response.ClientID)
 	assert.Empty(ts.T(), response.ClientSecret) // Should NOT be included in get response
 	assert.Equal(ts.T(), "Test Client", response.ClientName)
 }
@@ -193,7 +193,7 @@ func (ts *OAuthClientTestSuite) TestOAuthServerClientDeleteHandler() {
 	client, _ := ts.createTestOAuthClient()
 
 	// Create HTTP request with client in context
-	req := httptest.NewRequest(http.MethodDelete, "/admin/oauth/clients/"+client.ClientID, nil)
+	req := httptest.NewRequest(http.MethodDelete, "/admin/oauth/clients/"+client.ID.String(), nil)
 
 	// Add client to context (normally done by LoadOAuthServerClient middleware)
 	ctx := WithOAuthServerClient(req.Context(), client)
@@ -208,7 +208,7 @@ func (ts *OAuthClientTestSuite) TestOAuthServerClientDeleteHandler() {
 	assert.Empty(ts.T(), w.Body.String())
 
 	// Verify client was soft-deleted
-	deletedClient, err := ts.Server.getOAuthServerClient(context.Background(), client.ClientID)
+	deletedClient, err := ts.Server.getOAuthServerClient(context.Background(), client.ID)
 	assert.Error(ts.T(), err) // it was soft-deleted
 	assert.Nil(ts.T(), deletedClient)
 }
@@ -235,8 +235,8 @@ func (ts *OAuthClientTestSuite) TestOAuthServerClientListHandler() {
 
 	// Check that both clients are in the response (order might vary)
 	clientIDs := []string{response.Clients[0].ClientID, response.Clients[1].ClientID}
-	assert.Contains(ts.T(), clientIDs, client1.ClientID)
-	assert.Contains(ts.T(), clientIDs, client2.ClientID)
+	assert.Contains(ts.T(), clientIDs, client1.ID.String())
+	assert.Contains(ts.T(), clientIDs, client2.ID.String())
 
 	// Verify client secrets are not included in list response
 	for _, client := range response.Clients {

--- a/internal/api/oauthserver/service.go
+++ b/internal/api/oauthserver/service.go
@@ -11,9 +11,9 @@ import (
 	"slices"
 	"time"
 
+	"github.com/gofrs/uuid"
 	"github.com/pkg/errors"
 	"github.com/supabase/auth/internal/api/apierrors"
-	"github.com/supabase/auth/internal/crypto"
 	"github.com/supabase/auth/internal/models"
 	"github.com/supabase/auth/internal/utilities"
 )
@@ -141,11 +141,6 @@ func validateRedirectURI(uri string) error {
 	return nil
 }
 
-// generateClientID generates a URL-safe random client ID
-func generateClientID() string {
-	// Generate a 32-character alphanumeric client ID
-	return crypto.SecureAlphanumeric(32)
-}
 
 // generateClientSecret generates a secure random client secret
 func generateClientSecret() string {
@@ -193,7 +188,7 @@ func (s *Server) registerOAuthServerClient(ctx context.Context, params *OAuthSer
 	db := s.db.WithContext(ctx)
 
 	client := &models.OAuthServerClient{
-		ClientID:         generateClientID(),
+		ID:               uuid.Must(uuid.NewV4()),
 		RegistrationType: params.RegistrationType,
 		ClientType:       clientType,
 		ClientName:       utilities.StringPtr(params.ClientName),
@@ -222,11 +217,11 @@ func (s *Server) registerOAuthServerClient(ctx context.Context, params *OAuthSer
 	return client, plaintextSecret, nil
 }
 
-// getOAuthServerClient retrieves an OAuth client by client_id
-func (s *Server) getOAuthServerClient(ctx context.Context, clientID string) (*models.OAuthServerClient, error) {
+// getOAuthServerClient retrieves an OAuth client by ID
+func (s *Server) getOAuthServerClient(ctx context.Context, clientID uuid.UUID) (*models.OAuthServerClient, error) {
 	db := s.db.WithContext(ctx)
 
-	client, err := models.FindOAuthServerClientByClientID(db, clientID)
+	client, err := models.FindOAuthServerClientByID(db, clientID)
 	if err != nil {
 		return nil, err
 	}
@@ -235,10 +230,10 @@ func (s *Server) getOAuthServerClient(ctx context.Context, clientID string) (*mo
 }
 
 // deleteOAuthServerClient soft-deletes an OAuth client
-func (s *Server) deleteOAuthServerClient(ctx context.Context, clientID string) error {
+func (s *Server) deleteOAuthServerClient(ctx context.Context, clientID uuid.UUID) error {
 	db := s.db.WithContext(ctx)
 
-	client, err := models.FindOAuthServerClientByClientID(db, clientID)
+	client, err := models.FindOAuthServerClientByID(db, clientID)
 	if err != nil {
 		return err
 	}

--- a/internal/api/oauthserver/service_test.go
+++ b/internal/api/oauthserver/service_test.go
@@ -92,9 +92,9 @@ func (ts *OAuthServiceTestSuite) TestOAuthServerClientServiceMethods() {
 	assert.Equal(ts.T(), "dynamic", client.RegistrationType)
 
 	// Test getOAuthServerClient
-	retrievedClient, err := ts.Server.getOAuthServerClient(ctx, client.ClientID)
+	retrievedClient, err := ts.Server.getOAuthServerClient(ctx, client.ID)
 	require.NoError(ts.T(), err)
-	assert.Equal(ts.T(), client.ClientID, retrievedClient.ClientID)
+	assert.Equal(ts.T(), client.ID, retrievedClient.ID)
 
 }
 
@@ -133,11 +133,11 @@ func (ts *OAuthServiceTestSuite) TestDeleteOAuthServerClient() {
 
 	// Delete the client
 	ctx := context.Background()
-	err := ts.Server.deleteOAuthServerClient(ctx, client.ClientID)
+	err := ts.Server.deleteOAuthServerClient(ctx, client.ID)
 	require.NoError(ts.T(), err)
 
 	// Verify client was soft-deleted
-	deletedClient, err := ts.Server.getOAuthServerClient(ctx, client.ClientID)
+	deletedClient, err := ts.Server.getOAuthServerClient(ctx, client.ID)
 	assert.Error(ts.T(), err) // it was soft-deleted
 	assert.Nil(ts.T(), deletedClient)
 }

--- a/internal/models/oauth_client_test.go
+++ b/internal/models/oauth_client_test.go
@@ -239,6 +239,7 @@ func (ts *OAuthServerClientTestSuite) TestUpdateOAuthServerClient() {
 	originalName := "Original Name"
 	testSecretHash, _ := testHashClientSecret("test_secret")
 	client := &OAuthServerClient{
+		ID:               uuid.Must(uuid.NewV4()),
 		ClientName:       &originalName,
 		GrantTypes:       "authorization_code,refresh_token",
 		RegistrationType: "dynamic",

--- a/internal/models/oauth_client_test.go
+++ b/internal/models/oauth_client_test.go
@@ -210,7 +210,7 @@ func (ts *OAuthServerClientTestSuite) TestFindOAuthServerClientByClientID() {
 	testName := "Find By Client ID Test"
 	testSecretHash, _ := testHashClientSecret("test_secret")
 	client := &OAuthServerClient{
-		ClientID:         "test_client_find_by_client_id_" + uuid.Must(uuid.NewV4()).String()[:8],
+		ID:               uuid.Must(uuid.NewV4()),
 		ClientName:       &testName,
 		GrantTypes:       "authorization_code,refresh_token",
 		RegistrationType: "manual",
@@ -222,14 +222,14 @@ func (ts *OAuthServerClientTestSuite) TestFindOAuthServerClientByClientID() {
 	err := CreateOAuthServerClient(ts.db, client)
 	require.NoError(ts.T(), err)
 
-	// Find by client_id
-	foundClient, err := FindOAuthServerClientByClientID(ts.db, client.ClientID)
+	// Find by ID (which is now the client_id)
+	foundClient, err := FindOAuthServerClientByID(ts.db, client.ID)
 	require.NoError(ts.T(), err)
 	assert.Equal(ts.T(), client.ID, foundClient.ID)
 	assert.Equal(ts.T(), *client.ClientName, *foundClient.ClientName)
 
 	// Test not found
-	_, err = FindOAuthServerClientByClientID(ts.db, "nonexistent_client_id")
+	_, err = FindOAuthServerClientByID(ts.db, uuid.Must(uuid.NewV4()))
 	assert.Error(ts.T(), err)
 	assert.True(ts.T(), IsNotFoundError(err))
 }

--- a/migrations/20250903112500_remove_oauth_client_id_column.up.sql
+++ b/migrations/20250903112500_remove_oauth_client_id_column.up.sql
@@ -1,0 +1,13 @@
+-- Drop the client_id column and related constraints/indexes from oauth_clients table
+-- The id (uuid) field will serve as the public client_id
+
+-- Drop the unique constraint on client_id
+alter table {{ index .Options "Namespace" }}.oauth_clients 
+    drop constraint if exists oauth_clients_client_id_key;
+
+-- Drop the index on client_id
+drop index if exists {{ index .Options "Namespace" }}.oauth_clients_client_id_idx;
+
+-- Drop the client_id column
+alter table {{ index .Options "Namespace" }}.oauth_clients 
+    drop column if exists client_id;


### PR DESCRIPTION
## Summary

Simplified OAuth client model by removing redundant `client_id` column and using the primary `id` UUID field as the public client identifier.