### PR TITLE
feat: add phone to sms webhook payload

### DIFF
--- a/internal/api/mfa.go
+++ b/internal/api/mfa.go
@@ -409,12 +409,15 @@ func (a *API) challengePhoneFactor(w http.ResponseWriter, r *http.Request) error
 		return apierrors.NewInternalServerError("error generating sms template").WithInternalError(err)
 	}
 
+	phone := factor.Phone.String()
+
 	if config.Hook.SendSMS.Enabled {
 		input := v0hooks.SendSMSInput{
 			User: user,
 			SMS: v0hooks.SMS{
 				OTP:     otp,
 				SMSType: "mfa",
+				Phone:   phone,
 			},
 		}
 		output := v0hooks.SendSMSOutput{}
@@ -428,7 +431,7 @@ func (a *API) challengePhoneFactor(w http.ResponseWriter, r *http.Request) error
 			return apierrors.NewInternalServerError("Failed to get SMS provider").WithInternalError(err)
 		}
 		// We omit messageID for now, can consider reinstating if there are requests.
-		if _, err = smsProvider.SendMessage(factor.Phone.String(), message, channel, otp); err != nil {
+		if _, err = smsProvider.SendMessage(phone, message, channel, otp); err != nil {
 			return apierrors.NewInternalServerError("error sending message").WithInternalError(err)
 		}
 	}

--- a/internal/api/phone.go
+++ b/internal/api/phone.go
@@ -98,7 +98,8 @@ func (a *API) sendPhoneConfirmation(r *http.Request, tx *storage.Connection, use
 			input := v0hooks.SendSMSInput{
 				User: user,
 				SMS: v0hooks.SMS{
-					OTP: otp,
+					OTP:   otp,
+					Phone: phone,
 				},
 			}
 			output := v0hooks.SendSMSOutput{}

--- a/internal/hooks/v0hooks/v0hooks.go
+++ b/internal/hooks/v0hooks/v0hooks.go
@@ -95,6 +95,7 @@ type AfterUserCreatedOutput struct{}
 type SMS struct {
 	OTP     string `json:"otp,omitempty"`
 	SMSType string `json:"sms_type,omitempty"`
+	Phone   string `json:"phone,omitempty"`
 }
 
 // AccessTokenClaims is a struct thats used for JWT claims


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR adds the phone number to the SendSMS webhook, when a phone factor is challenged or a phone confirmation is required.

## What is the current behavior?

Currently, the SMS webhook only sends the `user_id` and the `otp_code`. However, we have no way of knowing which factor (device) was used in case the send SMS webhook is used for MFA (as opposed to phone confirmation, which uses the user's phone number), and there is more than one device enrolled for a single user. 

## What is the new behavior?

The webhook payload contains `phone`, which is either the user's phone number for phone confirmation or the factor phone number for MFA with a phone factor.

## Additional context

Add any other context or screenshots.
