### PR TITLE
feat: support `transfer_sub` in apple id tokens

### DIFF
--- a/internal/api/provider/oidc.go
+++ b/internal/api/provider/oidc.go
@@ -170,6 +170,8 @@ type AppleIDTokenClaims struct {
 
 	AuthTime       *float64        `json:"auth_time"`
 	IsPrivateEmail *IsPrivateEmail `json:"is_private_email"`
+
+	TransferSub string `json:"transfer_sub"`
 }
 
 func parseAppleIDToken(token *oidc.IDToken) (*oidc.IDToken, *UserProvidedData, error) {
@@ -199,6 +201,10 @@ func parseAppleIDToken(token *oidc.IDToken) (*oidc.IDToken, *UserProvidedData, e
 
 	if claims.AuthTime != nil {
 		data.Metadata.CustomClaims["auth_time"] = *claims.AuthTime
+	}
+
+	if claims.TransferSub != "" {
+		data.Metadata.CustomClaims["transfer_sub"] = claims.TransferSub
 	}
 
 	if len(data.Metadata.CustomClaims) < 1 {


### PR DESCRIPTION
Gain access to the [`transfer_sub` claim present in Apple ID tokens](https://developer.apple.com/documentation/signinwithapple/bringing-new-apps-and-users-into-your-team) when an app is being transferred from one owner to another (e.g. when an app is purchased by another company).