### PR TITLE
feat: add advisor to notify you when to double the max connection pool

### DIFF
--- a/internal/conf/configuration.go
+++ b/internal/conf/configuration.go
@@ -93,6 +93,12 @@ type EmailProviderConfiguration struct {
 	MagicLinkEnabled bool `json:"magic_link_enabled" default:"true" split_words:"true"`
 }
 
+type DBAdvisorConfiguration struct {
+	Enabled             bool          `json:"enabled"`
+	SamplingInterval    time.Duration `json:"sampling_interval" split_words:"true" default:"250ms"`
+	ObservationInterval time.Duration `json:"observation_interval" split_words:"true" default:"5s"`
+}
+
 // DBConfiguration holds all the database related configuration.
 type DBConfiguration struct {
 	Driver    string `json:"driver" required:"true"`
@@ -106,6 +112,8 @@ type DBConfiguration struct {
 	HealthCheckPeriod time.Duration `json:"health_check_period" split_words:"true"`
 	MigrationsPath    string        `json:"migrations_path" split_words:"true" default:"./migrations"`
 	CleanupEnabled    bool          `json:"cleanup_enabled" split_words:"true" default:"false"`
+
+	Advisor DBAdvisorConfiguration `json:"advisor"`
 }
 
 func (c *DBConfiguration) Validate() error {

--- a/internal/conf/configuration.go
+++ b/internal/conf/configuration.go
@@ -94,9 +94,9 @@ type EmailProviderConfiguration struct {
 }
 
 type DBAdvisorConfiguration struct {
-	Enabled             bool          `json:"enabled"`
-	SamplingInterval    time.Duration `json:"sampling_interval" split_words:"true" default:"250ms"`
-	ObservationInterval time.Duration `json:"observation_interval" split_words:"true" default:"5s"`
+	Enabled             bool          `json:"enabled" default:"true"`
+	SamplingInterval    time.Duration `json:"sampling_interval" split_words:"true" default:"200ms"`
+	ObservationInterval time.Duration `json:"observation_interval" split_words:"true" default:"20s"`
 }
 
 // DBConfiguration holds all the database related configuration.

--- a/internal/storage/advisor.go
+++ b/internal/storage/advisor.go
@@ -24,11 +24,15 @@ type Advisor struct {
 func (a *Advisor) Start(observeDuration time.Duration) {
 	nSamples := int(math.Round(observeDuration.Seconds() / a.Interval.Seconds()))
 
-	a.Stats = a.DB.Stats()
 	a.WaitDurationSamples = make([]time.Duration, nSamples)
 	a.WaitCountSamples = make([]int64, nSamples)
 
 	go func() {
+		// after server start the db stats are going to be worse, so ignore that period
+		time.Sleep(observeDuration)
+
+		a.Stats = a.DB.Stats()
+
 		for {
 			time.Sleep(a.Interval)
 			a.loop()

--- a/internal/storage/advisor.go
+++ b/internal/storage/advisor.go
@@ -26,7 +26,7 @@ type Advisor struct {
 }
 
 func (a *Advisor) Start(observeDuration time.Duration) {
-	a.setup()
+	a.setup(observeDuration)
 
 	go func() {
 		// after server start the db stats are going to be worse, so ignore that period

--- a/internal/storage/advisor.go
+++ b/internal/storage/advisor.go
@@ -1,0 +1,86 @@
+package storage
+
+import (
+	"database/sql"
+	"math"
+	"time"
+
+	"github.com/sirupsen/logrus"
+)
+
+type Advisor struct {
+	DB       *sql.DB
+	Interval time.Duration
+
+	Stats         sql.DBStats
+	LastAdvisedAt time.Time
+
+	Iterations int
+
+	WaitDurationSamples []time.Duration
+	WaitCountSamples    []int64
+}
+
+func (a *Advisor) Start(observeDuration time.Duration) {
+	nSamples := int(math.Round(observeDuration.Seconds() / a.Interval.Seconds()))
+
+	a.Stats = a.DB.Stats()
+	a.WaitDurationSamples = make([]time.Duration, nSamples)
+	a.WaitCountSamples = make([]int64, nSamples)
+
+	go func() {
+		for {
+			time.Sleep(a.Interval)
+			a.loop()
+		}
+	}()
+}
+
+func (a *Advisor) loop() {
+	a.Iterations += 1
+	if a.Iterations < 0 {
+		a.Iterations = 0
+	}
+
+	previousStats := a.Stats
+	a.Stats = a.DB.Stats()
+
+	a.WaitDurationSamples[a.Iterations%len(a.WaitDurationSamples)] = a.Stats.WaitDuration - previousStats.WaitDuration
+	a.WaitCountSamples[a.Iterations%len(a.WaitCountSamples)] = a.Stats.WaitCount - previousStats.WaitCount
+
+	advise := false
+
+	longWaitDurationSamples := 0
+	if a.Iterations >= len(a.WaitDurationSamples) {
+		for _, sample := range a.WaitDurationSamples {
+			if sample >= a.Interval {
+				longWaitDurationSamples += 1
+			}
+		}
+
+		// 1/3 of the observation time was spent waiting for over 1ms
+		advise = longWaitDurationSamples >= (len(a.WaitDurationSamples) / 3)
+	}
+
+	over2WaitingSamples := 0
+	if !advise && a.Iterations >= len(a.WaitCountSamples) {
+		for _, sample := range a.WaitCountSamples {
+			if sample > 2 {
+				over2WaitingSamples += 1
+			}
+		}
+
+		// 1/3 of the observation time we saw more than 2 goroutines waiting for a connection
+		advise = over2WaitingSamples >= (len(a.WaitCountSamples) / 3)
+	}
+
+	if advise && time.Since(a.LastAdvisedAt) >= time.Hour {
+		a.LastAdvisedAt = time.Now()
+
+		logrus.WithFields(logrus.Fields{
+			"component":                  "db.advisor",
+			"long_wait_duration_samples": longWaitDurationSamples,
+			"over_2_waiting_samples":     over2WaitingSamples,
+		}).Warn("Suboptimal database connection pool settings detected! Consider doubling the max DB pool size configuration")
+	}
+}

--- a/internal/storage/advisor_test.go
+++ b/internal/storage/advisor_test.go
@@ -36,13 +36,13 @@ func TestAdvisorZeroChanges(t *testing.T) {
 }
 
 func TestAdvisorWaitDuration(t *testing.T) {
-	advised := false
+	advised := 0
 
 	dbStats := sql.DBStats{}
 
 	advisor := Advisor{
 		AdviseFunc: func(advisory Advisory) {
-			advised = true
+			advised += 1
 		},
 		StatsFunc: func() sql.DBStats {
 			return dbStats
@@ -57,22 +57,22 @@ func TestAdvisorWaitDuration(t *testing.T) {
 
 	advisor.Stats = advisor.StatsFunc()
 
-	for i := 0; i < 3; i += 1 {
-		dbStats.WaitDuration += advisor.Interval
+	for i := 0; i < 20; i += 1 {
+		dbStats.WaitDuration += time.Millisecond
 		advisor.loop()
 	}
 
-	require.True(t, advised)
+	require.Equal(t, advised, 1)
 }
 
 func TestAdvisorWaitCount(t *testing.T) {
-	advised := false
+	advised := 0
 
 	dbStats := sql.DBStats{}
 
 	advisor := Advisor{
 		AdviseFunc: func(advisory Advisory) {
-			advised = true
+			advised += 1
 		},
 		StatsFunc: func() sql.DBStats {
 			return dbStats
@@ -87,10 +87,10 @@ func TestAdvisorWaitCount(t *testing.T) {
 
 	advisor.Stats = advisor.StatsFunc()
 
-	for i := 0; i < 3; i += 1 {
+	for i := 0; i < 20; i += 1 {
 		dbStats.WaitCount += 3
 		advisor.loop()
 	}
 
-	require.True(t, advised)
+	require.Equal(t, advised, 1)
 }

--- a/internal/storage/advisor_test.go
+++ b/internal/storage/advisor_test.go
@@ -1,0 +1,96 @@
+package storage
+
+import (
+	"database/sql"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAdvisorZeroChanges(t *testing.T) {
+	advised := false
+
+	advisor := Advisor{
+		AdviseFunc: func(advisory Advisory) {
+			advised = true
+		},
+		StatsFunc: func() sql.DBStats {
+			return sql.DBStats{}
+		},
+		Interval: time.Millisecond,
+	}
+
+	advisor.setup(10 * time.Millisecond)
+
+	require.Len(t, advisor.WaitDurationSamples, 10)
+	require.Len(t, advisor.WaitCountSamples, 10)
+
+	advisor.Stats = advisor.StatsFunc()
+
+	for i := 0; i < 11; i += 1 {
+		advisor.loop()
+	}
+
+	require.False(t, advised)
+}
+
+func TestAdvisorWaitDuration(t *testing.T) {
+	advised := false
+
+	dbStats := sql.DBStats{}
+
+	advisor := Advisor{
+		AdviseFunc: func(advisory Advisory) {
+			advised = true
+		},
+		StatsFunc: func() sql.DBStats {
+			return dbStats
+		},
+		Interval: time.Millisecond,
+	}
+
+	advisor.setup(10 * time.Millisecond)
+
+	require.Len(t, advisor.WaitDurationSamples, 10)
+	require.Len(t, advisor.WaitCountSamples, 10)
+
+	advisor.Stats = advisor.StatsFunc()
+
+	for i := 0; i < 3; i += 1 {
+		dbStats.WaitDuration += advisor.Interval
+		advisor.loop()
+	}
+
+	require.True(t, advised)
+}
+
+func TestAdvisorWaitCount(t *testing.T) {
+	advised := false
+
+	dbStats := sql.DBStats{}
+
+	advisor := Advisor{
+		AdviseFunc: func(advisory Advisory) {
+			advised = true
+		},
+		StatsFunc: func() sql.DBStats {
+			return dbStats
+		},
+		Interval: time.Millisecond,
+	}
+
+	advisor.setup(10 * time.Millisecond)
+
+	require.Len(t, advisor.WaitDurationSamples, 10)
+	require.Len(t, advisor.WaitCountSamples, 10)
+
+	advisor.Stats = advisor.StatsFunc()
+
+	for i := 0; i < 3; i += 1 {
+		dbStats.WaitCount += 3
+		advisor.loop()
+	}
+
+	require.True(t, advised)
+}


### PR DESCRIPTION
Adds a simple advisor that emits a log message every hour, if the number of [DBStats](https://pkg.go.dev/database/sql#DBStats) samples exceeds:

- 1/3 or more samples indicate more than 1ms wait for every millisecond in the sampling interval
- 1/3 or more samples indicate 2 or more goroutines have been waiting to acquire a connection from the pool

For instance, if you set `GOTRUE_DB_ADVISOR_SAMPLING_INTERVAL="100ms"` and `GOTRUE_DB_ADVISOR_OBSERVATION_INTERVAL="1s"` then:

- There are 1000 / 100 = 10 samples
- Every 100ms a sample is taken and the conditions are checked
- Log message is emitted if either one of the conditions are met at most once per hour