### PR TITLE
feat(oauth2): add admin endpoint to regenerate OAuth client secrets

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -348,6 +348,7 @@ func NewAPIWithVersion(globalConfig *conf.GlobalConfiguration, db *storage.Conne
 							r.Use(api.oauthServer.LoadOAuthServerClient)
 							r.Get("/", api.oauthServer.OAuthServerClientGet)
 							r.Delete("/", api.oauthServer.OAuthServerClientDelete)
+							r.Post("/regenerate_secret", api.oauthServer.OAuthServerClientRegenerateSecret)
 						})
 					})
 				})

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -62,7 +62,7 @@ func TestOAuthServerDisabledByDefault(t *testing.T) {
 
 	// OAuth server should be disabled by default
 	require.False(t, api.config.OAuthServer.Enabled)
-	
+
 	// OAuth server instance should not be initialized when disabled
 	require.Nil(t, api.oauthServer)
 }
@@ -78,7 +78,7 @@ func TestOAuthServerCanBeEnabled(t *testing.T) {
 
 	// OAuth server should be enabled
 	require.True(t, api.config.OAuthServer.Enabled)
-	
+
 	// OAuth server instance should be initialized when enabled
 	require.NotNil(t, api.oauthServer)
 }

--- a/internal/api/oauthserver/handlers.go
+++ b/internal/api/oauthserver/handlers.go
@@ -190,6 +190,27 @@ func (s *Server) OAuthServerClientDelete(w http.ResponseWriter, r *http.Request)
 	return nil
 }
 
+// OAuthServerClientRegenerateSecret handles POST /admin/oauth/clients/{client_id}/regenerate_secret
+func (s *Server) OAuthServerClientRegenerateSecret(w http.ResponseWriter, r *http.Request) error {
+	ctx := r.Context()
+	client := shared.GetOAuthServerClient(ctx)
+
+	// Only confidential clients can have their secrets regenerated
+	if !client.IsConfidential() {
+		return apierrors.NewBadRequestError(apierrors.ErrorCodeValidationFailed, "Cannot regenerate secret for public client")
+	}
+
+	updatedClient, plaintextSecret, err := s.regenerateOAuthServerClientSecret(ctx, client.ID)
+	if err != nil {
+		return apierrors.NewInternalServerError("Error regenerating OAuth client secret").WithInternalError(err)
+	}
+
+	response := oauthServerClientToResponse(updatedClient)
+	response.ClientSecret = plaintextSecret
+
+	return shared.SendJSON(w, http.StatusOK, response)
+}
+
 // OAuthServerClientList handles GET /admin/oauth/clients
 func (s *Server) OAuthServerClientList(w http.ResponseWriter, r *http.Request) error {
 	ctx := r.Context()


### PR DESCRIPTION
## Summary
- Add `POST /admin/oauth/clients/{client_id}/regenerate_secret` endpoint
- Only allow secret regeneration for confidential clients
- Return updated client with new plaintext secret in response