### PR TITLE
feat: add support for account changes notifications in email send hook

### DIFF
--- a/internal/api/mail.go
+++ b/internal/api/mail.go
@@ -844,6 +844,19 @@ func (a *API) sendEmail(r *http.Request, tx *storage.Connection, u *models.User,
 				emailData.Token = params.otpNew
 			}
 		}
+
+		// Augment the email data for the email send hook with notification-specific fields
+		switch params.emailActionType {
+		case mail.EmailChangedNotification:
+			emailData.OldEmail = params.oldEmail
+		case mail.PhoneChangedNotification:
+			emailData.OldPhone = params.oldPhone
+		case mail.IdentityLinkedNotification, mail.IdentityUnlinkedNotification:
+			emailData.Provider = params.provider
+		case mail.MFAFactorEnrolledNotification, mail.MFAFactorUnenrolledNotification:
+			emailData.FactorType = params.factorType
+		}
+
 		input := v0hooks.SendEmailInput{
 			User:      u,
 			EmailData: emailData,

--- a/internal/mailer/mailer.go
+++ b/internal/mailer/mailer.go
@@ -69,4 +69,8 @@ type EmailData struct {
 	SiteURL         string `json:"site_url"`
 	TokenNew        string `json:"token_new"`
 	TokenHashNew    string `json:"token_hash_new"`
+	OldEmail        string `json:"old_email"`
+	OldPhone        string `json:"old_phone"`
+	Provider        string `json:"provider"`
+	FactorType      string `json:"factor_type"`
 }


### PR DESCRIPTION
Adds support for Account Changes Notifications in the `Send Email Hook`.