### PR TITLE
feat(templatemailer): getPath function should append existing query strings instead of overwrite

### DIFF
--- a/internal/mailer/templatemailer/templatemailer.go
+++ b/internal/mailer/templatemailer/templatemailer.go
@@ -465,6 +465,12 @@ func getPath(filepath string, params *emailParams) (*url.URL, error) {
 	}
 	if params != nil {
 		path.RawQuery = fmt.Sprintf("token=%s&type=%s&redirect_to=%s", url.QueryEscape(params.Token), url.QueryEscape(params.Type), encodeRedirectURL(params.RedirectTo))
+
+		// If the path already has query params, append them
+		q := path.Query().Encode()
+		if q != "" {
+			path.RawQuery += fmt.Sprintf("&%s", q)
+		}
 	}
 	return path, nil
 }

--- a/internal/mailer/templatemailer/templatemailer_url_test.go
+++ b/internal/mailer/templatemailer/templatemailer_url_test.go
@@ -56,6 +56,12 @@ func TestGetPath(t *testing.T) {
 			Params:   &params,
 			Expected: "https://test.example.com?token=token&type=signup&redirect_to=https://example.com",
 		},
+		{
+			SiteURL:  "https://test.example.com/",
+			Path:     "/trailingslash?flow=test",
+			Params:   &params,
+			Expected: "https://test.example.com/trailingslash?token=token&type=signup&redirect_to=https://example.com&flow=test",
+		},
 	}
 
 	for _, c := range cases {


### PR DESCRIPTION
## What kind of change does this PR introduce?

This is a bug fix for issue: https://github.com/supabase/supabase/issues/36990

## What is the current behavior?

If you change `ConfirmationURL` for an email to `https://supabase.com?flow=test` the sent email will override the `flow=test` query string and only add specified parameters. 

## What is the new behavior?

New behavior fixes that and appends the whatever in the `ConfirmationURL` after the specified parameters. `?token_hash=xxxx&email=xxxxxx&flow=test`