### PR TITLE
feat: add `.well-known/openid-configuration`

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -174,7 +174,8 @@ func NewAPIWithVersion(globalConfig *conf.GlobalConfiguration, db *storage.Conne
 	}
 
 	r.Get("/health", api.HealthCheck)
-	r.Get("/.well-known/jwks.json", api.Jwks)
+	r.Get("/.well-known/jwks.json", api.WellKnownJwks)
+	r.Get("/.well-known/openid-configuration", api.WellKnownOpenID)
 
 	if globalConfig.OAuthServer.Enabled {
 		r.Get("/.well-known/oauth-authorization-server", api.oauthServer.OAuthServerMetadata)

--- a/internal/api/jwks.go
+++ b/internal/api/jwks.go
@@ -11,7 +11,7 @@ type JwksResponse struct {
 	Keys []jwk.Key `json:"keys"`
 }
 
-func (a *API) Jwks(w http.ResponseWriter, r *http.Request) error {
+func (a *API) WellKnownJwks(w http.ResponseWriter, r *http.Request) error {
 	config := a.config
 	resp := JwksResponse{
 		Keys: []jwk.Key{},
@@ -27,4 +27,20 @@ func (a *API) Jwks(w http.ResponseWriter, r *http.Request) error {
 
 	w.Header().Set("Cache-Control", "public, max-age=600")
 	return sendJSON(w, http.StatusOK, resp)
+}
+
+type OpenIDConfigurationResponse struct {
+	Issuer  string `json:"issuer"`
+	JWKSURL string `json:"jwks_uri"`
+}
+
+func (a *API) WellKnownOpenID(w http.ResponseWriter, r *http.Request) error {
+	config := a.config
+
+	w.Header().Set("Cache-Control", "public, max-age=600")
+
+	return sendJSON(w, http.StatusOK, OpenIDConfigurationResponse{
+		Issuer:  config.JWT.Issuer,
+		JWKSURL: config.JWT.Issuer + "/.well-known/jwks.json",
+	})
 }


### PR DESCRIPTION
Adds the `.well-known/openid-configuration` endpoint that serves a static response pointing to the `.well-known/jwks.json` URL. 

It's important to also have this, as AWS JWT Authorizers require the OpenID discovery URL, not just the `jwks.json`.

https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-jwt-authorizer.html