### PR TITLE
feat: properly handle redirect url fragments and unusual hostnames

### DIFF
--- a/internal/api/verify_test.go
+++ b/internal/api/verify_test.go
@@ -657,6 +657,20 @@ func (ts *VerifyTestSuite) TestVerifySignupWithRedirectURLContainedPath() {
 			requestredirectURL:  "http://test.dev:3000/bar/foo",
 			expectedredirectURL: "http://localhost:3000",
 		},
+		{
+			desc:                "redirect ignores fragment for validation",
+			siteURL:             "http://localhost:3000",
+			uriAllowList:        []string{"http://*.example.com/*"},
+			requestredirectURL:  "http://something#.example.com/abc",
+			expectedredirectURL: "http://localhost:3000",
+		},
+		{
+			desc:                "redirect ignores unusual hostnames",
+			siteURL:             "http://localhost:3000",
+			uriAllowList:        []string{"http://*.example.com/*"},
+			requestredirectURL:  "http://japanese。.example.com/abc",
+			expectedredirectURL: "http://localhost:3000",
+		},
 	}
 
 	for _, tC := range testCases {


### PR DESCRIPTION
Pattern matching should occur on the URL without the fragment. URLs with hostnames that are not usual (so having unicode characters) should be considered invalid.