### PR TITLE
fix: ensure correct SAML Entity ID in client SSO flow

### DIFF
--- a/internal/api/saml.go
+++ b/internal/api/saml.go
@@ -40,6 +40,11 @@ func (a *API) getSAMLServiceProvider(identityProvider *saml.EntityDescriptor, id
 
 	externalURL.Path += "sso/"
 
+	entityID := ""
+	if identityProvider != nil {
+		entityID = identityProvider.EntityID
+	}
+
 	provider := samlsp.DefaultServiceProvider(samlsp.Options{
 		URL:               *externalURL,
 		Key:               a.config.SAML.RSAPrivateKey,
@@ -47,6 +52,7 @@ func (a *API) getSAMLServiceProvider(identityProvider *saml.EntityDescriptor, id
 		SignRequest:       true,
 		AllowIDPInitiated: idpInitiated,
 		IDPMetadata:       identityProvider,
+		EntityID:          entityID,
 	})
 
 	provider.AuthnNameIDFormat = saml.PersistentNameIDFormat


### PR DESCRIPTION
When initiating a SAML client flow via the /sso endpoint, the service provider object Entity ID is omitted from the initialization options, causing the underlying saml library to incorrectly use the metadata URL for the SAML server as the Entity ID.

This causes some service providers (e.g. Microsoft Entra ID) to reject the SAML authentication request, as the inferred supabase auth server metadata URL does not match the provider's Entity ID.

This change ensures the service provider is correctly initialized with the provider Entity ID during the client auth flow, while retaining the existing behavior for the server metadata endpoint.