### PR TITLE
fix: mfa verify now works with refresh token algorithm v2

### DIFF
--- a/internal/api/token.go
+++ b/internal/api/token.go
@@ -348,6 +348,7 @@ func (a *API) updateMFASessionAndClaims(r *http.Request, tx *storage.Connection,
 				return apierrors.NewInternalServerError("Failed to update session").WithInternalError(terr)
 			}
 		} else {
+			// Legacy RTs: swap to ensure current token is the latest one
 			refreshToken, terr := models.GrantRefreshTokenSwap(config.AuditLog, r, tx, user, currentToken)
 			if terr != nil {
 				return terr


### PR DESCRIPTION
Verification didn't work as MFA verify issues a new refresh token. This was not moved to support v2 refresh tokens.