### PR TITLE
feat(oauthserver): use `NewOAuthServerAuthorizationParams` & configurable ttl for authorization

### DIFF
--- a/internal/api/oauthserver/authorize.go
+++ b/internal/api/oauthserver/authorize.go
@@ -136,16 +136,17 @@ func (s *Server) OAuthServerAuthorize(w http.ResponseWriter, r *http.Request) er
 	}
 
 	// Store authorization request in database (without user initially)
-	authorization := models.NewOAuthServerAuthorization(
-		client.ID, // Use the client's UUID instead of the public client_id string
-		params.RedirectURI,
-		params.Scope,
-		params.State,
-		params.Resource,
-		params.CodeChallenge,
-		params.CodeChallengeMethod,
-		params.Nonce,
-	)
+	authorization := models.NewOAuthServerAuthorization(models.NewOAuthServerAuthorizationParams{
+		ClientID:            client.ID,
+		RedirectURI:         params.RedirectURI,
+		Scope:               params.Scope,
+		State:               params.State,
+		Resource:            params.Resource,
+		CodeChallenge:       params.CodeChallenge,
+		CodeChallengeMethod: params.CodeChallengeMethod,
+		TTL:                 config.OAuthServer.AuthorizationTTL,
+		Nonce:               params.Nonce,
+	})
 
 	if err := models.CreateOAuthServerAuthorization(db, authorization); err != nil {
 		// Error creating authorization - redirect with server_error

--- a/internal/conf/configuration.go
+++ b/internal/conf/configuration.go
@@ -76,7 +76,7 @@ type OAuthServerConfiguration struct {
 	Enabled                  bool          `json:"enabled" default:"false"`
 	AllowDynamicRegistration bool          `json:"allow_dynamic_registration" split_words:"true"`
 	AuthorizationPath        string        `json:"authorization_path" split_words:"true"`
-	AuthorizationTimeout     time.Duration `json:"authorization_timeout" split_words:"true" default:"5m"`
+	AuthorizationTTL         time.Duration `json:"authorization_ttl" split_words:"true" default:"10m"`
 	// Placeholder for now, for (near) future extensibility
 	DefaultScope string `json:"default_scope" split_words:"true" default:"email"`
 }

--- a/internal/models/oauth_authorization.go
+++ b/internal/models/oauth_authorization.go
@@ -67,44 +67,57 @@ func (OAuthServerAuthorization) TableName() string {
 	return "oauth_authorizations"
 }
 
+// NewOAuthServerAuthorizationParams contains parameters for creating a new OAuth server authorization
+type NewOAuthServerAuthorizationParams struct {
+	ClientID            uuid.UUID
+	RedirectURI         string
+	Scope               string
+	State               string
+	Resource            string
+	CodeChallenge       string
+	CodeChallengeMethod string
+	TTL                 time.Duration
+	Nonce               string
+}
+
 // NewOAuthServerAuthorization creates a new OAuth server authorization request without user (for initial flow)
-func NewOAuthServerAuthorization(clientID uuid.UUID, redirectURI, scope, state, resource, codeChallenge, codeChallengeMethod, nonce string) *OAuthServerAuthorization {
+func NewOAuthServerAuthorization(params NewOAuthServerAuthorizationParams) *OAuthServerAuthorization {
 	id := uuid.Must(uuid.NewV4())
 	authorizationID := crypto.SecureAlphanumeric(32) // Generate random ID for frontend
 
 	now := time.Now()
-	expiresAt := now.Add(10 * time.Minute) // 10 minute expiration
+	expiresAt := now.Add(params.TTL)
 
 	auth := &OAuthServerAuthorization{
 		ID:              id,
 		AuthorizationID: authorizationID,
-		ClientID:        clientID,
+		ClientID:        params.ClientID,
 		UserID:          nil, // No user yet
-		RedirectURI:     redirectURI,
-		Scope:           scope,
+		RedirectURI:     params.RedirectURI,
+		Scope:           params.Scope,
 		ResponseType:    OAuthServerResponseTypeCode,
 		Status:          OAuthServerAuthorizationPending,
 		CreatedAt:       now,
 		ExpiresAt:       expiresAt,
 	}
 
-	if state != "" {
-		auth.State = &state
+	if params.State != "" {
+		auth.State = &params.State
 	}
-	if resource != "" {
-		auth.Resource = &resource
+	if params.Resource != "" {
+		auth.Resource = &params.Resource
 	}
-	if codeChallenge != "" {
-		auth.CodeChallenge = &codeChallenge
+	if params.CodeChallenge != "" {
+		auth.CodeChallenge = &params.CodeChallenge
 	}
-	if codeChallengeMethod != "" {
+	if params.CodeChallengeMethod != "" {
 		// Normalize code challenge method to lowercase for database storage
 		// Database enum expects 's256' and 'plain' (lowercase)
-		normalizedMethod := strings.ToLower(codeChallengeMethod)
+		normalizedMethod := strings.ToLower(params.CodeChallengeMethod)
 		auth.CodeChallengeMethod = &normalizedMethod
 	}
-	if nonce != "" {
-		auth.Nonce = &nonce
+	if params.Nonce != "" {
+		auth.Nonce = &params.Nonce
 	}
 
 	return auth

--- a/internal/models/oauth_authorization_test.go
+++ b/internal/models/oauth_authorization_test.go
@@ -11,24 +11,27 @@ import (
 
 func TestNewOAuthServerAuthorization(t *testing.T) {
 	clientID := uuid.Must(uuid.NewV4())
-	redirectURI := "https://example.com/callback"
-	scope := "openid profile"
-	state := "random-state"
-	codeChallenge := "test-challenge"
-	codeChallengeMethod := "S256"
-	resource := "https://api.example.com/"
 
-	auth := NewOAuthServerAuthorization(clientID, redirectURI, scope, state, resource, codeChallenge, codeChallengeMethod, "")
+	auth := NewOAuthServerAuthorization(NewOAuthServerAuthorizationParams{
+		ClientID:            clientID,
+		RedirectURI:         "https://example.com/callback",
+		Scope:               "openid profile",
+		State:               "random-state",
+		Resource:            "https://api.example.com/",
+		CodeChallenge:       "test-challenge",
+		CodeChallengeMethod: "S256",
+		TTL:                 10 * time.Minute,
+	})
 
 	assert.NotEmpty(t, auth.ID)
 	assert.NotEmpty(t, auth.AuthorizationID)
 	assert.Equal(t, clientID, auth.ClientID)
 	assert.Nil(t, auth.UserID)
-	assert.Equal(t, redirectURI, auth.RedirectURI)
-	assert.Equal(t, scope, auth.Scope)
-	assert.Equal(t, state, *auth.State)
-	assert.Equal(t, resource, *auth.Resource)
-	assert.Equal(t, codeChallenge, *auth.CodeChallenge)
+	assert.Equal(t, "https://example.com/callback", auth.RedirectURI)
+	assert.Equal(t, "openid profile", auth.Scope)
+	assert.Equal(t, "random-state", *auth.State)
+	assert.Equal(t, "https://api.example.com/", *auth.Resource)
+	assert.Equal(t, "test-challenge", *auth.CodeChallenge)
 	assert.Equal(t, "s256", *auth.CodeChallengeMethod) // Should be normalized to lowercase
 	assert.Equal(t, OAuthServerResponseTypeCode, auth.ResponseType)
 	assert.Equal(t, OAuthServerAuthorizationPending, auth.Status)
@@ -52,16 +55,15 @@ func TestNewOAuthServerAuthorization_CodeChallengeMethodNormalization(t *testing
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			auth := NewOAuthServerAuthorization(
-				uuid.Must(uuid.NewV4()),
-				"https://example.com/callback",
-				"openid",
-				"state",
-				"",
-				"challenge",
-				tc.input,
-				"", // nonce
-			)
+			auth := NewOAuthServerAuthorization(NewOAuthServerAuthorizationParams{
+				ClientID:            uuid.Must(uuid.NewV4()),
+				RedirectURI:         "https://example.com/callback",
+				Scope:               "openid",
+				State:               "state",
+				CodeChallenge:       "challenge",
+				CodeChallengeMethod: tc.input,
+				TTL:                 10 * time.Minute,
+			})
 
 			assert.Equal(t, tc.expected, *auth.CodeChallengeMethod,
 				"Expected code_challenge_method to be normalized to %s, got %s", tc.expected, *auth.CodeChallengeMethod)
@@ -75,14 +77,15 @@ func TestNewOAuthServerAuthorization_WithNonce(t *testing.T) {
 
 	// Test with nonce
 	authWithNonce := NewOAuthServerAuthorization(
-		clientID,
-		"https://example.com/callback",
-		"openid",
-		"state",
-		"",
-		"challenge",
-		"S256",
-		nonce,
+		NewOAuthServerAuthorizationParams{
+			ClientID:            clientID,
+			RedirectURI:         "https://example.com/callback",
+			Scope:               "openid",
+			State:               "state",
+			CodeChallenge:       "challenge",
+			CodeChallengeMethod: "S256",
+			Nonce:               nonce,
+		},
 	)
 
 	assert.NotNil(t, authWithNonce.Nonce)
@@ -90,14 +93,14 @@ func TestNewOAuthServerAuthorization_WithNonce(t *testing.T) {
 
 	// Test without nonce (empty string)
 	authWithoutNonce := NewOAuthServerAuthorization(
-		clientID,
-		"https://example.com/callback",
-		"openid",
-		"state",
-		"",
-		"challenge",
-		"S256",
-		"",
+		NewOAuthServerAuthorizationParams{
+			ClientID:            clientID,
+			RedirectURI:         "https://example.com/callback",
+			Scope:               "openid",
+			State:               "state",
+			CodeChallenge:       "challenge",
+			CodeChallengeMethod: "S256",
+		},
 	)
 
 	assert.Nil(t, authWithoutNonce.Nonce)


### PR DESCRIPTION
## Summary

This PR adds support for configurable OAuth authorization TTL (Time To Live) using the`GOTRUE_OAUTH_SERVER_AUTHORIZATION_TTL` environment variable, replacing the previous hardcoded 10-minute expiration. This is safe & requires no migration as it's not rolled out yet!

Also introduces params struct to be used with `NewOAuthServerAuthorization`.