### PR TITLE
chore: remove `text_pattern_ops` index on `phone` column

### DIFF
--- a/internal/indexworker/indexworker.go
+++ b/internal/indexworker/indexworker.go
@@ -308,12 +308,6 @@ func getUsersIndexes(namespace, trgmSchema string) []struct {
 			query: fmt.Sprintf(`CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_users_email_trgm
 				ON %q.users USING gin (email %s.gin_trgm_ops);`, namespace, trgmSchema),
 		},
-		// enables exact-match and prefix searches and sorting by phone number
-		{
-			name: "idx_users_phone_pattern",
-			query: fmt.Sprintf(`CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_users_phone_pattern
-				ON %q.users USING btree (phone text_pattern_ops);`, namespace),
-		},
 		// for range queries and sorting on created_at and last_sign_in_at
 		{
 			name: "idx_users_created_at_desc",


### PR DESCRIPTION
We have an existing `UNIQUE` index on the `phone` column (`users_phone_key`) that can be reused for:

1. Exact match queries
2. Prefixed search queries (`phone LIKE '123%'`) or range-based queries (`phone > '123' AND phone < '123'`)
3. Order by clauses `ORDER BY phone`

`text_pattern_ops` indexes do not support ordering.