### PR TITLE
fix: use URL-safe Base64 decoding for Firebase Scrypt password hash and salt

### DIFF
--- a/internal/crypto/password.go
+++ b/internal/crypto/password.go
@@ -125,12 +125,16 @@ func ParseFirebaseScryptHash(hash string) (*FirebaseScryptHashInput, error) {
 		return nil, fmt.Errorf("crypto: Firebase scrypt hash has invalid p=0")
 	}
 
-	rawHash, err := base64.URLEncoding.DecodeString(hashB64)
+	// Normalize URL-safe Base64 to standard Base64
+	// Firebase exports use URL-safe Base64 (-,_) but some data may use standard Base64 (+,/)
+	normalizedHash := strings.ReplaceAll(strings.ReplaceAll(hashB64, "-", "+"), "_", "/")
+	rawHash, err := base64.StdEncoding.DecodeString(normalizedHash)
 	if err != nil {
 		return nil, fmt.Errorf("crypto: Firebase scrypt hash has invalid base64 in the hash section %w", err)
 	}
 
-	salt, err := base64.URLEncoding.DecodeString(saltB64)
+	normalizedSalt := strings.ReplaceAll(strings.ReplaceAll(saltB64, "-", "+"), "_", "/")
+	salt, err := base64.StdEncoding.DecodeString(normalizedSalt)
 	if err != nil {
 		return nil, fmt.Errorf("crypto: Firebase scrypt salt has invalid base64 in the hash section %w", err)
 	}

--- a/internal/crypto/password_test.go
+++ b/internal/crypto/password_test.go
@@ -112,7 +112,12 @@ func TestFirebaseScrypt(t *testing.T) {
 	// all of these use the `mytestpassword` string as the valid one
 
 	examples := []string{
+		// URL-safe base64 salt and hash (contains _ instead of /)
 		"$fbscrypt$v=1,n=14,r=8,p=1,ss=Bw==,sk=ou9tdYTGyYm8kuR6Dt0Bp0kDuAYoXrK16mbZO4yGwAn3oLspjnN0/c41v8xZnO1n14J3MjKj1b2g6AUCAlFwMw==$C0sHCg9ek_7hsg==$A91H0C35fqAvqx6So9G_jXriM8h8KvW1kQpAOpP6NEVi9bU6xfUnNN1o0PiT7HP5k9ebaLWaD7m6PwNyiGgZDg==",
+		// salt is std base64
+		"$fbscrypt$v=1,n=14,r=8,p=1,ss=Bw==,sk=ou9tdYTGyYm8kuR6Dt0Bp0kDuAYoXrK16mbZO4yGwAn3oLspjnN0/c41v8xZnO1n14J3MjKj1b2g6AUCAlFwMw==$C0sHCg9ek/7hsg==$A91H0C35fqAvqx6So9G_jXriM8h8KvW1kQpAOpP6NEVi9bU6xfUnNN1o0PiT7HP5k9ebaLWaD7m6PwNyiGgZDg==",
+		// hash is std base64
+		"$fbscrypt$v=1,n=14,r=8,p=1,ss=Bw==,sk=ou9tdYTGyYm8kuR6Dt0Bp0kDuAYoXrK16mbZO4yGwAn3oLspjnN0/c41v8xZnO1n14J3MjKj1b2g6AUCAlFwMw==$C0sHCg9ek_7hsg==$A91H0C35fqAvqx6So9G/jXriM8h8KvW1kQpAOpP6NEVi9bU6xfUnNN1o0PiT7HP5k9ebaLWaD7m6PwNyiGgZDg==",
 	}
 
 	for _, example := range examples {
@@ -146,10 +151,6 @@ func TestFirebaseScrypt(t *testing.T) {
 		"$fbscrypt$v=1,n=14,r=8,p=1,ss=Bw==,sk=!!!$C0sHCg9ek_7hsg==$A91H0C35fqAvqx6So9G_jXriM8h8KvW1kQpAOpP6NEVi9bU6xfUnNN1o0PiT7HP5k9ebaLWaD7m6PwNyiGgZDg==",
 		// salt separator is not base64
 		"$fbscrypt$v=1,n=14,r=8,p=1,ss=!!!,sk=ou9tdYTGyYm8kuR6Dt0Bp0kDuAYoXrK16mbZO4yGwAn3oLspjnN0/c41v8xZnO1n14J3MjKj1b2g6AUCAlFwMw==$C0sHCg9ek_7hsg==$A91H0C35fqAvqx6So9G_jXriM8h8KvW1kQpAOpP6NEVi9bU6xfUnNN1o0PiT7HP5k9ebaLWaD7m6PwNyiGgZDg==",
-		// salt is std base64
-		"$fbscrypt$v=1,n=14,r=8,p=1,ss=Bw==,sk=ou9tdYTGyYm8kuR6Dt0Bp0kDuAYoXrK16mbZO4yGwAn3oLspjnN0/c41v8xZnO1n14J3MjKj1b2g6AUCAlFwMw==$C0sHCg9ek/7hsg==$A91H0C35fqAvqx6So9G_jXriM8h8KvW1kQpAOpP6NEVi9bU6xfUnNN1o0PiT7HP5k9ebaLWaD7m6PwNyiGgZDg==",
-		// hash is std base64
-		"$fbscrypt$v=1,n=14,r=8,p=1,ss=Bw==,sk=ou9tdYTGyYm8kuR6Dt0Bp0kDuAYoXrK16mbZO4yGwAn3oLspjnN0/c41v8xZnO1n14J3MjKj1b2g6AUCAlFwMw==$C0sHCg9ek_7hsg==$A91H0C35fqAvqx6So9G/jXriM8h8KvW1kQpAOpP6NEVi9bU6xfUnNN1o0PiT7HP5k9ebaLWaD7m6PwNyiGgZDg==",
 	}
 
 	for _, example := range negativeExamples {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Firebase Scrypt password hash and salt decoding uses base64.StdEncoding.
When users are exported from Firebase, their PasswordHash may contain URL-safe Base64 characters (`-` and `_`). These characters cannot be decoded by base64.StdEncoding.DecodeString(), causing decoding errors.
Related issue: https://github.com/firebase/firebase-admin-go/issues/479

## What is the new behavior?

* Changed PasswordHash and salt decoding to use base64.URLEncoding
* `signerKey` and `saltSeparator` continue to use base64.StdEncoding (as they are provided in standard Base64 format)

Test updates:
* Updated test data to use salt and hash containing URL-safe Base64 characters (_)
* Added negative test cases to verify that standard Base64 (containing `/`) in salt and hash results in errors

## Additional context
According to Firebase Admin SDK Issue https://github.com/firebase/firebase-admin-go/issues/479, when exporting user data from Firebase, the PasswordHash is encoded in URL-safe Base64, while the signerKey provided in the Firebase Console uses standard Base64.
When importing users from Firebase Auth, the exported data contains URL-safe Base64 encoded values like:
```
{  
  "passwordHash": "cxbDzJu2W1DU20SXh--UNtR9Tu2tH2GSKQ91hGBAEN49OJJpuZbdhz-3GdYnBujQXxkXdqnhUehXVeLA6zoF-g==",  
  "passwordSalt": "G-s6NpQQJdtvlQ=="
}
```
Both passwordHash and passwordSalt contain `-` characters, which are URL-safe Base64 specific and cannot be decoded with standard Base64.