### PR TITLE
feat: increment refresh token counter by 2 for mfa verify

### DIFF
--- a/internal/api/token.go
+++ b/internal/api/token.go
@@ -333,7 +333,13 @@ func (a *API) updateMFASessionAndClaims(r *http.Request, tx *storage.Connection,
 				return apierrors.NewInternalServerError("Failed to get session's refresh token key").WithInternalError(terr)
 			}
 
-			counter := *session.RefreshTokenCounter + 1
+			// Incrementing the refresh token counter by 2 here is
+			// counter intuitive, but is important for security. It
+			// means that the previous refresh token (issued with
+			// AAL1) will no longer be able to issue AAL2 sessions.
+			// It forces the client to have received the refresh
+			// token from the MFA verification flow.
+			counter := *session.RefreshTokenCounter + 2
 			session.RefreshTokenCounter = &counter
 
 			issuedRefreshToken = (&crypto.RefreshToken{


### PR DESCRIPTION
Increments the refresh token counter by 2 instead of 1 on the MFA verify action. This ensures that the previous refresh tokens (who were issued when the session was at AAL1) cannot be used any more to issue an AAL2 session by reuse.