### PR TITLE
fix: check each type independently

### DIFF
--- a/migrations/20221003041349_add_mfa_schema.up.sql
+++ b/migrations/20221003041349_add_mfa_schema.up.sql
@@ -1,7 +1,17 @@
 -- see: https://stackoverflow.com/questions/7624919/check-if-a-user-defined-type-already-exists-in-postgresql/48382296#48382296
 do $$ begin
     create type {{ index .Options "Namespace" }}.factor_type as enum('totp', 'webauthn');
+exception
+    when duplicate_object then null;
+end $$;
+
+do $$ begin
     create type {{ index .Options "Namespace" }}.factor_status as enum('unverified', 'verified');
+exception
+    when duplicate_object then null;
+end $$;
+
+do $$ begin
     create type {{ index .Options "Namespace" }}.aal_level as enum('aal1', 'aal2', 'aal3');
 exception
     when duplicate_object then null;


### PR DESCRIPTION
Because type creation resides in the do block it is all or nothing. When it's not a duplicate object that behavior is appropriate, but if it's because one of the types already exists then you will fail the creation of the other types.

For example:
* `aal_level` type already exists
* `factor_status` & `factor_type` are missing

Currently this would prevent `factor_status` & `factor_type` from ever getting created.