### PR TITLE
feat(oauth): add support for cursor://anysphere.cursor-mcp redirect URIs

### DIFF
--- a/internal/api/oauthserver/service_test.go
+++ b/internal/api/oauthserver/service_test.go
@@ -269,6 +269,41 @@ func (ts *OAuthServiceTestSuite) TestRedirectURIValidation() {
 			uri:         "http://127.0.0.1:8080/callback",
 			shouldError: false,
 		},
+		// Cursor MCP support test cases
+		{
+			name:        "Valid cursor://anysphere.cursor-mcp",
+			uri:         "cursor://anysphere.cursor-mcp",
+			shouldError: false,
+		},
+		{
+			name:        "Valid cursor://anysphere.cursor-mcp with path",
+			uri:         "cursor://anysphere.cursor-mcp/callback",
+			shouldError: false,
+		},
+		{
+			name:        "Valid cursor://anysphere.cursor-mcp with path and query",
+			uri:         "cursor://anysphere.cursor-mcp/auth/callback?state=abc",
+			shouldError: false,
+		},
+		{
+			name:        "Invalid cursor:// with wrong host",
+			uri:         "cursor://other.example.com/callback",
+			shouldError: true,
+			errorMsg:    "scheme must be HTTPS or HTTP (localhost only)",
+		},
+		{
+			name:        "Invalid cursor:// without host",
+			uri:         "cursor:///callback",
+			shouldError: true,
+			errorMsg:    "must have scheme and host",
+		},
+		{
+			name:        "Invalid cursor://anysphere.cursor-mcp with fragment",
+			uri:         "cursor://anysphere.cursor-mcp/callback#fragment",
+			shouldError: true,
+			errorMsg:    "fragment not allowed in redirect URI",
+		},
+		// Standard test cases
 		{
 			name:        "Invalid empty URI",
 			uri:         "",
@@ -297,7 +332,7 @@ func (ts *OAuthServiceTestSuite) TestRedirectURIValidation() {
 			name:        "Invalid URI format",
 			uri:         "not-a-uri",
 			shouldError: true,
-			errorMsg:    "must have scheme and host",
+			errorMsg:    "must have scheme",
 		},
 	}
 


### PR DESCRIPTION
Add support for Cursor IDE MCP (Model Context Protocol) OAuth flows by allowing the `cursor://anysphere.cursor-mcp` redirect URI scheme+host combination.

This enables Cursor IDE to authenticate users via Supabase Auth's OAuth 2.1 server for MCP integrations.

### Changes

- Add `allowedCustomSchemeHosts` map for validating custom scheme+host pairs
- Update `validateRedirectURI` to accept `cursor://anysphere.cursor-mcp` URIs
- Add comprehensive tests for the new redirect URI validation rules

### Allowed Redirect URIs

The following redirect URI patterns are now supported:

| Pattern | Example | Allowed |
|---------|---------|---------|
| HTTPS (any host) | `https://example.com/callback` | ✅ |
| HTTP localhost | `http://localhost:3000/callback` | ✅ |
| HTTP 127.0.0.1 | `http://127.0.0.1:8080/callback` | ✅ |
| Cursor MCP | `cursor://anysphere.cursor-mcp/callback` | ✅ |
| Cursor wrong host | `cursor://other.com/callback` | ❌ |
| Other schemes | `ftp://example.com/callback` | ❌ |