### PR TITLE
chore: bump go version in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23.7-alpine3.20 as build
+FROM golang:1.25.5-alpine3.23 as build
 ENV GO111MODULE=on
 ENV CGO_ENABLED=0
 ENV GOOS=linux

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM golang:1.23.7-alpine3.20
+FROM golang:1.25.5-alpine3.23
 ENV GO111MODULE=on
 ENV CGO_ENABLED=0
 ENV GOOS=linux


### PR DESCRIPTION
Bumps Go version to 1.25.5 in docker to match `go.mod`