### PR TITLE
feat: Add email send operation metrics

### DIFF
--- a/internal/api/mail.go
+++ b/internal/api/mail.go
@@ -27,8 +27,8 @@ import (
 
 var (
 	EmailRateLimitExceeded error = errors.New("email rate limit exceeded")
-	emailSendCounter             = observability.ObtainMetricCounter("gotrue_email_send_operations_counter_total", "Number of email send operations")
-	emailErrorsCounter           = observability.ObtainMetricCounter("gotrue_email_send_errors_counter_total", "Number of email send errors")
+	emailSendCounter             = observability.ObtainMetricCounter("global_auth_email_send_operations_total", "Number of email send operations")
+	emailErrorsCounter           = observability.ObtainMetricCounter("global_auth_email_send_errors_total", "Number of email send errors")
 )
 
 type GenerateLinkParams struct {


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR adds two new metrics, `gotrue_email_send_operations_counter_total` and `gotrue_email_send_errors_counter_total`, for tracking email send operations and errors respectively. The purpose of these metrics is to track email delivery independently of the various API handlers that may send email within Auth.

## What is the current behavior?

Users who want to track email sending operations in Auth must use indirect metrics like HTTP status codes to determine whether an email was successfully sent.

## What is the new behavior?

The `gotrue_email_send_operations_counter_total` counter will increment each time Auth attempts to send an email after performing validation and checking rate limits. The `gotrue_email_send_errors_counter_total` counter will increment each time an email send attempt fails.