### PR TITLE
Fix: SAML SP metadata endpoint generates incorrect XML with IDP EntityID

### DIFF
--- a/internal/api/saml.go
+++ b/internal/api/saml.go
@@ -51,6 +51,23 @@ func (a *API) getSAMLServiceProvider(identityProvider *saml.EntityDescriptor, id
 
 	provider.AuthnNameIDFormat = saml.PersistentNameIDFormat
 
+	baseURL := *externalURL
+
+	// Set MetadataURL
+	metadataURL := baseURL
+	metadataURL.Path += "saml/metadata"
+	provider.MetadataURL = metadataURL
+
+	// Set AcsURL (Assertion Consumer Service)
+	acsURL := baseURL
+	acsURL.Path += "saml/acs"
+	provider.AcsURL = acsURL
+
+	// Set SloURL (Single Logout)
+	sloURL := baseURL
+	sloURL.Path += "saml/slo"
+	provider.SloURL = sloURL
+
 	return &provider
 }
 


### PR DESCRIPTION
Issue
The SAML Service Provider metadata endpoint (/auth/v1/sso/saml/metadata) was generating incorrect XML that used the Identity Provider's EntityID as the base URL for all Service Provider service endpoints, instead of using the Supabase project's own URLs.

Expected:

<EntityDescriptor entityID="https://project.supabase.co/auth/v1/sso/saml/metadata">
  <SPSSODescriptor>
    <AssertionConsumerService Location="https://project.supabase.co/auth/v1/sso/saml/acs" />
    <SingleLogoutService Location="https://project.supabase.co/auth/v1/sso/saml/slo" />
  </SPSSODescriptor>
</EntityDescriptor>
Actual (before fix):

<EntityDescriptor entityID="https://idp.example.com/saml/metadata">
  <SPSSODescriptor>
    <AssertionConsumerService Location="https://idp.example.com/saml/acs" />
    <SingleLogoutService Location="https://idp.example.com/saml/slo" />
  </SPSSODescriptor>
</EntityDescriptor>
Impact: Identity Providers correctly rejected the metadata as it claimed the SP was hosted at the IDP's domain, completely blocking SAML SSO integration.

Related Issue: [#41716](https://github.com/supabase/auth/issues/2317)

Root Cause
The samlsp.DefaultServiceProvider() function (from crewjam/saml v0.4.14) was incorrectly initializing the ServiceProvider's MetadataURL, AcsURL, and SloURL fields, causing them to use incorrect base URLs during metadata generation.

Solution
Explicitly override the ServiceProvider's URL fields after creation to ensure they use the correct Supabase project base URL:

MetadataURL → {base}/sso/saml/metadata
AcsURL → {base}/sso/saml/acs
SloURL → {base}/sso/saml/slo
Changes
File: 
internal/api/saml.go

Added URL override logic in 
getSAMLServiceProvider()
 function (lines 54-72) to manually set the correct URLs after samlsp.DefaultServiceProvider() initialization.