### PR TITLE
docs(openapi): clarify AAL2 requirement for password/email updates when MFA is enabled

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -648,6 +648,13 @@ paths:
                 $ref: "#/components/schemas/UserSchema"
     put:
       summary: Update certain properties of the current user account.
+      description: |
+            **Important:**
+            If the user has MFA enabled (TOTP or SMS), this endpoint requires
+            an Authenticator Assurance Level (AAL) of 2.
+            Sessions obtained from password recovery links are AAL1 by default
+            and will be rejected when attempting to update email or password
+            unless MFA verification is completed.
       tags:
         - user
       security:
@@ -687,6 +694,11 @@ paths:
                 $ref: "#/components/schemas/UserSchema"
         400:
           $ref: "#/components/responses/BadRequestResponse"
+        401:
+          description: |
+              Unauthorized.
+              A session with Authenticator Assurance Level 2 (AAL2) is required
+              to update email or password when MFA is enabled.
         429:
           $ref: "#/components/responses/RateLimitResponse"
 


### PR DESCRIPTION
This PR documents existing Supabase Auth behavior where updating
email or password requires an AAL2 session when MFA (TOTP or SMS)
is enabled.

Sessions obtained from password recovery links are AAL1 by default
and will be rejected by PUT /user when attempting to update
email or password.

This change does NOT modify runtime behavior.
It clarifies the contract in the OpenAPI spec to avoid confusion.

Related issue:
- #2091 resetPasswordForEmail + MFA: Cannot update password due to AAL2 requirement