### PR TITLE
panic removed from verfiy

### DIFF
--- a/internal/api/verify.go
+++ b/internal/api/verify.go
@@ -111,10 +111,9 @@ func (a *API) Verify(w http.ResponseWriter, r *http.Request) error {
 			return err
 		}
 		return a.verifyPost(w, r, params)
-	default:
-		// this should have been handled by Chi
-		panic("Only GET and POST methods allowed")
 	}
+	//chi handles by sending a 405 Method Not Allowed response returning nil to compile
+	return nil
 }
 
 func (a *API) verifyGet(w http.ResponseWriter, r *http.Request, params *VerifyParams) error {


### PR DESCRIPTION
## What kind of change does this PR introduce?

In the verify method there was a unrequired panic as the chi router already handle if the method is  other than post or get.

## What is the current behavior?

Removed the panic from deafult will will never run.
## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
