### PR TITLE
fix: correctly parse JWT ValidMethods from env by enabling split_words

### DIFF
--- a/internal/conf/configuration.go
+++ b/internal/conf/configuration.go
@@ -137,7 +137,7 @@ type JWTConfiguration struct {
 	Issuer           string         `json:"issuer"`
 	KeyID            string         `json:"key_id" split_words:"true"`
 	Keys             JwtKeysDecoder `json:"keys"`
-	ValidMethods     []string       `json:"-"`
+	ValidMethods     []string       `json:"-" split_words:"true"`
 }
 
 type MFAFactorTypeConfiguration struct {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

JWT ValidMethods not parsed from env because split_words was missing on the struct tag, causing envconfig to look for `GOTRUE_JWT_VALIDMETHODS` instead of `GOTRUE_JWT_VALID_METHODS`. Since v2.71.1, cli defaults to asymmetric keys, which caused valid HS256 tokens to be rejected.

## What is the new behavior?

This change adds `split_words` to ensure the correct env var is used. I assume that `GOTRUE_JWT_VALID_METHODS` is the correct env var but if it isn't, then this issue can also be solved by updating the env var passed to auth service in [supabase cli](https://github.com/supabase/cli/blob/5122df4f64490526e3b90852c221e9ff4f6492f6/internal/start/start.go#L629) to
```
			env = append(env, "GOTRUE_JWT_VALIDMETHODS=HS256,RS256,ES256")
```

## Additional context

The following screenshots are from print statements I added

1. config.JWT.ValidMethods was nil because it was looking for wrong env var. It defaulted to jwk key algorithm (ES256).
https://github.com/supabase/auth/blob/645654df63a3da7929840659c065f6a9cdd4ba96/internal/conf/configuration.go#L1092-L1097
	<img width="1289" height="61" alt="Screenshot 2026-01-17 041756" src="https://github.com/user-attachments/assets/00d0e883-cec8-472a-946b-0ac65b6c140d" />
	
	<img width="622" height="122" alt="Screenshot 2026-01-17 042002" src="https://github.com/user-attachments/assets/844bcb38-cd45-4e11-992a-e230ade6cb1e" />

	
2. After
	<img width="977" height="82" alt="image" src="https://github.com/user-attachments/assets/55271d4a-16cf-4ec7-923e-f581d0f5c15d" />


