### PR TITLE
ci: generate GH token to allow creation of PRs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,11 +25,20 @@ jobs:
       RELEASE_CANDIDATE: ${{ steps.versions.outputs.RELEASE_CANDIDATE }}
       RELEASE_NAME: ${{ steps.versions.outputs.RELEASE_NAME }}
     steps:
+
+      - name: Generate token
+        id: app-token
+        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf
+        with:
+          app-id: ${{ secrets.GH_AUTOFIX_APP_ID }}
+          private-key: ${{ secrets.GH_AUTOFIX_PRIVATE_KEY }}
+
       - uses: googleapis/release-please-action@v4
         id: release
         with:
           release-type: go
           target-branch: ${{ github.ref_name }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - uses: actions/checkout@v4
         if: ${{ steps.release.outputs.release_created == 'true' || steps.release.outputs.prs_created == 'true' }}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Generates a GH token that allows the workflow to create PRs.

We no longer allow GHAs to create PRs by default.
