### PR TITLE
feat: log sb-auth-user-id, sb-auth-session-id, ... on sign in not just refresh token

### DIFF
--- a/internal/api/anonymous.go
+++ b/internal/api/anonymous.go
@@ -44,7 +44,7 @@ func (a *API) SignupAnonymously(w http.ResponseWriter, r *http.Request) error {
 		if terr != nil {
 			return terr
 		}
-		token, terr = a.issueRefreshToken(r, tx, newUser, models.Anonymous, grantParams)
+		token, terr = a.issueRefreshToken(r, w.Header(), tx, newUser, models.Anonymous, grantParams)
 		if terr != nil {
 			return terr
 		}

--- a/internal/api/external.go
+++ b/internal/api/external.go
@@ -257,7 +257,7 @@ func (a *API) internalExternalProviderCallback(w http.ResponseWriter, r *http.Re
 			terr = tx.Update(flowState)
 		} else {
 			// Implicit flow: issue tokens directly
-			token, terr = a.issueRefreshToken(r, tx, user, models.OAuth, grantParams)
+			token, terr = a.issueRefreshToken(r, w.Header(), tx, user, models.OAuth, grantParams)
 			if terr == nil && flowState != nil {
 				terr = tx.Destroy(flowState)
 			}

--- a/internal/api/samlacs.go
+++ b/internal/api/samlacs.go
@@ -320,7 +320,7 @@ func (a *API) handleSamlAcs(w http.ResponseWriter, r *http.Request) error {
 			}
 		}
 
-		token, terr = a.issueRefreshToken(r, tx, user, models.SSOSAML, grantParams)
+		token, terr = a.issueRefreshToken(r, w.Header(), tx, user, models.SSOSAML, grantParams)
 
 		if terr != nil {
 			return apierrors.NewInternalServerError("Unable to issue refresh token from SAML Assertion").WithInternalError(terr)

--- a/internal/api/signup.go
+++ b/internal/api/signup.go
@@ -312,7 +312,7 @@ func (a *API) Signup(w http.ResponseWriter, r *http.Request) error {
 			}); terr != nil {
 				return terr
 			}
-			token, terr = a.issueRefreshToken(r, tx, user, models.PasswordGrant, grantParams)
+			token, terr = a.issueRefreshToken(r, w.Header(), tx, user, models.PasswordGrant, grantParams)
 
 			if terr != nil {
 				return terr

--- a/internal/api/token.go
+++ b/internal/api/token.go
@@ -295,8 +295,8 @@ func (a *API) generateAccessToken(r *http.Request, tx *storage.Connection, user 
 	})
 }
 
-func (a *API) issueRefreshToken(r *http.Request, conn *storage.Connection, user *models.User, authenticationMethod models.AuthenticationMethod, grantParams models.GrantParams) (*tokens.AccessTokenResponse, error) {
-	return a.tokenService.IssueRefreshToken(r, make(http.Header), conn, user, authenticationMethod, grantParams)
+func (a *API) issueRefreshToken(r *http.Request, headers http.Header, conn *storage.Connection, user *models.User, authenticationMethod models.AuthenticationMethod, grantParams models.GrantParams) (*tokens.AccessTokenResponse, error) {
+	return a.tokenService.IssueRefreshToken(r, headers, conn, user, authenticationMethod, grantParams)
 }
 
 func (a *API) updateMFASessionAndClaims(r *http.Request, tx *storage.Connection, user *models.User, authenticationMethod models.AuthenticationMethod, grantParams models.GrantParams) (*tokens.AccessTokenResponse, error) {

--- a/internal/api/token_oidc.go
+++ b/internal/api/token_oidc.go
@@ -306,7 +306,7 @@ func (a *API) IdTokenGrant(ctx context.Context, w http.ResponseWriter, r *http.R
 			return terr
 		}
 
-		token, terr = a.issueRefreshToken(r, tx, user, models.OAuth, grantParams)
+		token, terr = a.issueRefreshToken(r, w.Header(), tx, user, models.OAuth, grantParams)
 		if terr != nil {
 			return terr
 		}

--- a/internal/api/verify.go
+++ b/internal/api/verify.go
@@ -182,7 +182,7 @@ func (a *API) verifyGet(w http.ResponseWriter, r *http.Request, params *VerifyPa
 		}
 
 		if isImplicitFlow(flowType) {
-			token, terr = a.issueRefreshToken(r, tx, user, models.OTP, grantParams)
+			token, terr = a.issueRefreshToken(r, w.Header(), tx, user, models.OTP, grantParams)
 			if terr != nil {
 				return terr
 			}
@@ -282,7 +282,7 @@ func (a *API) verifyPost(w http.ResponseWriter, r *http.Request, params *VerifyP
 		if terr := tx.Reload(user); terr != nil {
 			return terr
 		}
-		token, terr = a.issueRefreshToken(r, tx, user, models.OTP, grantParams)
+		token, terr = a.issueRefreshToken(r, w.Header(), tx, user, models.OTP, grantParams)
 		if terr != nil {
 			return terr
 		}

--- a/internal/api/web3.go
+++ b/internal/api/web3.go
@@ -165,7 +165,7 @@ func (a *API) web3GrantSolana(ctx context.Context, w http.ResponseWriter, r *htt
 			return terr
 		}
 
-		token, terr = a.issueRefreshToken(r, tx, user, models.Web3, grantParams)
+		token, terr = a.issueRefreshToken(r, w.Header(), tx, user, models.Web3, grantParams)
 		if terr != nil {
 			return terr
 		}
@@ -311,7 +311,7 @@ func (a *API) web3GrantEthereum(ctx context.Context, w http.ResponseWriter, r *h
 			return terr
 		}
 
-		token, terr = a.issueRefreshToken(r, tx, user, models.Web3, grantParams)
+		token, terr = a.issueRefreshToken(r, w.Header(), tx, user, models.Web3, grantParams)
 		if terr != nil {
 			return terr
 		}


### PR DESCRIPTION
In #2216 some new headers were added to responses that are able to track the user ID, session and other data which cannot be extracted from JWTs. This aids in debugging and correlation of all requests made by a specific user.