### PR TITLE
fix: reloader unittest races on writeWg

### DIFF
--- a/internal/reloader/poller_test.go
+++ b/internal/reloader/poller_test.go
@@ -168,6 +168,7 @@ func TestPoller(t *testing.T) {
 		defer egCancel()
 
 		writerWg := new(sync.WaitGroup)
+		writerWg.Add(1)
 		writerDoneCh := make(chan struct{})
 
 		notifyCalled := false
@@ -190,7 +191,6 @@ func TestPoller(t *testing.T) {
 			return pr.watch(egCtx, time.Millisecond*100, notifyFn, errFn)
 		})
 
-		writerWg.Add(1)
 		eg.Go(func() error {
 			defer writerWg.Done()
 


### PR DESCRIPTION
It's possible for `writerWg.Add(1)` to race with the `notifyFn` passed in `eg.Go`'s call to `pr.watch`. Simple fix is incrementing after writeWg is initialized.