### PR TITLE
fix(api): update rate limiters on hot config reload

### DIFF
--- a/cmd/serve_cmd.go
+++ b/cmd/serve_cmd.go
@@ -145,12 +145,8 @@ func serve(ctx context.Context) {
 						templatemailer.FromConfig(latestCfg, mrCache),
 					),
 
-					// Persist existing rate limiters.
-					//
-					// TODO(cstockton): we should consider updating these, if we
-					// rely on hot config reloads 100% then rate limiter changes
-					// won't be picked up.
-					limiterOpts,
+					// Update rate limiters based on new config.
+					api.NewLimiterOptions(latestCfg),
 				)
 				ah.Store(latestAPI)
 			}


### PR DESCRIPTION
Previously, rate limiters were persisted across hot reloads, preventing configuration changes from taking effect. This change ensures rate limiters are updated with new config values, enabling dynamic rate limiting adjustments without restarting the service.

This was a TODO