### PR TITLE
feat: add metadata field to all hooks

### DIFF
--- a/internal/api/e2e_test.go
+++ b/internal/api/e2e_test.go
@@ -66,7 +66,12 @@ func runVerifyBeforeUserCreatedHook(
 		hookReq := &v0hooks.BeforeUserCreatedInput{}
 		err := call.Unmarshal(hookReq)
 		require.NoError(t, err)
+
+		require.NotNil(t, hookReq.Metadata)
+		require.NotEmpty(t, hookReq.Metadata.IPAddress)
 		require.Equal(t, v0hooks.BeforeUserCreated, hookReq.Metadata.Name)
+		require.NotEqual(t, uuid.Nil, hookReq.Metadata.UUID)
+		require.False(t, hookReq.Metadata.Time.IsZero())
 
 		u := hookReq.User
 		require.Equal(t, expUser.ID, u.ID)
@@ -103,7 +108,12 @@ func runVerifyAfterUserCreatedHook(
 		hookReq := &v0hooks.AfterUserCreatedInput{}
 		err := call.Unmarshal(hookReq)
 		require.NoError(t, err)
+
+		require.NotNil(t, hookReq.Metadata)
+		require.NotEmpty(t, hookReq.Metadata.IPAddress)
 		require.Equal(t, v0hooks.AfterUserCreated, hookReq.Metadata.Name)
+		require.NotEqual(t, uuid.Nil, hookReq.Metadata.UUID)
+		require.False(t, hookReq.Metadata.Time.IsZero())
 
 		u := hookReq.User
 		require.Equal(t, expUser.ID, u.ID)
@@ -175,6 +185,12 @@ func signupAndConfirmEmail(
 	hookReq := &v0hooks.SendEmailInput{}
 	err = call.Unmarshal(hookReq)
 	require.NoError(t, err)
+
+	require.NotNil(t, hookReq.Metadata)
+	require.NotEmpty(t, hookReq.Metadata.IPAddress)
+	require.Equal(t, v0hooks.SendEmail, hookReq.Metadata.Name)
+	require.NotEqual(t, uuid.Nil, hookReq.Metadata.UUID)
+	require.False(t, hookReq.Metadata.Time.IsZero())
 
 	// verify that the latest user from find user matches OTP
 	otpHash := crypto.GenerateTokenHash(
@@ -285,6 +301,12 @@ func TestE2EHooks(t *testing.T) {
 				err = call.Unmarshal(hookReq)
 				require.NoError(t, err)
 
+				require.NotNil(t, hookReq.Metadata)
+				require.NotEmpty(t, hookReq.Metadata.IPAddress)
+				require.Equal(t, v0hooks.SendSMS, hookReq.Metadata.Name)
+				require.NotEqual(t, uuid.Nil, hookReq.Metadata.UUID)
+				require.False(t, hookReq.Metadata.Time.IsZero())
+
 				latestUser, err := models.FindUserByID(inst.Conn, signupUser.ID)
 				require.NoError(t, err)
 				require.NotNil(t, latestUser)
@@ -382,6 +404,12 @@ func TestE2EHooks(t *testing.T) {
 					hookReq := &v0hooks.SendSMSInput{}
 					err = call.Unmarshal(hookReq)
 					require.NoError(t, err)
+
+					require.NotNil(t, hookReq.Metadata)
+					require.NotEmpty(t, hookReq.Metadata.IPAddress)
+					require.Equal(t, v0hooks.SendSMS, hookReq.Metadata.Name)
+					require.NotEqual(t, uuid.Nil, hookReq.Metadata.UUID)
+					require.False(t, hookReq.Metadata.Time.IsZero())
 
 					require.Equal(t, currentUser.ID, hookReq.User.ID)
 					require.Equal(t, currentUser.Aud, hookReq.User.Aud)
@@ -924,6 +952,13 @@ func TestE2EHooks(t *testing.T) {
 					hookReq := &v0hooks.CustomAccessTokenInput{}
 					err := call.Unmarshal(hookReq)
 					require.NoError(t, err)
+
+					require.NotNil(t, hookReq.Metadata)
+					require.NotEmpty(t, hookReq.Metadata.IPAddress)
+					require.Equal(t, v0hooks.CustomizeAccessToken, hookReq.Metadata.Name)
+					require.NotEqual(t, uuid.Nil, hookReq.Metadata.UUID)
+					require.False(t, hookReq.Metadata.Time.IsZero())
+
 					require.Equal(t, currentUser.ID, hookReq.UserID)
 					require.Equal(t, currentUser.ID.String(), hookReq.Claims.Subject)
 				}
@@ -1127,6 +1162,12 @@ func TestE2EHooks(t *testing.T) {
 				err = call.Unmarshal(hookReq)
 				require.NoError(t, err)
 
+				require.NotNil(t, hookReq.Metadata)
+				require.NotEmpty(t, hookReq.Metadata.IPAddress)
+				require.Equal(t, v0hooks.SendEmail, hookReq.Metadata.Name)
+				require.NotEqual(t, uuid.Nil, hookReq.Metadata.UUID)
+				require.False(t, hookReq.Metadata.Time.IsZero())
+
 				// hook user matches the signup user
 				require.Equal(t, signupUser.ID, hookReq.User.ID)
 				require.Equal(t, signupUser.Aud, hookReq.User.Aud)
@@ -1240,6 +1281,12 @@ func TestE2EHooks(t *testing.T) {
 				err = call.Unmarshal(hookReq)
 				require.NoError(t, err)
 
+				require.NotNil(t, hookReq.Metadata)
+				require.NotEmpty(t, hookReq.Metadata.IPAddress)
+				require.Equal(t, v0hooks.SendEmail, hookReq.Metadata.Name)
+				require.NotEqual(t, uuid.Nil, hookReq.Metadata.UUID)
+				require.False(t, hookReq.Metadata.Time.IsZero())
+
 				// verify there is an ott generated
 				ott, err := models.FindOneTimeToken(
 					inst.Conn,
@@ -1342,6 +1389,12 @@ func TestE2EHooks(t *testing.T) {
 				hookReq := &v0hooks.SendEmailInput{}
 				err = call.Unmarshal(hookReq)
 				require.NoError(t, err)
+
+				require.NotNil(t, hookReq.Metadata)
+				require.NotEmpty(t, hookReq.Metadata.IPAddress)
+				require.Equal(t, v0hooks.SendEmail, hookReq.Metadata.Name)
+				require.NotEqual(t, uuid.Nil, hookReq.Metadata.UUID)
+				require.False(t, hookReq.Metadata.Time.IsZero())
 
 				// hook user matches the signup user
 				require.Equal(t, signupUser.ID, hookReq.User.ID)
@@ -1452,6 +1505,12 @@ func TestE2EHooks(t *testing.T) {
 				hookReq := &v0hooks.SendEmailInput{}
 				err = call.Unmarshal(hookReq)
 				require.NoError(t, err)
+
+				require.NotNil(t, hookReq.Metadata)
+				require.NotEmpty(t, hookReq.Metadata.IPAddress)
+				require.Equal(t, v0hooks.SendEmail, hookReq.Metadata.Name)
+				require.NotEqual(t, uuid.Nil, hookReq.Metadata.UUID)
+				require.False(t, hookReq.Metadata.Time.IsZero())
 
 				// verify there is an ott generated
 				ott, err := models.FindOneTimeToken(

--- a/internal/api/mail.go
+++ b/internal/api/mail.go
@@ -860,12 +860,13 @@ func (a *API) sendEmail(r *http.Request, tx *storage.Connection, u *models.User,
 			emailData.FactorType = params.factorType
 		}
 
-		input := v0hooks.SendEmailInput{
-			User:      u,
-			EmailData: emailData,
-		}
+		input := v0hooks.NewSendEmailInput(
+			r,
+			u,
+			emailData,
+		)
 		output := v0hooks.SendEmailOutput{}
-		return a.hooksMgr.InvokeHook(tx, r, &input, &output)
+		return a.hooksMgr.InvokeHook(tx, r, input, &output)
 	}
 
 	// Increment email send operations here, since this metric is meant to count number of mail

--- a/internal/api/phone.go
+++ b/internal/api/phone.go
@@ -95,15 +95,16 @@ func (a *API) sendPhoneConfirmation(r *http.Request, tx *storage.Connection, use
 		otp = crypto.GenerateOtp(config.Sms.OtpLength)
 
 		if config.Hook.SendSMS.Enabled {
-			input := v0hooks.SendSMSInput{
-				User: user,
-				SMS: v0hooks.SMS{
+			input := v0hooks.NewSendSMSInput(
+				r,
+				user,
+				v0hooks.SMS{
 					OTP:   otp,
 					Phone: phone,
 				},
-			}
+			)
 			output := v0hooks.SendSMSOutput{}
-			err := a.hooksMgr.InvokeHook(tx, r, &input, &output)
+			err := a.hooksMgr.InvokeHook(tx, r, input, &output)
 			if err != nil {
 				return "", err
 			}

--- a/internal/api/token.go
+++ b/internal/api/token.go
@@ -152,12 +152,13 @@ func (a *API) ResourceOwnerPasswordGrant(ctx context.Context, w http.ResponseWri
 	}
 
 	if config.Hook.PasswordVerificationAttempt.Enabled {
-		input := v0hooks.PasswordVerificationAttemptInput{
-			UserID: user.ID,
-			Valid:  isValidPassword,
-		}
+		input := v0hooks.NewPasswordVerificationAttemptInput(
+			r,
+			user.ID,
+			isValidPassword,
+		)
 		output := v0hooks.PasswordVerificationAttemptOutput{}
-		if err := a.hooksMgr.InvokeHook(nil, r, &input, &output); err != nil {
+		if err := a.hooksMgr.InvokeHook(nil, r, input, &output); err != nil {
 			return err
 		}
 

--- a/internal/hooks/v0hooks/v0hooks.go
+++ b/internal/hooks/v0hooks/v0hooks.go
@@ -115,10 +115,27 @@ type AccessTokenClaims struct {
 }
 
 type MFAVerificationAttemptInput struct {
+	Metadata   *Metadata `json:"metadata"`
 	UserID     uuid.UUID `json:"user_id"`
 	FactorID   uuid.UUID `json:"factor_id"`
 	FactorType string    `json:"factor_type"`
 	Valid      bool      `json:"valid"`
+}
+
+func NewMFAVerificationAttemptInput(
+	r *http.Request,
+	userID uuid.UUID,
+	factorID uuid.UUID,
+	factorType string,
+	valid bool,
+) *MFAVerificationAttemptInput {
+	return &MFAVerificationAttemptInput{
+		Metadata:   NewMetadata(r, MFAVerification),
+		UserID:     userID,
+		FactorID:   factorID,
+		FactorType: factorType,
+		Valid:      valid,
+	}
 }
 
 type MFAVerificationAttemptOutput struct {
@@ -127,8 +144,21 @@ type MFAVerificationAttemptOutput struct {
 }
 
 type PasswordVerificationAttemptInput struct {
-	UserID uuid.UUID `json:"user_id"`
-	Valid  bool      `json:"valid"`
+	Metadata *Metadata `json:"metadata"`
+	UserID   uuid.UUID `json:"user_id"`
+	Valid    bool      `json:"valid"`
+}
+
+func NewPasswordVerificationAttemptInput(
+	r *http.Request,
+	userID uuid.UUID,
+	valid bool,
+) *PasswordVerificationAttemptInput {
+	return &PasswordVerificationAttemptInput{
+		Metadata: NewMetadata(r, PasswordVerification),
+		UserID:   userID,
+		Valid:    valid,
+	}
 }
 
 type PasswordVerificationAttemptOutput struct {
@@ -138,9 +168,24 @@ type PasswordVerificationAttemptOutput struct {
 }
 
 type CustomAccessTokenInput struct {
+	Metadata             *Metadata          `json:"metadata"`
 	UserID               uuid.UUID          `json:"user_id"`
 	Claims               *AccessTokenClaims `json:"claims"`
 	AuthenticationMethod string             `json:"authentication_method"`
+}
+
+func NewCustomAccessTokenInput(
+	r *http.Request,
+	userID uuid.UUID,
+	claims *AccessTokenClaims,
+	authenticationMethod string,
+) *CustomAccessTokenInput {
+	return &CustomAccessTokenInput{
+		Metadata:             NewMetadata(r, CustomizeAccessToken),
+		UserID:               userID,
+		Claims:               claims,
+		AuthenticationMethod: authenticationMethod,
+	}
 }
 
 type CustomAccessTokenOutput struct {
@@ -178,16 +223,42 @@ func (o *CustomAccessTokenOutput) UnmarshalJSON(b []byte) error {
 }
 
 type SendSMSInput struct {
-	User *models.User `json:"user,omitempty"`
-	SMS  SMS          `json:"sms,omitempty"`
+	Metadata *Metadata    `json:"metadata"`
+	User     *models.User `json:"user,omitempty"`
+	SMS      SMS          `json:"sms,omitempty"`
+}
+
+func NewSendSMSInput(
+	r *http.Request,
+	user *models.User,
+	sms SMS,
+) *SendSMSInput {
+	return &SendSMSInput{
+		Metadata: NewMetadata(r, SendSMS),
+		User:     user,
+		SMS:      sms,
+	}
 }
 
 type SendSMSOutput struct {
 }
 
 type SendEmailInput struct {
+	Metadata  *Metadata        `json:"metadata"`
 	User      *models.User     `json:"user"`
 	EmailData mailer.EmailData `json:"email_data"`
+}
+
+func NewSendEmailInput(
+	r *http.Request,
+	user *models.User,
+	emailData mailer.EmailData,
+) *SendEmailInput {
+	return &SendEmailInput{
+		Metadata:  NewMetadata(r, SendEmail),
+		User:      user,
+		EmailData: emailData,
+	}
 }
 
 type SendEmailOutput struct {

--- a/internal/tokens/service.go
+++ b/internal/tokens/service.go
@@ -696,11 +696,12 @@ func (s *Service) GenerateAccessToken(r *http.Request, tx *storage.Connection, p
 
 	var gotrueClaims jwt.Claims = claims
 	if config.Hook.CustomAccessToken.Enabled {
-		input := &v0hooks.CustomAccessTokenInput{
-			UserID:               params.User.ID,
-			Claims:               claims,
-			AuthenticationMethod: params.AuthenticationMethod.String(),
-		}
+		input := v0hooks.NewCustomAccessTokenInput(
+			r,
+			params.User.ID,
+			claims,
+			params.AuthenticationMethod.String(),
+		)
 
 		output := &v0hooks.CustomAccessTokenOutput{}
 


### PR DESCRIPTION
Adds constructors for all hook input types:
* MFAVerificationAttemptInput
* PasswordVerificationAttemptInput
* CustomAccessTokenInput
* SendSMSInput,
* SendEmailInput

To consistently populate metadata fields:
* `name` - Hook Name
* `uuid` - Request UUID
* `time` - Request Time
* `ip_address` Request IP Address

This improves observability and security auditing by guaranteeing that all hook invocations include request metadata. It also enables new use cases by passing the request IP address. For example more advanced methods for rate limiting login or MFA attempts may now be implemented.