### PR TITLE
chore: remove legacy JWT-based flow state handling

### DIFF
--- a/internal/api/context.go
+++ b/internal/api/context.go
@@ -33,7 +33,6 @@ const (
 	oauthVerifierKey    = contextKey("oauth_verifier")
 	ssoProviderKey      = contextKey("sso_provider")
 	externalHostKey     = contextKey("external_host")
-	flowStateKey        = contextKey("flow_state_id")
 	oauthClientStateKey = contextKey("oauth_client_state_id")
 	flowStateContextKey = contextKey("flow_state")
 )
@@ -126,18 +125,6 @@ func withSignature(ctx context.Context, id string) context.Context {
 
 func withInviteToken(ctx context.Context, token string) context.Context {
 	return context.WithValue(ctx, inviteTokenKey, token)
-}
-
-func withFlowStateID(ctx context.Context, FlowStateID string) context.Context {
-	return context.WithValue(ctx, flowStateKey, FlowStateID)
-}
-
-func getFlowStateID(ctx context.Context) string {
-	obj := ctx.Value(flowStateKey)
-	if obj == nil {
-		return ""
-	}
-	return obj.(string)
 }
 
 func withOAuthClientStateID(ctx context.Context, oauthClientStateID uuid.UUID) context.Context {

--- a/internal/api/external_oauth.go
+++ b/internal/api/external_oauth.go
@@ -26,8 +26,8 @@ type OAuthProviderData struct {
 	code         string
 }
 
-// loadFlowState parses the `state` query parameter as a JWS payload,
-// extracting the provider requested
+// loadFlowState parses the `state` query parameter as a UUID,
+// loads the flow state from the database, and extracts the provider requested
 func (a *API) loadFlowState(w http.ResponseWriter, r *http.Request) (context.Context, error) {
 	ctx := r.Context()
 	db := a.db.WithContext(ctx)


### PR DESCRIPTION
With `v2.186.0`, we introduced an opaque state to migrate away from the JWT-based state parameter. This PR removes the graceful fallback to the JWT-based state as the UUID state handling should be available to all projects.