### PR TITLE
fix: clarify error message when token missing email or phone in verify endpoint

### DIFF
--- a/internal/api/verify.go
+++ b/internal/api/verify.go
@@ -78,7 +78,7 @@ func (p *VerifyParams) Validate(r *http.Request, a *API) error {
 				}
 				p.TokenHash = crypto.GenerateTokenHash(p.Email, p.Token)
 			} else {
-				return apierrors.NewBadRequestError(apierrors.ErrorCodeValidationFailed, "When verifying with a token, you must provide either email address or phone number")
+				return apierrors.NewBadRequestError(apierrors.ErrorCodeValidationFailed, "When verifying with a token, you must provide either an email address or a phone number")
 			}
 		} else if p.TokenHash != "" {
 			if p.Email != "" || p.Phone != "" || p.RedirectTo != "" {


### PR DESCRIPTION
…hone

## What kind of change does this PR introduce?

Bug fix / validation improvement


## What is the current behavior?
The POST /verify endpoint returns confusing validation errors when request
parameters are invalid.
Specifically:
when both token and token_hash are provided
when neither is provided
when token is provided without email or phone
when token_hash is provided along with other fields
The validation logic enforces specific parameter combinations, but the
error message does not clearly explain what is wrong, which can confuse developers.

## What is the new behavior?

This change only improves the error message and does not modify the existing
validation logic or verification flow.
The change has not been tested in a running Supabase instance yet,
but it is limited to validation messaging and does not affect core logic.

## Additional context

Add any other context or screenshots.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Clarified token verification error: when a token is supplied but neither email nor phone is provided, users now see the clearer message — "When verifying with a token, you must provide either an email address or a phone number" — to reduce confusion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->