### PR TITLE
fix(hooks): propagate error objects from hook calls

### DIFF
--- a/internal/hooks/hookserrors/hookserrors.go
+++ b/internal/hooks/hookserrors/hookserrors.go
@@ -75,6 +75,10 @@ func check(e *Error) error {
 
 	httpCode := e.HTTPCode
 	if httpCode == 0 {
+		// TODO(cstockton): this really should be a BadRequest as default and
+		// the returned code should be bounded to 4XX codes, ideally specific
+		// 4xx codes.
+		// if httpCode/100 == 4 { httpCode = http.StatusBadRequest }
 		httpCode = http.StatusInternalServerError
 	}
 

--- a/internal/hooks/hookshttp/hookshttp.go
+++ b/internal/hooks/hookshttp/hookshttp.go
@@ -17,6 +17,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/supabase/auth/internal/api/apierrors"
 	"github.com/supabase/auth/internal/conf"
+	"github.com/supabase/auth/internal/hooks/hookserrors"
 	"github.com/supabase/auth/internal/observability"
 
 	standardwebhooks "github.com/standard-webhooks/standard-webhooks/libraries/go"
@@ -225,6 +226,10 @@ func (o *Dispatcher) runHTTPHook(
 					)
 				}
 			}
+			if err := hookserrors.Check(body); err != nil {
+				return nil, err
+			}
+
 			return body, nil
 		case http.StatusTooManyRequests, http.StatusServiceUnavailable:
 			retryAfterHeader := rsp.Header.Get("retry-after")

--- a/internal/hooks/hookshttp/hookshttp_test.go
+++ b/internal/hooks/hookshttp/hookshttp_test.go
@@ -185,6 +185,28 @@ func TestDispatch(t *testing.T) {
 				io.WriteString(w, "12345")
 			}),
 		},
+
+		{
+			desc:   "fail - returning error objects",
+			errStr: "500: failed to verify ip addres",
+			hr: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Add("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+
+				io.WriteString(w, `{"error": {"message": "failed to verify ip addres"}}`)
+			}),
+		},
+
+		{
+			desc:   "fail - returning error objects with status",
+			errStr: "400: failed to verify ip addres",
+			hr: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Add("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+
+				io.WriteString(w, `{"error": {"message": "failed to verify ip addres", "http_code": 400}}`)
+			}),
+		},
 	}
 
 	// error status codes

--- a/internal/hooks/v0hooks/manager_test.go
+++ b/internal/hooks/v0hooks/manager_test.go
@@ -256,14 +256,16 @@ func TestHooks(t *testing.T) {
 			},
 			req: NewBeforeUserCreatedInput(httpReq, &models.User{}),
 			res: &BeforeUserCreatedOutput{},
-			exp: &BeforeUserCreatedOutput{Decision: "reject"},
 			sql: `
 				create or replace function
 					v0hooks_test_before_user_created_reject(input jsonb)
 				returns json as $$
 				begin
-					return '{"decision": "reject"}'::jsonb;
+					return '{"error": {"message": "custom error"}}'::jsonb;
 				end; $$ language plpgsql;`,
+
+			// TODO(cstockton): These really should be 400 errors
+			errStr: "500: custom error",
 		},
 
 		{
@@ -278,14 +280,14 @@ func TestHooks(t *testing.T) {
 			},
 			req: NewBeforeUserCreatedInput(httpReq, &models.User{}),
 			res: &BeforeUserCreatedOutput{},
-			exp: &BeforeUserCreatedOutput{Decision: "reject", Message: "test case"},
 			sql: `
 				create or replace function
 					v0hooks_test_before_user_created_reject_msg(input jsonb)
 				returns json as $$
 				begin
-					return '{"decision": "reject", "message": "test case"}'::jsonb;
+					return '{"error": {"message": "custom error", "http_code": 403}}'::jsonb;
 				end; $$ language plpgsql;`,
+			errStr: "403: custom error",
 		},
 
 		{

--- a/internal/hooks/v0hooks/v0hooks.go
+++ b/internal/hooks/v0hooks/v0hooks.go
@@ -70,8 +70,6 @@ func NewBeforeUserCreatedInput(
 }
 
 type BeforeUserCreatedOutput struct {
-	Decision string `json:"decision"`
-	Message  string `json:"message"`
 }
 
 type AfterUserCreatedInput struct {


### PR DESCRIPTION
Package `hookerrors` was meant to introduce consistent error handling across `hookshttp` and `hookspgfunc`. However it was not being used within the `hookshttp` package. This change fixes that to have one consistent error mechanism supported across all hooks.

For http hooks specifically there is an error in the supabase docs that I will resolve in a follow up pr. The status code from the invoked hook should indicate the response status only for the auth server. This means a response of 500 will be treated as a failed invocation of the hook and the response body will not be ready.

Responses will only be read when the status code is 200 or 202. If so it will read the body, if it is the body will be checked by the hookserrors package for an error object. If present it will be propagated to the original client.