### PR TITLE
feat: merge UserInfo claims into ID token for custom OIDC providers

### DIFF
--- a/internal/api/custom_oauth_admin.go
+++ b/internal/api/custom_oauth_admin.go
@@ -60,6 +60,7 @@ type AdminCustomOAuthProviderParams struct {
 	Issuer         string  `json:"issuer,omitempty"`
 	DiscoveryURL   *string `json:"discovery_url,omitempty"`
 	SkipNonceCheck *bool   `json:"skip_nonce_check,omitempty"`
+	FetchUserinfo  *bool   `json:"fetch_userinfo,omitempty"`
 
 	// OAuth2-specific fields
 	AuthorizationURL string  `json:"authorization_url,omitempty"`
@@ -452,6 +453,7 @@ func buildProviderFromParams(params *AdminCustomOAuthProviderParams, providerTyp
 		provider.Issuer = &params.Issuer
 		provider.DiscoveryURL = params.DiscoveryURL
 		provider.SkipNonceCheck = getBoolOrDefault(params.SkipNonceCheck, false)
+		provider.FetchUserinfo = getBoolOrDefault(params.FetchUserinfo, false)
 
 		// Ensure openid scope is present for OIDC
 		hasOpenID := false
@@ -542,6 +544,9 @@ func updateProviderFromParams(provider *models.CustomOAuthProvider, params *Admi
 		}
 		if params.SkipNonceCheck != nil {
 			provider.SkipNonceCheck = *params.SkipNonceCheck
+		}
+		if params.FetchUserinfo != nil {
+			provider.FetchUserinfo = *params.FetchUserinfo
 		}
 	} else if provider.IsOAuth2() {
 		if params.AuthorizationURL != "" {

--- a/internal/api/external.go
+++ b/internal/api/external.go
@@ -762,6 +762,7 @@ func (a *API) loadCustomProvider(ctx context.Context, db *storage.Connection, id
 		scopeList,
 		*customProvider.Issuer,
 		customProvider.PKCEEnabled,
+		customProvider.FetchUserinfo,
 		customProvider.AcceptableClientIDs,
 		customProvider.AttributeMapping,
 		customProvider.AuthorizationParams,

--- a/internal/models/custom_oauth_provider.go
+++ b/internal/models/custom_oauth_provider.go
@@ -39,6 +39,7 @@ type CustomOAuthProvider struct {
 	AuthorizationParams slices.Map    `db:"authorization_params" json:"authorization_params"`
 	Enabled             bool          `db:"enabled" json:"enabled"`
 	EmailOptional       bool          `db:"email_optional" json:"email_optional"`
+	FetchUserinfo       bool          `db:"fetch_userinfo" json:"fetch_userinfo"`
 
 	// OIDC-specific fields (null for OAuth2 providers)
 	Issuer            *string        `db:"issuer" json:"issuer,omitempty"`

--- a/migrations/20260221120000_add_fetch_userinfo_to_custom_oauth_providers.up.sql
+++ b/migrations/20260221120000_add_fetch_userinfo_to_custom_oauth_providers.up.sql
@@ -1,0 +1,8 @@
+-- Add fetch_userinfo column to custom_oauth_providers
+-- When true for OIDC providers, UserInfo endpoint is called after ID token
+-- verification and claims are merged. Useful for providers like NHS CIS2
+-- where profile/role data is only available via UserInfo, not the ID token.
+
+/* auth_migration: 20260221120000 */
+ALTER TABLE {{ index .Options "Namespace" }}.custom_oauth_providers
+    ADD COLUMN IF NOT EXISTS fetch_userinfo boolean NOT NULL DEFAULT false;


### PR DESCRIPTION
## Summary
- Adds a `fetch_userinfo` option for custom OIDC providers that fetches the UserInfo endpoint after ID token verification and merges the claims
- Needed for providers like NHS CIS2 where profile/role data is only available via UserInfo, not in the ID token
- UserInfo claim values take precedence over ID token claims for non-empty fields

## When this applies

Some OIDC providers only return minimal claims in the ID token (e.g. `sub`, `email`) and serve richer profile data exclusively through the UserInfo endpoint. With `fetch_userinfo: true`, the provider will call UserInfo after verifying the ID token and merge the results.

**Applies (`fetch_userinfo: true`):**
- **NHS CIS2** — role/profile data (`nhsid_nrbac_roles`, `uid`, `id_assurance_level`) is only on the UserInfo endpoint; the ID token only contains `sub` and basic identity
- **Some enterprise IdPs** — organisations that configure their IdP to keep the ID token lean and serve extended attributes (groups, roles, department) via UserInfo only
- **Providers with large claim sets** — IdPs that cap ID token size and offload overflow claims to UserInfo

**Does not apply (`fetch_userinfo: false`, the default):**
- **Standard OIDC providers** (Google, Azure AD, Okta) — these already include `email`, `name`, `picture`, etc. in the ID token
- **Providers where ID token is sufficient** — if all the claims you need are already in the ID token, there's no reason to make an extra HTTP call
- **OAuth2-only providers** — this option is OIDC-specific; plain OAuth2 custom providers always use the userinfo URL directly

## Merge behaviour

When enabled, claims are merged as follows:
- UserInfo values **override** ID token values for non-empty fields
- ID token values are **preserved** if the corresponding UserInfo field is empty/zero
- If UserInfo returns additional fields not in the ID token, they are **added**
- If the UserInfo call **fails**, the provider falls back silently to ID token data only (non-fatal)

## Test plan
- [x] Verify `fetch_userinfo` flag can be set via admin API (create and update)
- [x] Verify OIDC provider with `fetch_userinfo=true` stores the flag and userinfo endpoint
- [x] Verify OIDC provider with `fetch_userinfo=false` (default) behaves as before
- [x] Unit tests for `mergeClaims`: filling missing fields, overriding, empty strings preserved, custom claims (NHS roles), email_verified override
- [ ] Verify UserInfo failure is non-fatal and falls back to ID token data only
- [ ] Run migration on test database

🤖 Generated with [Claude Code](https://claude.com/claude-code)