### PR TITLE
feat: modernize IsNotFoundError handler to support errors.Is

### DIFF
--- a/internal/models/errors.go
+++ b/internal/models/errors.go
@@ -1,48 +1,26 @@
 package models
 
+import "errors"
+
+// sentinel error for all not found errors.
+var errNotFound = errors.New("not found")
+
+// sentinel error for unique constraint violations.
+var errUniqueConstraintViolated = errors.New("unique constraint violated")
+
 // IsNotFoundError returns whether an error represents a "not found" error.
 func IsNotFoundError(err error) bool {
-	switch err.(type) {
-	case UserNotFoundError, *UserNotFoundError:
-		return true
-	case SessionNotFoundError, *SessionNotFoundError:
-		return true
-	case ConfirmationTokenNotFoundError, *ConfirmationTokenNotFoundError:
-		return true
-	case ConfirmationOrRecoveryTokenNotFoundError, *ConfirmationOrRecoveryTokenNotFoundError:
-		return true
-	case RefreshTokenNotFoundError, *RefreshTokenNotFoundError:
-		return true
-	case IdentityNotFoundError, *IdentityNotFoundError:
-		return true
-	case ChallengeNotFoundError, *ChallengeNotFoundError:
-		return true
-	case FactorNotFoundError, *FactorNotFoundError:
-		return true
-	case SSOProviderNotFoundError, *SSOProviderNotFoundError:
-		return true
-	case SAMLRelayStateNotFoundError, *SAMLRelayStateNotFoundError:
-		return true
-	case FlowStateNotFoundError, *FlowStateNotFoundError:
-		return true
-	case OneTimeTokenNotFoundError, *OneTimeTokenNotFoundError:
-		return true
-	case OAuthServerClientNotFoundError, *OAuthServerClientNotFoundError:
-		return true
-	case OAuthServerAuthorizationNotFoundError, *OAuthServerAuthorizationNotFoundError:
-		return true
-	case OAuthClientStateNotFoundError, *OAuthClientStateNotFoundError:
-		return true
-	case CustomOAuthProviderNotFoundError, *CustomOAuthProviderNotFoundError:
-		return true
-	}
-	return false
+	return errors.Is(err, errNotFound)
 }
 
 type SessionNotFoundError struct{}
 
 func (e SessionNotFoundError) Error() string {
 	return "Session not found"
+}
+
+func (e SessionNotFoundError) Is(target error) bool {
+	return target == errNotFound
 }
 
 // UserNotFoundError represents when a user is not found.
@@ -52,11 +30,19 @@ func (e UserNotFoundError) Error() string {
 	return "User not found"
 }
 
+func (e UserNotFoundError) Is(target error) bool {
+	return target == errNotFound
+}
+
 // IdentityNotFoundError represents when an identity is not found.
 type IdentityNotFoundError struct{}
 
 func (e IdentityNotFoundError) Error() string {
 	return "Identity not found"
+}
+
+func (e IdentityNotFoundError) Is(target error) bool {
+	return target == errNotFound
 }
 
 // ConfirmationOrRecoveryTokenNotFoundError represents when a confirmation or recovery token is not found.
@@ -66,11 +52,19 @@ func (e ConfirmationOrRecoveryTokenNotFoundError) Error() string {
 	return "Confirmation or Recovery Token not found"
 }
 
+func (e ConfirmationOrRecoveryTokenNotFoundError) Is(target error) bool {
+	return target == errNotFound
+}
+
 // ConfirmationTokenNotFoundError represents when a confirmation token is not found.
 type ConfirmationTokenNotFoundError struct{}
 
 func (e ConfirmationTokenNotFoundError) Error() string {
 	return "Confirmation Token not found"
+}
+
+func (e ConfirmationTokenNotFoundError) Is(target error) bool {
+	return target == errNotFound
 }
 
 // RefreshTokenNotFoundError represents when a refresh token is not found.
@@ -80,6 +74,10 @@ func (e RefreshTokenNotFoundError) Error() string {
 	return "Refresh Token not found"
 }
 
+func (e RefreshTokenNotFoundError) Is(target error) bool {
+	return target == errNotFound
+}
+
 // FactorNotFoundError represents when a user is not found.
 type FactorNotFoundError struct{}
 
@@ -87,11 +85,19 @@ func (e FactorNotFoundError) Error() string {
 	return "Factor not found"
 }
 
+func (e FactorNotFoundError) Is(target error) bool {
+	return target == errNotFound
+}
+
 // ChallengeNotFoundError represents when a user is not found.
 type ChallengeNotFoundError struct{}
 
 func (e ChallengeNotFoundError) Error() string {
 	return "Challenge not found"
+}
+
+func (e ChallengeNotFoundError) Is(target error) bool {
+	return target == errNotFound
 }
 
 // SSOProviderNotFoundError represents an error when a SSO Provider can't be
@@ -102,12 +108,20 @@ func (e SSOProviderNotFoundError) Error() string {
 	return "SSO Identity Provider not found"
 }
 
+func (e SSOProviderNotFoundError) Is(target error) bool {
+	return target == errNotFound
+}
+
 // SAMLRelayStateNotFoundError represents an error when a SAML relay state
 // can't be found.
 type SAMLRelayStateNotFoundError struct{}
 
 func (e SAMLRelayStateNotFoundError) Error() string {
 	return "SAML RelayState not found"
+}
+
+func (e SAMLRelayStateNotFoundError) Is(target error) bool {
+	return target == errNotFound
 }
 
 // FlowStateNotFoundError represents an error when an FlowState can't be
@@ -118,12 +132,12 @@ func (e FlowStateNotFoundError) Error() string {
 	return "Flow State not found"
 }
 
+func (e FlowStateNotFoundError) Is(target error) bool {
+	return target == errNotFound
+}
+
 func IsUniqueConstraintViolatedError(err error) bool {
-	switch err.(type) {
-	case UserEmailUniqueConflictError, *UserEmailUniqueConflictError:
-		return true
-	}
-	return false
+	return errors.Is(err, errUniqueConstraintViolated)
 }
 
 type UserEmailUniqueConflictError struct{}
@@ -132,10 +146,18 @@ func (e UserEmailUniqueConflictError) Error() string {
 	return "User email unique constraint violated"
 }
 
+func (e UserEmailUniqueConflictError) Is(target error) bool {
+	return target == errUniqueConstraintViolated
+}
+
 type OAuthClientStateNotFoundError struct{}
 
 func (e OAuthClientStateNotFoundError) Error() string {
 	return "OAuth state not found"
+}
+
+func (e OAuthClientStateNotFoundError) Is(target error) bool {
+	return target == errNotFound
 }
 
 // CustomOAuthProviderNotFoundError represents an error when a custom OAuth/OIDC provider can't be found
@@ -143,4 +165,8 @@ type CustomOAuthProviderNotFoundError struct{}
 
 func (e CustomOAuthProviderNotFoundError) Error() string {
 	return "Custom OAuth provider not found"
+}
+
+func (e CustomOAuthProviderNotFoundError) Is(target error) bool {
+	return target == errNotFound
 }

--- a/internal/models/oauth_authorization.go
+++ b/internal/models/oauth_authorization.go
@@ -303,3 +303,7 @@ type OAuthServerAuthorizationNotFoundError struct{}
 func (e OAuthServerAuthorizationNotFoundError) Error() string {
 	return "OAuth authorization not found"
 }
+
+func (e OAuthServerAuthorizationNotFoundError) Is(target error) bool {
+	return target == errNotFound
+}

--- a/internal/models/oauth_client.go
+++ b/internal/models/oauth_client.go
@@ -205,6 +205,10 @@ func (e OAuthServerClientNotFoundError) Error() string {
 	return "OAuth client not found"
 }
 
+func (e OAuthServerClientNotFoundError) Is(target error) bool {
+	return target == errNotFound
+}
+
 type InvalidRedirectURIError struct {
 	URI string
 }

--- a/internal/models/one_time_token.go
+++ b/internal/models/one_time_token.go
@@ -99,6 +99,10 @@ func (e OneTimeTokenNotFoundError) Error() string {
 	return "One-time token not found"
 }
 
+func (e OneTimeTokenNotFoundError) Is(target error) bool {
+	return target == errNotFound
+}
+
 type OneTimeToken struct {
 	ID uuid.UUID `json:"id" db:"id"`
 


### PR DESCRIPTION
Replace type switch based error detection with shared sentinel errors and errors.Is. Each model error now implements Is() to map to the appropriate sentinel.

Removes large IsNotFoundError and IsUniqueConstraintViolatedError switches.

This is in preparation of future pull requests to modernize and refactor some error handling so we may add reliable error metrics.