### PR TITLE
fix: add limit to recovery session

### DIFF
--- a/internal/api/user.go
+++ b/internal/api/user.go
@@ -191,7 +191,7 @@ func (a *API) UserUpdate(w http.ResponseWriter, r *http.Request) error {
 							return err
 						}
 						if !isCurrentPasswordCorrect {
-							return apierrors.NewBadRequestError(apierrors.ErrorCodeCurrentPasswordMismatch, "Current password required when setting new password.")
+							return apierrors.NewBadRequestError(apierrors.ErrorCodeCurrentPasswordMismatch, "A valid current password required when setting new password.")
 						}
 					}
 				}

--- a/internal/api/user.go
+++ b/internal/api/user.go
@@ -170,12 +170,16 @@ func (a *API) UserUpdate(w http.ResponseWriter, r *http.Request) error {
 				if config.Security.UpdatePasswordRequireCurrentPassword {
 					// user may be in a password reset flow, where they do not have a currentPassword
 					isRecoverySession := false
-					for _, claim := range session.AMRClaims {
-						// password recovery flows can be via otp or a magic link, check if the current session
-						// was created with one of those
-						if claim.GetAuthenticationMethod() == "otp" || claim.GetAuthenticationMethod() == "magiclink" {
-							isRecoverySession = true
-							break
+
+					// it is only a recovery session if it was recently created
+					if time.Now().Before(session.CreatedAt.Add(15*time.Minute)) {
+						for _, claim := range session.AMRClaims {
+							// password recovery flows can be via otp or a magic link, check if the current session
+							// was created with one of those
+							if claim.GetAuthenticationMethod() == "otp" || claim.GetAuthenticationMethod() == "magiclink" {
+								isRecoverySession = true
+								break
+							}
 						}
 					}
 					if !isRecoverySession {

--- a/internal/api/user_test.go
+++ b/internal/api/user_test.go
@@ -289,6 +289,27 @@ func (ts *UserTestSuite) TestUserUpdatePassword() {
 		notRecentlyLoggedIn.ID).Exec(),
 	)
 
+	// create a recovery session (OTP) created recently (within 15 minutes)
+	recentRecoverySession, err := models.NewSession(u.ID, nil)
+	require.NoError(ts.T(), err)
+	require.NoError(ts.T(), ts.API.db.Create(recentRecoverySession))
+	require.NoError(ts.T(), models.AddClaimToSession(ts.API.db, recentRecoverySession.ID, models.OTP))
+	recentRecoverySession, err = models.FindSessionByID(ts.API.db, recentRecoverySession.ID, true)
+	require.NoError(ts.T(), err)
+
+	// create a recovery session (OTP) whose created_at is older than 15 minutes
+	staleRecoverySession, err := models.NewSession(u.ID, nil)
+	require.NoError(ts.T(), err)
+	require.NoError(ts.T(), ts.API.db.Create(staleRecoverySession))
+	require.NoError(ts.T(), models.AddClaimToSession(ts.API.db, staleRecoverySession.ID, models.OTP))
+	require.NoError(ts.T(), ts.API.db.RawQuery(
+		"update "+staleRecoverySession.TableName()+" set created_at = ? where id = ?",
+		time.Now().Add(-20*time.Minute),
+		staleRecoverySession.ID).Exec(),
+	)
+	staleRecoverySession, err = models.FindSessionByID(ts.API.db, staleRecoverySession.ID, true)
+	require.NoError(ts.T(), err)
+
 	type expected struct {
 		code            int
 		isAuthenticated bool
@@ -363,6 +384,24 @@ func (ts *UserTestSuite) TestUserUpdatePassword() {
 			requireReauthentication: false,
 			requireCurrentPassword:  true,
 			sessionId:               r.SessionId,
+			expected:                expected{code: http.StatusBadRequest, isAuthenticated: false},
+		},
+		{
+			desc:                    "Current password not required for recent recovery session (OTP, within 15 minutes)",
+			newPassword:             "newpassword123",
+			nonce:                   "",
+			requireReauthentication: false,
+			requireCurrentPassword:  true,
+			sessionId:               &recentRecoverySession.ID,
+			expected:                expected{code: http.StatusOK, isAuthenticated: true},
+		},
+		{
+			desc:                    "Current password required for stale recovery session (OTP, older than 15 minutes)",
+			newPassword:             "newpassword456",
+			nonce:                   "",
+			requireReauthentication: false,
+			requireCurrentPassword:  true,
+			sessionId:               &staleRecoverySession.ID,
 			expected:                expected{code: http.StatusBadRequest, isAuthenticated: false},
 		},
 	}

--- a/internal/api/user_test.go
+++ b/internal/api/user_test.go
@@ -289,27 +289,6 @@ func (ts *UserTestSuite) TestUserUpdatePassword() {
 		notRecentlyLoggedIn.ID).Exec(),
 	)
 
-	// create a recovery session (OTP) created recently (within 15 minutes)
-	recentRecoverySession, err := models.NewSession(u.ID, nil)
-	require.NoError(ts.T(), err)
-	require.NoError(ts.T(), ts.API.db.Create(recentRecoverySession))
-	require.NoError(ts.T(), models.AddClaimToSession(ts.API.db, recentRecoverySession.ID, models.OTP))
-	recentRecoverySession, err = models.FindSessionByID(ts.API.db, recentRecoverySession.ID, true)
-	require.NoError(ts.T(), err)
-
-	// create a recovery session (OTP) whose created_at is older than 15 minutes
-	staleRecoverySession, err := models.NewSession(u.ID, nil)
-	require.NoError(ts.T(), err)
-	require.NoError(ts.T(), ts.API.db.Create(staleRecoverySession))
-	require.NoError(ts.T(), models.AddClaimToSession(ts.API.db, staleRecoverySession.ID, models.OTP))
-	require.NoError(ts.T(), ts.API.db.RawQuery(
-		"update "+staleRecoverySession.TableName()+" set created_at = ? where id = ?",
-		time.Now().Add(-20*time.Minute),
-		staleRecoverySession.ID).Exec(),
-	)
-	staleRecoverySession, err = models.FindSessionByID(ts.API.db, staleRecoverySession.ID, true)
-	require.NoError(ts.T(), err)
-
 	type expected struct {
 		code            int
 		isAuthenticated bool
@@ -386,24 +365,6 @@ func (ts *UserTestSuite) TestUserUpdatePassword() {
 			sessionId:               r.SessionId,
 			expected:                expected{code: http.StatusBadRequest, isAuthenticated: false},
 		},
-		{
-			desc:                    "Current password not required for recent recovery session (OTP, within 15 minutes)",
-			newPassword:             "newpassword123",
-			nonce:                   "",
-			requireReauthentication: false,
-			requireCurrentPassword:  true,
-			sessionId:               &recentRecoverySession.ID,
-			expected:                expected{code: http.StatusOK, isAuthenticated: true},
-		},
-		{
-			desc:                    "Current password required for stale recovery session (OTP, older than 15 minutes)",
-			newPassword:             "newpassword456",
-			nonce:                   "",
-			requireReauthentication: false,
-			requireCurrentPassword:  true,
-			sessionId:               &staleRecoverySession.ID,
-			expected:                expected{code: http.StatusBadRequest, isAuthenticated: false},
-		},
 	}
 
 	for _, c := range cases {
@@ -459,6 +420,7 @@ func (ts *UserTestSuite) TestUserUpdatePasswordViaRecovery() {
 		newPassword     string
 		currentPassword string
 		recoveryType    models.AuthenticationMethod
+		staleSession    bool
 		expected        expected
 	}{
 		{
@@ -479,6 +441,20 @@ func (ts *UserTestSuite) TestUserUpdatePasswordViaRecovery() {
 			recoveryType: models.EmailChange,
 			expected:     expected{code: http.StatusBadRequest, isAuthenticated: true},
 		},
+		{
+			desc:         "Current password not required for recent OTP recovery session (within 15 minutes)",
+			newPassword:  "newpassword789",
+			recoveryType: models.OTP,
+			staleSession: false,
+			expected:     expected{code: http.StatusOK, isAuthenticated: true},
+		},
+		{
+			desc:         "Current password required for stale OTP recovery session (older than 15 minutes)",
+			newPassword:  "newpassword789",
+			recoveryType: models.OTP,
+			staleSession: true,
+			expected:     expected{code: http.StatusBadRequest, isAuthenticated: true},
+		},
 	}
 
 	for _, c := range cases {
@@ -492,6 +468,14 @@ func (ts *UserTestSuite) TestUserUpdatePasswordViaRecovery() {
 
 			// Add AMR claim to session to simulate recovery flow
 			require.NoError(ts.T(), models.AddClaimToSession(ts.API.db, session.ID, c.recoveryType))
+
+			if c.staleSession {
+				require.NoError(ts.T(), ts.API.db.RawQuery(
+					"update "+session.TableName()+" set created_at = ? where id = ?",
+					time.Now().Add(-20*time.Minute),
+					session.ID).Exec(),
+				)
+			}
 
 			// Reload session with AMR claims
 			session, err = models.FindSessionByID(ts.API.db, session.ID, true)


### PR DESCRIPTION

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

A session would be deemed a recovery session indefinitely long. 

## What is the new behavior?

This time boxes the recovery to 15 minutes.

