### PR TITLE
fix: stop requesting account_email by default for Kakao

### DIFF
--- a/internal/api/external_kakao_test.go
+++ b/internal/api/external_kakao_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strings"
 	"time"
 
 	"github.com/stretchr/testify/require"
@@ -24,6 +25,10 @@ func (ts *ExternalTestSuite) TestSignupExternalKakao() {
 	ts.Equal(ts.Config.External.Kakao.RedirectURI, q.Get("redirect_uri"))
 	ts.Equal(ts.Config.External.Kakao.ClientID, []string{q.Get("client_id")})
 	ts.Equal("code", q.Get("response_type"))
+	scopes := strings.Fields(q.Get("scope"))
+	ts.Contains(scopes, "profile_image")
+	ts.Contains(scopes, "profile_nickname")
+	ts.NotContains(scopes, "account_email")
 
 	assertValidOAuthState(ts, q.Get("state"), "kakao")
 }

--- a/internal/api/provider/kakao.go
+++ b/internal/api/provider/kakao.go
@@ -84,8 +84,9 @@ func NewKakaoProvider(ext conf.OAuthProviderConfiguration, scopes string) (OAuth
 	authHost := chooseHost(ext.URL, defaultKakaoAuthBase)
 	apiHost := chooseHost(ext.URL, defaultKakaoAPIBase)
 
+	// account_email is not requested by default because it requires
+	// Kakao Business app registration in many setups.
 	oauthScopes := []string{
-		"account_email",
 		"profile_image",
 		"profile_nickname",
 	}

--- a/internal/api/provider/kakao_test.go
+++ b/internal/api/provider/kakao_test.go
@@ -1,0 +1,42 @@
+package provider
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/supabase/auth/internal/conf"
+)
+
+func TestNewKakaoProvider_DefaultScopes(t *testing.T) {
+	ext := conf.OAuthProviderConfiguration{
+		Enabled:     true,
+		ClientID:    []string{"test-client-id"},
+		Secret:      "test-secret",
+		RedirectURI: "http://localhost:9999/callback",
+	}
+
+	p, err := NewKakaoProvider(ext, "")
+	require.NoError(t, err)
+
+	kakao, ok := p.(*kakaoProvider)
+	require.True(t, ok)
+	assert.Equal(t, []string{"profile_image", "profile_nickname"}, kakao.Config.Scopes)
+	assert.NotContains(t, kakao.Config.Scopes, "account_email")
+}
+
+func TestNewKakaoProvider_AppendsCustomScopes(t *testing.T) {
+	ext := conf.OAuthProviderConfiguration{
+		Enabled:     true,
+		ClientID:    []string{"test-client-id"},
+		Secret:      "test-secret",
+		RedirectURI: "http://localhost:9999/callback",
+	}
+
+	p, err := NewKakaoProvider(ext, "account_email")
+	require.NoError(t, err)
+
+	kakao, ok := p.(*kakaoProvider)
+	require.True(t, ok)
+	assert.Equal(t, []string{"profile_image", "profile_nickname", "account_email"}, kakao.Config.Scopes)
+}


### PR DESCRIPTION
## Summary
- remove `account_email` from the default Kakao OAuth scopes
- keep Kakao default scopes as `profile_image`, `profile_nickname`
- add regression tests to ensure `account_email` is not requested by default

## Why
`account_email` consent is available only for Kakao Business apps in many setups. Requesting it by default can break Kakao login for non-business apps.

## Testing
- Could not run tests in this environment because Docker daemon was not running and Go is not installed locally.
- Added/updated tests in:
  - `internal/api/provider/kakao_test.go`
  - `internal/api/external_kakao_test.go`
