### PR TITLE
feat: add PKCE support for `/resend`

### DIFF
--- a/internal/api/resend.go
+++ b/internal/api/resend.go
@@ -12,16 +12,22 @@ import (
 
 // ResendConfirmationParams holds the parameters for a resend request
 type ResendConfirmationParams struct {
-	Type  string `json:"type"`
-	Email string `json:"email"`
-	Phone string `json:"phone"`
+	Type                string `json:"type"`
+	Email               string `json:"email"`
+	Phone               string `json:"phone"`
+	CodeChallenge       string `json:"code_challenge"`
+	CodeChallengeMethod string `json:"code_challenge_method"`
 }
 
 func (p *ResendConfirmationParams) Validate(a *API) error {
 	config := a.config
 
 	switch p.Type {
-	case mail.SignupVerification, mail.EmailChangeVerification, smsVerification, phoneChangeVerification:
+	case mail.SignupVerification, mail.EmailChangeVerification:
+		if err := validatePKCEParams(p.CodeChallengeMethod, p.CodeChallenge); err != nil {
+			return err
+		}
+	case smsVerification, phoneChangeVerification:
 		break
 	default:
 		// type does not match one of the above
@@ -121,8 +127,13 @@ func (a *API) Resend(w http.ResponseWriter, r *http.Request) error {
 			if terr := models.NewAuditLogEntry(config.AuditLog, r, tx, user, models.UserConfirmationRequestedAction, "", nil); terr != nil {
 				return terr
 			}
-			// PKCE not implemented yet
-			return a.sendConfirmation(r, tx, user, models.ImplicitFlow)
+			flowType := getFlowFromChallenge(params.CodeChallenge)
+			if isPKCEFlow(flowType) {
+				if _, terr := generateFlowState(tx, models.EmailSignup.String(), models.EmailSignup, params.CodeChallengeMethod, params.CodeChallenge, &user.ID); terr != nil {
+					return terr
+				}
+			}
+			return a.sendConfirmation(r, tx, user, flowType)
 		case smsVerification:
 			if terr := models.NewAuditLogEntry(config.AuditLog, r, tx, user, models.UserRecoveryRequestedAction, "", nil); terr != nil {
 				return terr
@@ -133,7 +144,13 @@ func (a *API) Resend(w http.ResponseWriter, r *http.Request) error {
 			}
 			messageID = mID
 		case mail.EmailChangeVerification:
-			return a.sendEmailChange(r, tx, user, user.EmailChange, models.ImplicitFlow)
+			flowType := getFlowFromChallenge(params.CodeChallenge)
+			if isPKCEFlow(flowType) {
+				if _, terr := generateFlowState(tx, models.EmailChange.String(), models.EmailChange, params.CodeChallengeMethod, params.CodeChallenge, &user.ID); terr != nil {
+					return terr
+				}
+			}
+			return a.sendEmailChange(r, tx, user, user.EmailChange, flowType)
 		case phoneChangeVerification:
 			mID, terr := a.sendPhoneConfirmation(r, tx, user, user.PhoneChange, phoneChangeVerification, sms_provider.SMSProvider)
 			if terr != nil {

--- a/internal/api/resend_test.go
+++ b/internal/api/resend_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -109,6 +110,68 @@ func (ts *ResendTestSuite) TestResendValidation() {
 
 }
 
+func (ts *ResendTestSuite) TestResendPKCEValidation() {
+	const validChallenge = "testtesttesttesttesttesttestteststeststesttesttesttest"
+	cases := []struct {
+		desc     string
+		params   map[string]interface{}
+		expected map[string]interface{}
+	}{
+		{
+			desc: "Signup with code_challenge but missing code_challenge_method",
+			params: map[string]interface{}{
+				"type":           "signup",
+				"email":          "foo@example.com",
+				"code_challenge": validChallenge,
+			},
+			expected: map[string]interface{}{
+				"code":    http.StatusBadRequest,
+				"message": InvalidPKCEParamsErrorMessage,
+			},
+		},
+		{
+			desc: "Signup with code_challenge_method but missing code_challenge",
+			params: map[string]interface{}{
+				"type":                  "signup",
+				"email":                 "foo@example.com",
+				"code_challenge_method": "s256",
+			},
+			expected: map[string]interface{}{
+				"code":    http.StatusBadRequest,
+				"message": InvalidPKCEParamsErrorMessage,
+			},
+		},
+		{
+			desc: "Email change with code_challenge but missing code_challenge_method",
+			params: map[string]interface{}{
+				"type":           "email_change",
+				"email":          "foo@example.com",
+				"code_challenge": validChallenge,
+			},
+			expected: map[string]interface{}{
+				"code":    http.StatusBadRequest,
+				"message": InvalidPKCEParamsErrorMessage,
+			},
+		},
+	}
+	for _, c := range cases {
+		ts.Run(c.desc, func() {
+			var buffer bytes.Buffer
+			require.NoError(ts.T(), json.NewEncoder(&buffer).Encode(c.params))
+			req := httptest.NewRequest(http.MethodPost, "http://localhost/resend", &buffer)
+			req.Header.Set("Content-Type", "application/json")
+
+			w := httptest.NewRecorder()
+			ts.API.handler.ServeHTTP(w, req)
+			require.Equal(ts.T(), c.expected["code"], w.Code)
+
+			data := make(map[string]interface{})
+			require.NoError(ts.T(), json.NewDecoder(w.Body).Decode(&data))
+			require.Equal(ts.T(), c.expected["message"], data["msg"])
+		})
+	}
+}
+
 func (ts *ResendTestSuite) TestResendSuccess() {
 	// Create user
 	u, err := models.NewUser("123456789", "foo@example.com", "password", ts.Config.JWT.Aud, nil)
@@ -150,8 +213,7 @@ func (ts *ResendTestSuite) TestResendSuccess() {
 	cases := []struct {
 		desc   string
 		params map[string]interface{}
-		// expected map[string]interface{}
-		user *models.User
+		user   *models.User
 	}{
 		{
 			desc: "Resend signup confirmation",
@@ -214,4 +276,72 @@ func (ts *ResendTestSuite) TestResendSuccess() {
 			}
 		})
 	}
+}
+
+func (ts *ResendTestSuite) TestResendPKCESuccess() {
+	const testCodeChallenge = "testtesttesttesttesttesttestteststeststesttesttesttest"
+
+	// Avoid max freq limit error
+	now := time.Now().Add(-1 * time.Minute)
+
+	ts.Config.Mailer.SecureEmailChangeEnabled = false
+
+	// Fresh user for signup PKCE resend
+	signupUser, err := models.NewUser("", "pkce-signup@example.com", "password", ts.Config.JWT.Aud, nil)
+	require.NoError(ts.T(), err)
+	signupUser.ConfirmationToken = "oldtoken"
+	signupUser.ConfirmationSentAt = &now
+	require.NoError(ts.T(), ts.API.db.Create(signupUser))
+	require.NoError(ts.T(), models.CreateOneTimeToken(ts.API.db, signupUser.ID, signupUser.GetEmail(), signupUser.ConfirmationToken, models.ConfirmationToken))
+
+	// Fresh user for email_change PKCE resend
+	emailChangeUser, err := models.NewUser("", "pkce-change@example.com", "password", ts.Config.JWT.Aud, nil)
+	require.NoError(ts.T(), err)
+	emailChangeUser.EmailChange = "pkce-change-new@example.com"
+	emailChangeUser.EmailChangeSentAt = &now
+	emailChangeUser.EmailChangeTokenNew = "oldchangetoken"
+	require.NoError(ts.T(), ts.API.db.Create(emailChangeUser))
+	require.NoError(ts.T(), models.CreateOneTimeToken(ts.API.db, emailChangeUser.ID, emailChangeUser.EmailChange, emailChangeUser.EmailChangeTokenNew, models.EmailChangeTokenNew))
+
+	ts.Run("Resend signup confirmation with PKCE", func() {
+		var buffer bytes.Buffer
+		require.NoError(ts.T(), json.NewEncoder(&buffer).Encode(map[string]interface{}{
+			"type":                  "signup",
+			"email":                 signupUser.GetEmail(),
+			"code_challenge":        testCodeChallenge,
+			"code_challenge_method": "s256",
+		}))
+		req := httptest.NewRequest(http.MethodPost, "http://localhost/resend", &buffer)
+		req.Header.Set("Content-Type", "application/json")
+
+		w := httptest.NewRecorder()
+		ts.API.handler.ServeHTTP(w, req)
+		require.Equal(ts.T(), http.StatusOK, w.Code)
+
+		dbUser, err := models.FindUserByID(ts.API.db, signupUser.ID)
+		require.NoError(ts.T(), err)
+		require.NotEqual(ts.T(), dbUser.ConfirmationToken, signupUser.ConfirmationToken)
+		require.True(ts.T(), strings.HasPrefix(dbUser.ConfirmationToken, PKCEPrefix), "expected pkce_ prefix on ConfirmationToken, got: %s", dbUser.ConfirmationToken)
+	})
+
+	ts.Run("Resend email change with PKCE", func() {
+		var buffer bytes.Buffer
+		require.NoError(ts.T(), json.NewEncoder(&buffer).Encode(map[string]interface{}{
+			"type":                  "email_change",
+			"email":                 emailChangeUser.GetEmail(),
+			"code_challenge":        testCodeChallenge,
+			"code_challenge_method": "s256",
+		}))
+		req := httptest.NewRequest(http.MethodPost, "http://localhost/resend", &buffer)
+		req.Header.Set("Content-Type", "application/json")
+
+		w := httptest.NewRecorder()
+		ts.API.handler.ServeHTTP(w, req)
+		require.Equal(ts.T(), http.StatusOK, w.Code)
+
+		dbUser, err := models.FindUserByID(ts.API.db, emailChangeUser.ID)
+		require.NoError(ts.T(), err)
+		require.NotEqual(ts.T(), dbUser.EmailChangeTokenNew, emailChangeUser.EmailChangeTokenNew)
+		require.True(ts.T(), strings.HasPrefix(dbUser.EmailChangeTokenNew, PKCEPrefix), "expected pkce_ prefix on EmailChangeTokenNew, got: %s", dbUser.EmailChangeTokenNew)
+	})
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

The `/resend` endpoint hardcodes `models.ImplicitFlow` for both `signup` and `email_change` verification types ([#42527](https://github.com/supabase/supabase/issues/42527)). This means resent confirmation emails always use the implicit flow — redirecting with tokens in the URL hash fragment (`#access_token=...`) — even when the original `signUp()` used PKCE.

This creates an inconsistency where:
- Initial signup email: `https://example.com/auth/confirm?code=xxx` (PKCE, works with server routes)
- Resent email: `https://example.com/auth/confirm#access_token=xxx` (implicit, requires client-side handling)

Server-side route handlers (e.g., Next.js `route.ts`) cannot read hash fragments, forcing developers to implement workarounds with client components and dual flow handling.

Closes #42527

## What is the new behavior?

The `/resend` endpoint now accepts optional `code_challenge` and `code_challenge_method` parameters for `signup` and `email_change` types. When provided, the endpoint:

1. Determines the flow type from `code_challenge` (PKCE if present, implicit if absent)
2. Creates a `FlowState` record for PKCE flows (needed by `/verify` to issue an auth code)
3. Passes the correct flow type to `sendConfirmation` / `sendEmailChange`

This produces confirmation emails with `?code=...` query params instead of `#access_token=...` hash fragments, consistent with the initial signup flow.

When `code_challenge` is not provided, behavior is **unchanged** — implicit flow is used, maintaining full backward compatibility.

**Changes:**
- `internal/api/resend.go`: Added `CodeChallenge` and `CodeChallengeMethod` fields to `ResendConfirmationParams`. Added PKCE param validation for email-based types. Replaced hardcoded `ImplicitFlow` with flow-aware logic for `signup` and `email_change` cases.
- `internal/api/resend_test.go`: Added `TestResendPKCEValidation` (invalid PKCE params return 400) and `TestResendPKCESuccess` (signup and email change tokens get `pkce_` prefix when PKCE params are provided).

## Additional context

This is the server-side half of the fix. The JS SDK (`auth-js`) needs a corresponding update to send `code_challenge` / `code_challenge_method` in `resend()` calls when `flowType === 'pkce'`, following the same pattern already used by `signUp()` and `signInWithOtp()`. See [this PR](https://github.com/supabase/supabase-js/pull/2144)

The implementation mirrors the existing PKCE pattern used across the codebase (`signup.go`, `user.go`, `recover.go`, `magic_link.go`): `getFlowFromChallenge` → conditional `generateFlowState` → pass `flowType` to the email sender.
