### PR TITLE
fix: add MaxBytesReader middleware to limit request body size to 1MB

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,8 +52,8 @@ vet: # Vet the code
 	go vet $(CHECK_FILES)
 
 sec: check-gosec # Check for security vulnerabilities
-	gosec -quiet -exclude-generated -exclude=G117,G704 $(CHECK_FILES)
-	gosec -quiet -tests -exclude-generated -exclude=G101,G104,G117,G704 $(CHECK_FILES)
+	gosec -quiet -exclude-generated -exclude=G117,G120,G704 $(CHECK_FILES)
+	gosec -quiet -tests -exclude-generated -exclude=G101,G104,G117,G120,G704 $(CHECK_FILES)
 
 check-gosec:
 	@command -v gosec >/dev/null 2>&1 \

--- a/cmd/serve_cmd.go
+++ b/cmd/serve_cmd.go
@@ -163,7 +163,7 @@ func serve(ctx context.Context) {
 	}
 
 	wg.Add(1)
-	go func() {
+	go func() { // #nosec G118 -- Cleanup goroutine intentionally outlives the request; context.Background() is required for shutdown after parent context is cancelled.
 		defer wg.Done()
 
 		<-ctx.Done()

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -164,6 +164,7 @@ func NewAPIWithVersion(globalConfig *conf.GlobalConfiguration, db *storage.Conne
 	)
 	r.UseBypass(logger)
 	r.UseBypass(xffmw.Handler)
+	r.UseBypass(limitRequestBody(1 << 20)) // 1MB
 
 	if globalConfig.API.MaxRequestDuration > 0 {
 		r.UseBypass(timeoutMiddleware(globalConfig.API.MaxRequestDuration))

--- a/internal/api/apierrors/errorcode.go
+++ b/internal/api/apierrors/errorcode.go
@@ -108,6 +108,8 @@ const (
 	ErrorCodeOAuthAuthorizationNotFound ErrorCode = "oauth_authorization_not_found"
 	ErrorCodeOAuthConsentNotFound       ErrorCode = "oauth_consent_not_found"
 
+	ErrorCodeRequestEntityTooLarge ErrorCode = "request_entity_too_large"
+
 	ErrorCodeCustomProviderNotFound  ErrorCode = "custom_provider_not_found"
 	ErrorCodeOverCustomProviderQuota ErrorCode = "over_custom_provider_quota"
 )

--- a/internal/api/helpers.go
+++ b/internal/api/helpers.go
@@ -85,6 +85,9 @@ type RequestParams interface {
 func retrieveRequestParams[A RequestParams](r *http.Request, params *A) error {
 	body, err := utilities.GetBodyBytes(r)
 	if err != nil {
+		if err, ok := err.(*http.MaxBytesError); ok {
+			return apierrors.NewHTTPError(http.StatusRequestEntityTooLarge, apierrors.ErrorCodeRequestEntityTooLarge, "Request body too large (max %d bytes)", err.Limit)
+		}
 		return apierrors.NewInternalServerError("Could not read body into byte slice").WithInternalError(err)
 	}
 	if err := json.Unmarshal(body, params); err != nil {

--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -454,6 +454,19 @@ func (t *timeoutResponseWriter) finallyWrite(w http.ResponseWriter) {
 	}
 }
 
+// limitRequestBody wraps the request body with http.MaxBytesReader to prevent
+// memory exhaustion from excessively large request bodies (gosec G120).
+func limitRequestBody(maxBytes int64) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Body != nil && r.Body != http.NoBody {
+				r.Body = http.MaxBytesReader(w, r.Body, maxBytes)
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
 func timeoutMiddleware(timeout time.Duration) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/middleware_test.go
+++ b/internal/api/middleware_test.go
@@ -709,6 +709,62 @@ func (ts *MiddlewareTestSuite) TestLimitHandler() {
 	require.Equal(ts.T(), http.StatusTooManyRequests, w.Code)
 }
 
+func (ts *MiddlewareTestSuite) TestLimitRequestBodyMiddleware() {
+	const maxBytes = 1 << 10 // 1KB for testing
+
+	bodyReadHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, err := io.ReadAll(r.Body)
+		if err != nil {
+			w.WriteHeader(http.StatusRequestEntityTooLarge)
+			w.Write([]byte(err.Error()))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("ok"))
+	})
+
+	handler := limitRequestBody(maxBytes)(bodyReadHandler)
+
+	ts.Run("allows request within limit", func() {
+		body := bytes.NewReader(make([]byte, maxBytes-1))
+		req := httptest.NewRequest(http.MethodPost, "http://localhost", body)
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+		require.Equal(ts.T(), http.StatusOK, w.Code)
+		require.Equal(ts.T(), "ok", w.Body.String())
+	})
+
+	ts.Run("rejects request exceeding limit", func() {
+		body := bytes.NewReader(make([]byte, maxBytes+1))
+		req := httptest.NewRequest(http.MethodPost, "http://localhost", body)
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+		require.Equal(ts.T(), http.StatusRequestEntityTooLarge, w.Code)
+	})
+
+	ts.Run("allows nil body", func() {
+		req := httptest.NewRequest(http.MethodGet, "http://localhost", nil)
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+		require.Equal(ts.T(), http.StatusOK, w.Code)
+	})
+
+	ts.Run("allows empty body", func() {
+		req := httptest.NewRequest(http.MethodPost, "http://localhost", http.NoBody)
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+		require.Equal(ts.T(), http.StatusOK, w.Code)
+	})
+
+	ts.Run("allows request at exact limit", func() {
+		body := bytes.NewReader(make([]byte, maxBytes))
+		req := httptest.NewRequest(http.MethodPost, "http://localhost", body)
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+		require.Equal(ts.T(), http.StatusOK, w.Code)
+	})
+}
+
 type MockCleanup struct {
 	mock.Mock
 }

--- a/internal/api/signup_test.go
+++ b/internal/api/signup_test.go
@@ -151,3 +151,21 @@ func (ts *SignupTestSuite) TestVerifySignup() {
 	require.NotEmpty(ts.T(), v.Get("expires_in"))
 	require.NotEmpty(ts.T(), v.Get("refresh_token"))
 }
+
+// TestSignupRequestBodyTooLarge verifies that the MaxBytesReader middleware
+// rejects oversized request bodies with a 413 error through the full handler chain.
+func (ts *SignupTestSuite) TestSignupRequestBodyTooLarge() {
+	// Create a body that exceeds the 1MB limit (1<<20 + 1 bytes)
+	largeBody := make([]byte, (1<<20)+1)
+	req := httptest.NewRequest(http.MethodPost, "/signup", bytes.NewReader(largeBody))
+	req.Header.Set("Content-Type", "application/json")
+
+	w := httptest.NewRecorder()
+	ts.API.handler.ServeHTTP(w, req)
+
+	require.Equal(ts.T(), http.StatusRequestEntityTooLarge, w.Code)
+
+	var data map[string]interface{}
+	require.NoError(ts.T(), json.NewDecoder(w.Body).Decode(&data))
+	require.Equal(ts.T(), "request_entity_too_large", data["error_code"])
+}

--- a/internal/observability/metrics.go
+++ b/internal/observability/metrics.go
@@ -47,9 +47,9 @@ func enablePrometheusMetrics(ctx context.Context, mc *conf.MetricsConfig) error 
 	otel.SetMeterProvider(provider)
 
 	cleanupWaitGroup.Add(1)
-	go func() {
+	go func() { // #nosec G118 -- Cleanup goroutine intentionally manages server lifecycle independent of request context.
 		addr := net.JoinHostPort(mc.PrometheusListenHost, mc.PrometheusListenPort)
-		baseContext, cancel := context.WithCancel(context.Background())
+		baseContext, cancel := context.WithCancel(context.Background()) // #nosec G118 -- cancel() is called in the shutdown goroutine below; baseContext is for the HTTP server.
 
 		server := &http.Server{
 			Addr:    addr,
@@ -100,7 +100,7 @@ func enableOpenTelemetryMetrics(ctx context.Context, mc *conf.MetricsConfig) err
 		otel.SetMeterProvider(meterProvider)
 
 		cleanupWaitGroup.Add(1)
-		go func() {
+		go func() { // #nosec G118 -- Cleanup goroutine intentionally outlives the request; context.Background() is required for shutdown after parent context is cancelled.
 			defer cleanupWaitGroup.Done()
 
 			<-ctx.Done()
@@ -127,7 +127,7 @@ func enableOpenTelemetryMetrics(ctx context.Context, mc *conf.MetricsConfig) err
 		otel.SetMeterProvider(meterProvider)
 
 		cleanupWaitGroup.Add(1)
-		go func() {
+		go func() { // #nosec G118 -- Cleanup goroutine intentionally outlives the request; context.Background() is required for shutdown after parent context is cancelled.
 			defer cleanupWaitGroup.Done()
 
 			<-ctx.Done()

--- a/internal/observability/profiler.go
+++ b/internal/observability/profiler.go
@@ -17,7 +17,7 @@ func ConfigureProfiler(ctx context.Context, pc *conf.ProfilerConfig) error {
 		return nil
 	}
 	addr := net.JoinHostPort(pc.Host, pc.Port)
-	baseContext, cancel := context.WithCancel(context.Background())
+	baseContext, cancel := context.WithCancel(context.Background()) // #nosec G118 -- cancel() is called in the shutdown goroutine below; baseContext is for the HTTP server.
 	cleanupWaitGroup.Add(1)
 	go func() {
 		server := &http.Server{

--- a/internal/observability/tracing.go
+++ b/internal/observability/tracing.go
@@ -79,7 +79,7 @@ func enableOpenTelemetryTracing(ctx context.Context, tc *conf.TracingConfig) err
 	)
 
 	cleanupWaitGroup.Add(1)
-	go func() {
+	go func() { // #nosec G118 -- Cleanup goroutine intentionally outlives the request; context.Background() is required for shutdown after parent context is cancelled.
 		defer cleanupWaitGroup.Done()
 
 		<-ctx.Done()

--- a/internal/reloader/reloader_test.go
+++ b/internal/reloader/reloader_test.go
@@ -773,7 +773,7 @@ func helpCopyEnvFile(t testing.TB, dir, name, src string) string {
 	}
 
 	dst := filepath.Join(dir, name)
-	err = os.WriteFile(dst, data, 0600)
+	err = os.WriteFile(dst, data, 0600) // #nosec G703 -- Test helper; dir and name are controlled by the test.
 	if err != nil {
 		require.Nil(t, err)
 	}


### PR DESCRIPTION
 Adds a global limitRequestBody middleware using http.MaxBytesReader to prevent memory exhaustion from oversized request bodies. Returns 413 with error code `request_entity_too_large` when exceeded.

* G120 excluded from gosec since it's handled by middleware now
* G118 annotations added for context handling