### PR TITLE
fix(auth): support newlines in SMS OTP templates

### DIFF
--- a/internal/api/phone.go
+++ b/internal/api/phone.go
@@ -167,5 +167,10 @@ func generateSMSFromTemplate(SMSTemplate *template.Template, otp string) (string
 	}{Code: otp}); err != nil {
 		return "", err
 	}
-	return message.String(), nil
+
+	renderedMessage := message.String()
+	renderedMessage = strings.ReplaceAll(renderedMessage, "\\r\\n", "\r\n")
+	renderedMessage = strings.ReplaceAll(renderedMessage, "\\n", "\n")
+
+	return renderedMessage, nil
 }

--- a/internal/api/phone_test.go
+++ b/internal/api/phone_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"text/template"
 	"time"
 
 	"github.com/stretchr/testify/assert"
@@ -441,4 +442,27 @@ func (ts *PhoneTestSuite) TestSendSMSHook() {
 	deleteJobsTableSQL := `drop table if exists job_queue`
 	require.NoError(ts.T(), ts.API.db.RawQuery(deleteJobsTableSQL).Exec())
 
+}
+
+func TestGenerateSMSFromTemplateWithEscapedNewline(t *testing.T) {
+	tmpl, err := template.New("").Parse(`Your code is {{ .Code }}\n@app.com #{{ .Code }}`)
+	require.NoError(t, err)
+
+	message, err := generateSMSFromTemplate(tmpl, "123456")
+	require.NoError(t, err)
+
+	expected := "Your code is 123456\n@app.com #123456"
+	require.Equal(t, expected, message)
+}
+
+func TestGenerateSMSFromTemplateWithLiteralNewline(t *testing.T) {
+	tmpl, err := template.New("").Parse(`Your code is {{ .Code }}
+@app.com #{{ .Code }}`)
+	require.NoError(t, err)
+
+	message, err := generateSMSFromTemplate(tmpl, "123456")
+	require.NoError(t, err)
+
+	expected := "Your code is 123456\n@app.com #123456"
+	require.Equal(t, expected, message)
 }


### PR DESCRIPTION
Closes supabase/supabase#6435

## What changed
- support escaped newlines (`\n`) in SMS OTP templates
- preserve literal newlines in rendered SMS messages
- add tests for escaped and literal newline handling

## Tests
- `go test ./internal/api -run TestGenerateSMSFromTemplate -v`

## Notes
The fix is in `supabase/auth` because the SMS template rendering happens there.