### PR TITLE
fix(oauth): allow absolute OAuth authorization consent URLs

### DIFF
--- a/internal/api/oauthserver/authorize.go
+++ b/internal/api/oauthserver/authorize.go
@@ -167,7 +167,7 @@ func (s *Server) OAuthServerAuthorize(w http.ResponseWriter, r *http.Request) er
 	}
 
 	baseURL := s.buildAuthorizationURL(config.SiteURL, config.OAuthServer.AuthorizationPath)
-	redirectURL := fmt.Sprintf("%s?authorization_id=%s", baseURL, authorization.AuthorizationID)
+	redirectURL := s.buildAuthorizationRedirectURL(baseURL, authorization.AuthorizationID)
 
 	http.Redirect(w, r, redirectURL, http.StatusFound)
 	return nil
@@ -626,7 +626,7 @@ func (s *Server) buildErrorRedirectURL(redirectURI, errorCode, errorDescription,
 // If pathToJoin is an absolute URL, it is returned as-is.
 func (s *Server) buildAuthorizationURL(baseURL, pathToJoin string) string {
 	if parsed, err := url.Parse(pathToJoin); err == nil && parsed.IsAbs() {
-		return pathToJoin
+		return parsed.String()
 	}
 
 	// Trim trailing slash from baseURL
@@ -638,4 +638,17 @@ func (s *Server) buildAuthorizationURL(baseURL, pathToJoin string) string {
 	}
 
 	return baseURL + pathToJoin
+}
+
+// buildAuthorizationRedirectURL appends authorization_id while preserving existing query params/fragments.
+func (s *Server) buildAuthorizationRedirectURL(baseURL, authorizationID string) string {
+	u, err := url.Parse(baseURL)
+	if err != nil {
+		return fmt.Sprintf("%s?authorization_id=%s", baseURL, authorizationID)
+	}
+
+	q := u.Query()
+	q.Set("authorization_id", authorizationID)
+	u.RawQuery = q.Encode()
+	return u.String()
 }

--- a/internal/api/oauthserver/authorize_test.go
+++ b/internal/api/oauthserver/authorize_test.go
@@ -159,6 +159,45 @@ func TestBuildAuthorizationURL(t *testing.T) {
 	}
 }
 
+
+
+func TestBuildAuthorizationRedirectURL(t *testing.T) {
+	server := &Server{}
+
+	tests := []struct {
+		name            string
+		baseURL         string
+		authorizationID string
+		expected        string
+	}{
+		{
+			name:            "adds authorization_id to URL without query",
+			baseURL:         "https://app.example.com/custom-consent",
+			authorizationID: "auth-123",
+			expected:        "https://app.example.com/custom-consent?authorization_id=auth-123",
+		},
+		{
+			name:            "preserves existing query parameters",
+			baseURL:         "https://app.example.com/custom-consent?foo=bar",
+			authorizationID: "auth-123",
+			expected:        "https://app.example.com/custom-consent?authorization_id=auth-123&foo=bar",
+		},
+		{
+			name:            "preserves fragment",
+			baseURL:         "https://app.example.com/custom-consent?foo=bar#frag",
+			authorizationID: "auth-123",
+			expected:        "https://app.example.com/custom-consent?authorization_id=auth-123&foo=bar#frag",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := server.buildAuthorizationRedirectURL(tt.baseURL, tt.authorizationID)
+			assert.Equal(t, tt.expected, actual)
+		})
+	}
+}
+
 func TestValidateRequestOriginEdgeCases(t *testing.T) {
 	globalConfig, err := conf.LoadGlobal(oauthServerTestConfig)
 	require.NoError(t, err)


### PR DESCRIPTION
## Summary
- treat `GOTRUE_OAUTH_SERVER_AUTHORIZATION_PATH` as either a relative path or an absolute URL when building the consent redirect target
- preserve existing relative-path behavior (`/oauth/consent` joins against `SITE_URL`) while allowing hosted users to point consent flows at a dedicated external UI
- add focused unit coverage for relative joins and absolute URL passthrough in `buildAuthorizationURL`

## Testing
- `go test ./internal/api/oauthserver -run 'TestBuildAuthorizationURL|TestValidateRequestOrigin'`

## Related
- Fixes #2408
