### PR TITLE
feat: make default user role configurable via GOTRUE_DB_DEFAULT_ROLE

### DIFF
--- a/internal/api/admin.go
+++ b/internal/api/admin.go
@@ -466,7 +466,7 @@ func (a *API) adminUserCreate(w http.ResponseWriter, r *http.Request) error {
 			return terr
 		}
 
-		role := config.JWT.DefaultGroupName
+		role := config.DB.DefaultRole
 		if params.Role != "" {
 			role = params.Role
 		}

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -86,7 +86,7 @@ func (a *API) deprecationNotices() {
 	}
 
 	if config.JWT.DefaultGroupName != "" {
-		log.Warn("DEPRECATION NOTICE: GOTRUE_JWT_DEFAULT_GROUP_NAME not supported by Supabase's GoTrue, will be removed soon")
+		log.Warn("DEPRECATION NOTICE: GOTRUE_JWT_DEFAULT_GROUP_NAME is deprecated, use GOTRUE_DB_DEFAULT_ROLE instead")
 	}
 }
 

--- a/internal/api/signup.go
+++ b/internal/api/signup.go
@@ -385,7 +385,7 @@ func (a *API) signupNewUser(conn *storage.Connection, user *models.User) (*model
 		if terr = tx.Create(user); terr != nil {
 			return apierrors.NewInternalServerError("Database error saving new user").WithInternalError(terr)
 		}
-		if terr = user.SetRole(tx, config.JWT.DefaultGroupName); terr != nil {
+		if terr = user.SetRole(tx, config.DB.DefaultRole); terr != nil {
 			return apierrors.NewInternalServerError("Database error updating user").WithInternalError(terr)
 		}
 		return nil

--- a/internal/conf/configuration.go
+++ b/internal/conf/configuration.go
@@ -110,6 +110,7 @@ type DBConfiguration struct {
 	Driver    string `json:"driver" required:"true"`
 	URL       string `json:"url" envconfig:"DATABASE_URL" required:"true"`
 	Namespace string `json:"namespace" envconfig:"DB_NAMESPACE" default:"auth"`
+	DefaultRole string `json:"default_role" split_words:"true"`
 
 	// Percentage of DB conns the auth server may use in
 	// integer form i.e.: [1, 100] -> [1%, 100%]
@@ -1139,6 +1140,14 @@ func populateGlobal(config *GlobalConfiguration) error {
 func (config *GlobalConfiguration) ApplyDefaults() error {
 	if config.JWT.AdminGroupName == "" {
 		config.JWT.AdminGroupName = "admin"
+	}
+
+	if config.DB.DefaultRole == "" {
+		if config.JWT.DefaultGroupName != "" {
+			config.DB.DefaultRole = config.JWT.DefaultGroupName
+		} else {
+			config.DB.DefaultRole = "authenticated"
+		}
 	}
 
 	if len(config.JWT.AdminRoles) == 0 {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix + feature

## What is the current behavior?

Default role for new users is tied to the deprecated GOTRUE_JWT_DEFAULT_GROUP_NAME. If not set, users get an empty role, causing issues on redeployment. 
Fixes #2359

## What is the new behavior?

New env var GOTRUE_DB_DEFAULT_ROLE lets you configure the default role. Falls back to "authenticated" if not set. GOTRUE_JWT_DEFAULT_GROUP_NAME still works with a deprecation warning.
