### PR TITLE
fix: enforce rate limit for sign-ups and sign-ins (fixes #2333)

### DIFF
--- a/internal/api/options.go
+++ b/internal/api/options.go
@@ -36,6 +36,7 @@ type LimiterOptions struct {
 	Phone ratelimit.Limiter
 
 	Signups             *limiter.Limiter
+	SignIns             *limiter.Limiter
 	AnonymousSignIns    *limiter.Limiter
 	Recover             *limiter.Limiter
 	Resend              *limiter.Limiter
@@ -106,8 +107,9 @@ func NewLimiterOptions(gc *conf.GlobalConfiguration) *LimiterOptions {
 	o.MagicLink = newLimiterPer5mOver1h(gc.RateLimitOtp)
 	o.Otp = newLimiterPer5mOver1h(gc.RateLimitOtp)
 	o.User = newLimiterPer5mOver1h(gc.RateLimitOtp)
-	o.Signups = newLimiterPer5mOver1h(gc.RateLimitOtp)
-	o.OAuthClientRegister = newLimiterPer5mOver1h(gc.RateLimitOAuthDynamicClientRegister)
+	o.Signups = newLimiterPer5mOver1h(gc.RateLimitSignInSignUps)
+  o.SignIns = newLimiterPer5mOver1h(gc.RateLimitSignInSignUps)
+  o.OAuthClientRegister = newLimiterPer5mOver1h(gc.RateLimitOAuthDynamicClientRegister)
 
 	return o
 }

--- a/internal/api/token.go
+++ b/internal/api/token.go
@@ -42,17 +42,20 @@ func (a *API) Token(w http.ResponseWriter, r *http.Request) error {
 	grantType := r.FormValue("grant_type")
 
 	handler := a.ResourceOwnerPasswordGrant
-	limiter := a.limiterOpts.Token
+	limiter := a.limiterOpts.SignIns
 
 	switch grantType {
 	case "password":
 		// set above
 	case "refresh_token":
 		handler = a.RefreshTokenGrant
+		limiter = a.limiterOpts.Token
 	case "id_token":
 		handler = a.IdTokenGrant
+		limiter = a.limiterOpts.Token
 	case "pkce":
 		handler = a.PKCE
+		limiter = a.limiterOpts.Token
 	case "web3":
 		handler = a.Web3Grant
 		limiter = a.limiterOpts.Web3

--- a/internal/conf/configuration.go
+++ b/internal/conf/configuration.go
@@ -386,6 +386,7 @@ type GlobalConfiguration struct {
 	RateLimitSso                        float64 `split_words:"true" default:"30"`
 	RateLimitAnonymousUsers             float64 `split_words:"true" default:"30"`
 	RateLimitOtp                        float64 `split_words:"true" default:"30"`
+	RateLimitSignInSignUps              float64 `split_words:"true" default:"30"`
 	RateLimitWeb3                       float64 `split_words:"true" default:"30"`
 	RateLimitOAuthDynamicClientRegister float64 `split_words:"true" default:"10"`
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

The rate limit for sign-ups and sign-ins configured via the dashboard or 
config.toml (sign_in_sign_ups) is never enforced. Requests only get blocked 
after ~30-50 attempts due to a different unrelated limit firing instead.

Fixes #2333

## What is the new behavior?

Sign-up and sign-in requests are correctly blocked once the configured 
limit is reached. The /token password grant (sign-in) is also now covered 
by this limit, which it previously wasn't at all.

## Additional context

Three issues were found:
1. RateLimitSignInSignUps field was missing from GlobalConfiguration so 
   the configured value was always silently ignored.
2. The Signups limiter was incorrectly wired to RateLimitOtp instead of 
   the sign-in/sign-up limit.
3. Sign-ins (/token?grant_type=password) were using the token refresh 
   limiter (default 150/5min) instead of the sign-in limit.