### PR TITLE
fix: create email identity when OAuth-only user sets a password via updateUser

### DIFF
--- a/internal/api/user.go
+++ b/internal/api/user.go
@@ -225,6 +225,27 @@ func (a *API) UserUpdate(w http.ResponseWriter, r *http.Request) error {
 				return terr
 			}
 
+			if user.GetEmail() != "" {
+				if _, terr = models.FindIdentityByIdAndProvider(tx, user.ID.String(), "email"); terr != nil {
+					if !models.IsNotFoundError(terr) {
+						return apierrors.NewInternalServerError("Error finding email identity").WithInternalError(terr)
+					}
+					emailIdentity, terr := models.NewIdentity(user, "email", map[string]interface{}{
+						"sub":   user.ID.String(),
+						"email": user.GetEmail(),
+					})
+					if terr != nil {
+						return apierrors.NewInternalServerError("Error creating email identity").WithInternalError(terr)
+					}
+					if terr := tx.Create(emailIdentity); terr != nil {
+						return apierrors.NewInternalServerError("Error saving email identity").WithInternalError(terr)
+					}
+					if terr := user.UpdateAppMetaDataProviders(tx); terr != nil {
+						return apierrors.NewInternalServerError("Error updating providers").WithInternalError(terr)
+					}
+				}
+			}
+
 			// send a Password Changed email notification to the user to inform them that their password has been changed
 			if config.Mailer.Notifications.PasswordChangedEnabled && user.GetEmail() != "" {
 				if err := a.sendPasswordChangedNotification(r, tx, user); err != nil {


### PR DESCRIPTION
Fixes #2320

## Problem
When `updateUser` is called with a password on an OAuth-only account, no `email` identity was created in `auth.identities`. This meant the user could not sign in with email+password even though the password was saved correctly on the `users` row.

## Fix
Inside the password-update transaction in `UserUpdate`, after `UpdatePassword` succeeds, check whether the user already has an `email` identity. If not (i.e. OAuth-only account), create one using the user's existing confirmed email and call `UpdateAppMetaDataProviders` so that `app_metadata.providers` includes `"email"`.

The fix is no-op for users who already have an email identity.

## Changes
- `internal/api/user.go` 