### PR TITLE
chore: parallelize go build invocations in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,9 +24,10 @@ help: ## Show this help.
 all: vet sec static build ## Run the tests and build the binary.
 
 build: deps ## Build the binary.
-	CGO_ENABLED=0 go build $(FLAGS)
-	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build $(FLAGS) -o auth-arm64
-	CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build $(FLAGS) -o auth-darwin-arm64
+	CGO_ENABLED=0 go build $(FLAGS) & \
+	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build $(FLAGS) -o auth-arm64 & \
+	CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build $(FLAGS) -o auth-darwin-arm64 & \
+	wait
 
 build-strip: deps ## Build a stripped binary, for which the version file needs to be rewritten.
 	echo "package utilities" > internal/utilities/version.go


### PR DESCRIPTION
Run the 3 independent cross-platform builds in the `build` target concurrently using background processes and `wait`, reducing build time by ~50% in CI.