### PR TITLE
fix(sms): support literal \n in SMS OTP templates

### DIFF
--- a/internal/conf/configuration.go
+++ b/internal/conf/configuration.go
@@ -1114,6 +1114,7 @@ func populateGlobal(config *GlobalConfiguration) error {
 		if SMSTemplate == "" {
 			SMSTemplate = "Your code is {{ .Code }}"
 		}
+		SMSTemplate = strings.ReplaceAll(SMSTemplate, "\\n", "\n")
 		template, err := template.New("").Parse(SMSTemplate)
 		if err != nil {
 			return err
@@ -1126,6 +1127,7 @@ func populateGlobal(config *GlobalConfiguration) error {
 		if smsTemplate == "" {
 			smsTemplate = "Your code is {{ .Code }}"
 		}
+		smsTemplate = strings.ReplaceAll(smsTemplate, "\\n", "\n")
 		template, err := template.New("").Parse(smsTemplate)
 		if err != nil {
 			return err


### PR DESCRIPTION
Fixes supabase/supabase#6435

## Summary
Users want to use newlines (`\n`) in their SMS OTP templates configured via environment variables, but SMS providers were sending the literal string `\n` instead of an actual newline character.

This PR fixes the issue by replacing any literal `\n` sequences in the SMS template string with actual newline characters before parsing the Go template.

## Changes
- In `internal/conf/configuration.go`, added `strings.ReplaceAll(template, "\\n", "\n")` before parsing both `Sms.Template` and `MFA.Phone.Template`