### PR TITLE
chore: limit aal1 sessions correctly

### DIFF
--- a/internal/api/token.go
+++ b/internal/api/token.go
@@ -398,7 +398,7 @@ func (a *API) updateMFASessionAndClaims(r *http.Request, tx *storage.Connection,
 	return &tokens.AccessTokenResponse{
 		Token:        tokenString,
 		TokenType:    "bearer",
-		ExpiresIn:    config.JWT.Exp,
+		ExpiresIn:    int(expiresAt - a.Now().Unix()),
 		ExpiresAt:    expiresAt,
 		RefreshToken: issuedRefreshToken,
 		User:         user,

--- a/internal/tokens/service.go
+++ b/internal/tokens/service.go
@@ -669,8 +669,18 @@ func (s *Service) GenerateAccessToken(r *http.Request, tx *storage.Connection, p
 		return "", 0, terr
 	}
 
+	var expiresAt time.Time
+
 	issuedAt := s.now().UTC()
-	expiresAt := issuedAt.Add(time.Second * time.Duration(config.JWT.Exp))
+	if config.Sessions.AllowLowAAL != nil && *config.Sessions.AllowLowAAL != 0 && models.CompareAAL(aal, params.User.HighestPossibleAAL()) < 0 {
+		// if user has mfa enabled and the session has not yet been upgraded
+		// and Limit duration of AAL1 sessions is enabled
+		// expiresAt should be set to the maximum duration for low aal sessions
+		expiresAt = issuedAt.Add(*config.Sessions.AllowLowAAL)
+	} else {
+		expiresAt = issuedAt.Add(time.Second * time.Duration(config.JWT.Exp))
+	}
+
 	var clientID string
 	if params.ClientID != nil && *params.ClientID != uuid.Nil {
 		clientID = params.ClientID.String()

--- a/internal/tokens/service.go
+++ b/internal/tokens/service.go
@@ -676,7 +676,7 @@ func (s *Service) GenerateAccessToken(r *http.Request, tx *storage.Connection, p
 		// if user has mfa enabled and the session has not yet been upgraded
 		// and Limit duration of AAL1 sessions is enabled
 		// expiresAt should be set to the maximum duration for low aal sessions
-		expiresAt = issuedAt.Add(*config.Sessions.AllowLowAAL)
+		expiresAt = session.CreatedAt.UTC().Add(*config.Sessions.AllowLowAAL)
 	} else {
 		expiresAt = issuedAt.Add(time.Second * time.Duration(config.JWT.Exp))
 	}

--- a/internal/tokens/service.go
+++ b/internal/tokens/service.go
@@ -627,7 +627,7 @@ func (s *Service) RefreshTokenGrant(ctx context.Context, db *storage.Connection,
 			newTokenResponse = &AccessTokenResponse{
 				Token:        tokenString,
 				TokenType:    "bearer",
-				ExpiresIn:    config.JWT.Exp,
+				ExpiresIn:    int(expiresAt - s.now().Unix()),
 				ExpiresAt:    expiresAt,
 				RefreshToken: issuedToken,
 				User:         user,
@@ -669,23 +669,18 @@ func (s *Service) GenerateAccessToken(r *http.Request, tx *storage.Connection, p
 		return "", 0, terr
 	}
 
-	var expiresAt time.Time
-
 	issuedAt := s.now().UTC()
+	expiresAt := issuedAt.Add(time.Second * time.Duration(config.JWT.Exp))
+
 	if config.Sessions.AllowLowAAL != nil && *config.Sessions.AllowLowAAL != 0 && models.CompareAAL(aal, params.User.HighestPossibleAAL()) < 0 {
 		// if user has mfa enabled and the session has not yet been upgraded
 		// and Limit duration of AAL1 sessions is enabled
 		// expiresAt should be set to the maximum duration for low aal sessions
 		// don't allow sessions.AllowLowAAL to exceed config.JWT.Exp
-		standardExp := issuedAt.Add(time.Second * time.Duration(config.JWT.Exp))
 		lowAALExp := session.CreatedAt.UTC().Add(*config.Sessions.AllowLowAAL)
-		if lowAALExp.Before(standardExp) {
+		if lowAALExp.Before(expiresAt) {
 			expiresAt = lowAALExp
-		} else {
-			expiresAt = standardExp
 		}
-	} else {
-		expiresAt = issuedAt.Add(time.Second * time.Duration(config.JWT.Exp))
 	}
 
 	var clientID string
@@ -949,7 +944,7 @@ func (s *Service) IssueRefreshToken(r *http.Request, responseHeaders http.Header
 	return &AccessTokenResponse{
 		Token:        tokenString,
 		TokenType:    "bearer",
-		ExpiresIn:    config.JWT.Exp,
+		ExpiresIn:    int(expiresAt - s.now().Unix()),
 		ExpiresAt:    expiresAt,
 		RefreshToken: refreshToken,
 		User:         user,

--- a/internal/tokens/service.go
+++ b/internal/tokens/service.go
@@ -676,7 +676,14 @@ func (s *Service) GenerateAccessToken(r *http.Request, tx *storage.Connection, p
 		// if user has mfa enabled and the session has not yet been upgraded
 		// and Limit duration of AAL1 sessions is enabled
 		// expiresAt should be set to the maximum duration for low aal sessions
-		expiresAt = session.CreatedAt.UTC().Add(*config.Sessions.AllowLowAAL)
+		// don't allow sessions.AllowLowAAL to exceed config.JWT.Exp
+		standardExp := issuedAt.Add(time.Second * time.Duration(config.JWT.Exp))
+		lowAALExp := session.CreatedAt.UTC().Add(*config.Sessions.AllowLowAAL)
+		if lowAALExp.Before(standardExp) {
+			expiresAt = lowAALExp
+		} else {
+			expiresAt = standardExp
+		}
 	} else {
 		expiresAt = issuedAt.Add(time.Second * time.Duration(config.JWT.Exp))
 	}

--- a/internal/tokens/service_test.go
+++ b/internal/tokens/service_test.go
@@ -1237,7 +1237,7 @@ func TestGenerateAccessTokenAllowLowAAL(t *testing.T) {
 			AuthenticationMethod: models.PasswordGrant,
 		})
 		require.NoError(t, err)
-		require.Equal(t, now.Add(allowLowAAL).Unix(), expiresAt)
+		require.Equal(t, session.CreatedAt.UTC().Add(allowLowAAL).Unix(), expiresAt)
 	})
 
 	t.Run("AAL2 session for MFA user uses standard JWT expiry", func(t *testing.T) {

--- a/internal/tokens/service_test.go
+++ b/internal/tokens/service_test.go
@@ -1256,6 +1256,7 @@ func TestGenerateAccessTokenAllowLowAAL(t *testing.T) {
 		aal2 := models.AAL2.String()
 		session.AAL = &aal2
 		require.NoError(t, conn.Create(session))
+		require.NoError(t, models.AddClaimToSession(conn, session.ID, models.TOTPSignIn))
 
 		cfg := *config
 		cfg.Sessions.AllowLowAAL = &allowLowAAL

--- a/internal/tokens/service_test.go
+++ b/internal/tokens/service_test.go
@@ -1192,3 +1192,113 @@ func TestAsRedirectURL(t *testing.T) {
 	require.Contains(t, fragment, "sb", "Fragment should contain Supabase Auth identifier 'sb'")
 	require.Equal(t, "", fragment.Get("sb"), "Supabase Auth identifier should have empty value")
 }
+
+func TestGenerateAccessTokenAllowLowAAL(t *testing.T) {
+	config, err := conf.LoadGlobal("../../hack/test.env")
+	require.NoError(t, err)
+
+	conn, err := test.SetupDBConnection(config)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	allowLowAAL := 5 * time.Minute
+
+	req, err := http.NewRequest("POST", "https://example.com/", nil)
+	require.NoError(t, err)
+
+	now := time.Now().UTC().Truncate(time.Second)
+
+	t.Run("AAL1 session for MFA user uses AllowLowAAL expiry", func(t *testing.T) {
+		models.TruncateAll(conn)
+
+		u, err := models.NewUser("", "test@example.com", "password", "authenticated", nil)
+		require.NoError(t, err)
+		require.NoError(t, conn.Create(u))
+
+		// Add a verified TOTP factor so HighestPossibleAAL() returns AAL2
+		factor := models.NewFactor(u, "my-totp", models.TOTP, models.FactorStateVerified)
+		require.NoError(t, conn.Create(factor))
+		require.NoError(t, conn.Eager().Find(u, u.ID))
+
+		session, err := models.NewSession(u.ID, nil)
+		require.NoError(t, err)
+		// Session stays at AAL1 (default)
+		require.NoError(t, conn.Create(session))
+
+		cfg := *config
+		cfg.Sessions.AllowLowAAL = &allowLowAAL
+
+		srv := NewService(&cfg, &panicHookManager{})
+		srv.SetTimeFunc(func() time.Time { return now })
+
+		_, expiresAt, err := srv.GenerateAccessToken(req, conn, GenerateAccessTokenParams{
+			User:                 u,
+			SessionID:            &session.ID,
+			AuthenticationMethod: models.PasswordGrant,
+		})
+		require.NoError(t, err)
+		require.Equal(t, now.Add(allowLowAAL).Unix(), expiresAt)
+	})
+
+	t.Run("AAL2 session for MFA user uses standard JWT expiry", func(t *testing.T) {
+		models.TruncateAll(conn)
+
+		u, err := models.NewUser("", "test2@example.com", "password", "authenticated", nil)
+		require.NoError(t, err)
+		require.NoError(t, conn.Create(u))
+
+		factor := models.NewFactor(u, "my-totp", models.TOTP, models.FactorStateVerified)
+		require.NoError(t, conn.Create(factor))
+		require.NoError(t, conn.Eager().Find(u, u.ID))
+
+		session, err := models.NewSession(u.ID, &factor.ID)
+		require.NoError(t, err)
+		aal2 := models.AAL2.String()
+		session.AAL = &aal2
+		require.NoError(t, conn.Create(session))
+
+		cfg := *config
+		cfg.Sessions.AllowLowAAL = &allowLowAAL
+
+		srv := NewService(&cfg, &panicHookManager{})
+		srv.SetTimeFunc(func() time.Time { return now })
+
+		_, expiresAt, err := srv.GenerateAccessToken(req, conn, GenerateAccessTokenParams{
+			User:                 u,
+			SessionID:            &session.ID,
+			AuthenticationMethod: models.PasswordGrant,
+		})
+		require.NoError(t, err)
+		require.Equal(t, now.Add(time.Second*time.Duration(config.JWT.Exp)).Unix(), expiresAt)
+	})
+
+	t.Run("AAL1 session without AllowLowAAL uses standard JWT expiry", func(t *testing.T) {
+		models.TruncateAll(conn)
+
+		u, err := models.NewUser("", "test3@example.com", "password", "authenticated", nil)
+		require.NoError(t, err)
+		require.NoError(t, conn.Create(u))
+
+		factor := models.NewFactor(u, "my-totp", models.TOTP, models.FactorStateVerified)
+		require.NoError(t, conn.Create(factor))
+		require.NoError(t, conn.Eager().Find(u, u.ID))
+
+		session, err := models.NewSession(u.ID, nil)
+		require.NoError(t, err)
+		require.NoError(t, conn.Create(session))
+
+		cfg := *config
+		cfg.Sessions.AllowLowAAL = nil
+
+		srv := NewService(&cfg, &panicHookManager{})
+		srv.SetTimeFunc(func() time.Time { return now })
+
+		_, expiresAt, err := srv.GenerateAccessToken(req, conn, GenerateAccessTokenParams{
+			User:                 u,
+			SessionID:            &session.ID,
+			AuthenticationMethod: models.PasswordGrant,
+		})
+		require.NoError(t, err)
+		require.Equal(t, now.Add(time.Second*time.Duration(config.JWT.Exp)).Unix(), expiresAt)
+	})
+}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

When `MFA_ALLOW_LOW_AAL` is false, AAL1 sessions JWTs should be limited to 15 minutes. Currently the JWT is created with an expiry set to the standard session timeout. And the LOW_AAL timeout is only checked when the refresh_token is issued.
This means AAL1 sessions can be valid beyond the 15 minute window.

## What is the new behavior?
AAL1 JWTs are limited to 15minutes.

