### PR TITLE
fix: check SIWE ExpirationTime independently of NotBefore

### DIFF
--- a/internal/api/web3.go
+++ b/internal/api/web3.go
@@ -244,7 +244,7 @@ func (a *API) web3GrantEthereum(ctx context.Context, w http.ResponseWriter, r *h
 		return apierrors.NewOAuthError("invalid_grant", "Signed Ethereum message becomes valid in the future")
 	}
 
-	if parsedMessage.NotBefore != nil && parsedMessage.ExpirationTime != nil && !parsedMessage.ExpirationTime.IsZero() && now.After(*parsedMessage.ExpirationTime) {
+	if parsedMessage.ExpirationTime != nil && !parsedMessage.ExpirationTime.IsZero() && now.After(*parsedMessage.ExpirationTime) {
 		return apierrors.NewOAuthError("invalid_grant", "Signed Ethereum message is expired")
 	}
 


### PR DESCRIPTION
Fixes #2453

In `web3GrantEthereum`, the expiration check for SIWE messages is gated on `NotBefore != nil`:

```go
if parsedMessage.NotBefore != nil && parsedMessage.ExpirationTime != nil && ...
```

Per EIP-4361, `not-before` and `expiration-time` are independent optional fields. When a SIWE message includes an `expirationTime` but omits `notBefore`, the entire expiration check is skipped and the expired message is accepted.

The Solana handler already checks them independently and doesn't have this problem.

The `MaximumValidityDuration` fallback is a separate, broader window based on `IssuedAt` -- it doesn't respect the per-message `ExpirationTime`. So a message that sets a short expiration would still be accepted for the full `MaximumValidityDuration`.

The fix removes `parsedMessage.NotBefore != nil &&` from the expiration check condition, matching the pattern used in the Solana handler.