### PR TITLE
feat: add GOTRUE_DB_DEFAULT_ROLE with backward compatibility and tests

### DIFF
--- a/example.env
+++ b/example.env
@@ -7,6 +7,9 @@ GOTRUE_JWT_AUD="authenticated"
 GOTRUE_JWT_DEFAULT_GROUP_NAME="authenticated"
 GOTRUE_JWT_ADMIN_ROLES="supabase_admin,service_role"
 
+# Default role assigned to newly created users
+GOTRUE_DB_DEFAULT_ROLE="authenticated"
+
 # Database & API connection details
 GOTRUE_DB_DRIVER="postgres"
 DB_NAMESPACE="auth"

--- a/internal/api/admin.go
+++ b/internal/api/admin.go
@@ -466,7 +466,7 @@ func (a *API) adminUserCreate(w http.ResponseWriter, r *http.Request) error {
 			return terr
 		}
 
-		role := config.JWT.DefaultGroupName
+		role := config.DB.DefaultRole
 		if params.Role != "" {
 			role = params.Role
 		}

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -86,7 +86,7 @@ func (a *API) deprecationNotices() {
 	}
 
 	if config.JWT.DefaultGroupName != "" {
-		log.Warn("DEPRECATION NOTICE: GOTRUE_JWT_DEFAULT_GROUP_NAME not supported by Supabase's GoTrue, will be removed soon")
+		log.Warn("DEPRECATION NOTICE: GOTRUE_JWT_DEFAULT_GROUP_NAME is deprecated, use GOTRUE_DB_DEFAULT_ROLE instead")
 	}
 }
 

--- a/internal/api/signup.go
+++ b/internal/api/signup.go
@@ -385,7 +385,7 @@ func (a *API) signupNewUser(conn *storage.Connection, user *models.User) (*model
 		if terr = tx.Create(user); terr != nil {
 			return apierrors.NewInternalServerError("Database error saving new user").WithInternalError(terr)
 		}
-		if terr = user.SetRole(tx, config.JWT.DefaultGroupName); terr != nil {
+		if terr = user.SetRole(tx, config.DB.DefaultRole); terr != nil {
 			return apierrors.NewInternalServerError("Database error updating user").WithInternalError(terr)
 		}
 		return nil

--- a/internal/conf/configuration.go
+++ b/internal/conf/configuration.go
@@ -110,6 +110,7 @@ type DBConfiguration struct {
 	Driver    string `json:"driver" required:"true"`
 	URL       string `json:"url" envconfig:"DATABASE_URL" required:"true"`
 	Namespace string `json:"namespace" envconfig:"DB_NAMESPACE" default:"auth"`
+	DefaultRole string `json:"default_role" split_words:"true"`
 
 	// Percentage of DB conns the auth server may use in
 	// integer form i.e.: [1, 100] -> [1%, 100%]
@@ -1140,6 +1141,14 @@ func populateGlobal(config *GlobalConfiguration) error {
 func (config *GlobalConfiguration) ApplyDefaults() error {
 	if config.JWT.AdminGroupName == "" {
 		config.JWT.AdminGroupName = "admin"
+	}
+
+	if config.DB.DefaultRole == "" {
+		if config.JWT.DefaultGroupName != "" {
+			config.DB.DefaultRole = config.JWT.DefaultGroupName
+		} else {
+			config.DB.DefaultRole = "authenticated"
+		}
 	}
 
 	if len(config.JWT.AdminRoles) == 0 {

--- a/internal/conf/configuration_test.go
+++ b/internal/conf/configuration_test.go
@@ -1360,6 +1360,56 @@ func TestWebAuthnConfigurationValidate(t *testing.T) {
 	}
 }
 
+func TestDefaultRoleApplyDefaults(t *testing.T) {
+	// Case 1: GOTRUE_DB_DEFAULT_ROLE is set — should use it directly
+	{
+		val := &GlobalConfiguration{
+			JWT: JWTConfiguration{Secret: "a"},
+			DB:  DBConfiguration{DefaultRole: "custom_role"},
+		}
+		err := val.ApplyDefaults()
+		require.NoError(t, err)
+		require.Equal(t, "custom_role", val.DB.DefaultRole)
+	}
+
+	// Case 2: neither is set — should default to "authenticated"
+	{
+		val := &GlobalConfiguration{
+			JWT: JWTConfiguration{Secret: "a"},
+		}
+		err := val.ApplyDefaults()
+		require.NoError(t, err)
+		require.Equal(t, "authenticated", val.DB.DefaultRole)
+	}
+
+	// Case 3: only GOTRUE_JWT_DEFAULT_GROUP_NAME is set — backward compat
+	{
+		val := &GlobalConfiguration{
+			JWT: JWTConfiguration{
+				Secret:           "a",
+				DefaultGroupName: "legacy_role",
+			},
+		}
+		err := val.ApplyDefaults()
+		require.NoError(t, err)
+		require.Equal(t, "legacy_role", val.DB.DefaultRole)
+	}
+
+	// Case 4: both are set — DB.DefaultRole takes precedence
+	{
+		val := &GlobalConfiguration{
+			JWT: JWTConfiguration{
+				Secret:           "a",
+				DefaultGroupName: "legacy_role",
+			},
+			DB: DBConfiguration{DefaultRole: "new_role"},
+		}
+		err := val.ApplyDefaults()
+		require.NoError(t, err)
+		require.Equal(t, "new_role", val.DB.DefaultRole)
+	}
+}
+
 func toPtr[T any](v T) *T {
 	return &(&([1]T{T(v)}))[0]
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature (with backward compatibility)

## What is the current behavior?

The default role for newly created users is derived from `GOTRUE_JWT_DEFAULT_GROUP_NAME`, which is being deprecated. This couples user role assignment with JWT configuration and limits flexibility.

Fixes #2359

## What is the new behavior?

- Introduces a new environment variable: `GOTRUE_DB_DEFAULT_ROLE`
- This value is used as the default role for newly created users
- Backward compatibility is preserved:
  - If `GOTRUE_DB_DEFAULT_ROLE` is set → it is used
  - Else if `GOTRUE_JWT_DEFAULT_GROUP_NAME` is set → fallback to it
  - Else → defaults to `"authenticated"`
- Adds a deprecation warning for `GOTRUE_JWT_DEFAULT_GROUP_NAME`

## Additional context

- Updates user creation logic to use `DB.DefaultRole`
- Updates `example.env` to include the new variable
- Keeps existing behavior unchanged unless the new variable is used

## Tests

- Added `TestDefaultRoleApplyDefaults` to verify:
  - Custom role usage
  - Default fallback behavior
  - Backward compatibility
  - Precedence rules

- Verified locally using:
  ```bash
  go test ./internal/conf -v