### PR TITLE
feat: support live reloading of individual rate limits

### DIFF
--- a/cmd/serve_cmd.go
+++ b/cmd/serve_cmd.go
@@ -14,6 +14,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/supabase/auth/internal/api"
+	"github.com/supabase/auth/internal/api/apilimiter"
 	"github.com/supabase/auth/internal/api/apiworker"
 	"github.com/supabase/auth/internal/conf"
 	"github.com/supabase/auth/internal/mailer/templatemailer"
@@ -63,10 +64,10 @@ func serve(ctx context.Context) {
 	defer wg.Wait() // Do not return to caller until this goroutine is done.
 
 	mrCache := templatemailer.NewCache()
-	limiterOpts := api.NewLimiterOptions(config)
+	initialLim := apilimiter.New(config)
 	initialAPI := api.NewAPIWithVersion(
 		config, db, utilities.Version,
-		limiterOpts,
+		api.WithLimiter(initialLim),
 		api.WithMailer(templatemailer.FromConfig(config, mrCache)),
 	)
 
@@ -130,11 +131,12 @@ func serve(ctx context.Context) {
 				exitFn("config reloader is exiting")
 			}()
 
+			previousLim := initialLim
 			fn := func(latestCfg *conf.GlobalConfiguration) {
 				le.Info("reloading api with new configuration")
 
-				// When config is updated we notify the apiworker.
-				wrk.ReloadConfig(latestCfg)
+				// Update the previous limiter with the latest config
+				latestLim := previousLim.Update(le, latestCfg)
 
 				// Create a new API version with the updated config.
 				latestAPI := api.NewAPIWithVersion(
@@ -146,13 +148,17 @@ func serve(ctx context.Context) {
 					),
 
 					// Persist existing rate limiters.
-					//
-					// TODO(cstockton): we should consider updating these, if we
-					// rely on hot config reloads 100% then rate limiter changes
-					// won't be picked up.
-					limiterOpts,
+					api.WithLimiter(latestLim),
 				)
+
+				// Assign this config as the latest configuration
 				ah.Store(latestAPI)
+
+				// When config is updated we notify the apiworker.
+				wrk.ReloadConfig(latestCfg)
+
+				// Update previous limiter
+				previousLim = latestLim
 			}
 
 			rl := reloader.NewReloader(rc, watchDir)

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -9,6 +9,7 @@ import (
 	"github.com/sebest/xff"
 	"github.com/sirupsen/logrus"
 	"github.com/supabase/auth/internal/api/apierrors"
+	"github.com/supabase/auth/internal/api/apilimiter"
 	"github.com/supabase/auth/internal/api/apitask"
 	"github.com/supabase/auth/internal/api/oauthserver"
 	"github.com/supabase/auth/internal/api/provider"
@@ -54,7 +55,7 @@ type API struct {
 	// overrideTime can be used to override the clock used by handlers. Should only be used in tests!
 	overrideTime func() time.Time
 
-	limiterOpts *LimiterOptions
+	limiterOpts *apilimiter.Limiter
 }
 
 func (a *API) GetConfig() *conf.GlobalConfiguration { return a.config }
@@ -110,7 +111,7 @@ func NewAPIWithVersion(globalConfig *conf.GlobalConfiguration, db *storage.Conne
 		api.captchaVerifier = security.NewCaptchaVerifier(&globalConfig.Security.Captcha)
 	}
 	if api.limiterOpts == nil {
-		api.limiterOpts = NewLimiterOptions(globalConfig)
+		api.limiterOpts = apilimiter.New(globalConfig)
 	}
 	if api.hooksMgr == nil {
 		httpDr := hookshttp.New()

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"github.com/supabase/auth/internal/api/apilimiter"
 	"github.com/supabase/auth/internal/conf"
 	"github.com/supabase/auth/internal/crypto"
 	"github.com/supabase/auth/internal/storage"
@@ -55,8 +56,8 @@ func setupAPIForTestWithCallback(cb func(*conf.GlobalConfiguration, *storage.Con
 		cb(nil, conn)
 	}
 
-	limiterOpts := NewLimiterOptions(config)
-	return NewAPIWithVersion(config, conn, apiTestVersion, limiterOpts), config, nil
+	limiterOpts := apilimiter.New(config)
+	return NewAPIWithVersion(config, conn, apiTestVersion, WithLimiter(limiterOpts)), config, nil
 }
 
 func TestEmailEnabledByDefault(t *testing.T) {

--- a/internal/api/apilimiter/apilimiter.go
+++ b/internal/api/apilimiter/apilimiter.go
@@ -1,0 +1,391 @@
+package apilimiter
+
+import (
+	"maps"
+	"slices"
+	"time"
+
+	"github.com/didip/tollbooth/v5"
+	"github.com/didip/tollbooth/v5/limiter"
+	"github.com/sirupsen/logrus"
+	"github.com/supabase/auth/internal/conf"
+	"github.com/supabase/auth/internal/ratelimit"
+)
+
+const (
+	// GOTRUE_RATE_LIMIT_EMAIL_SENT
+	//   -> RateLimitEmailSent
+	envRateLimitEmailSent = "GOTRUE_RATE_LIMIT_EMAIL_SENT"
+	fieldEmail            = "Email"
+
+	// GOTRUE_RATE_LIMIT_SMS_SENT
+	//   -> RateLimitSmsSent
+	envRateLimitSmsSent = "GOTRUE_RATE_LIMIT_SMS_SENT"
+	fieldPhone          = "Phone"
+
+	// GOTRUE_RATE_LIMIT_ANONYMOUS_USERS
+	//  -> RateLimitAnonymousUsers
+	envRateLimitAnonymousUsers = "GOTRUE_RATE_LIMIT_ANONYMOUS_USERS"
+	fieldAnonymousSignIns      = "AnonymousSignIns"
+
+	// GOTRUE_MFA_RATE_LIMIT_CHALLENGE_AND_VERIFY
+	//   -> MFA.RateLimitChallengeAndVerify
+	envMFARateLimitChallengeAndVerify = "GOTRUE_MFA_RATE_LIMIT_CHALLENGE_AND_VERIFY"
+	fieldFactorChallenge              = "FactorChallenge"
+	fieldFactorVerify                 = "FactorVerify"
+
+	// GOTRUE_RATE_LIMIT_OTP
+	//   -> RateLimitOtp
+	envRateLimitOtp = "GOTRUE_RATE_LIMIT_OTP"
+	fieldMagicLink  = "MagicLink"
+	fieldOtp        = "Otp"
+	fieldRecover    = "Recover"
+	fieldResend     = "Resend"
+	fieldSignups    = "Signups"
+	fieldUser       = "User"
+
+	// GOTRUE_RATE_LIMIT_OAUTH_DYNAMIC_CLIENT_REGISTER
+	//   -> RateLimitOAuthDynamicClientRegister
+	envRateLimitOAuthDynamicClientRegister = "GOTRUE_RATE_LIMIT_OAUTH_DYNAMIC_CLIENT_REGISTER"
+	fieldOAuthClientRegister               = "OAuthClientRegister"
+
+	// GOTRUE_RATE_LIMIT_PASSKEY
+	//   -> RateLimitPasskey
+	envRateLimitPasskey        = "GOTRUE_RATE_LIMIT_PASSKEY"
+	fieldPasskeyAuthentication = "PasskeyAuthentication"
+
+	// GOTRUE_SAML_RATE_LIMIT_ASSERTION
+	//   -> SAML.RateLimitAssertion
+	envSAMLRateLimitAssertion = "GOTRUE_SAML_RATE_LIMIT_ASSERTION"
+	fieldSAMLAssertion        = "SAMLAssertion"
+
+	// GOTRUE_RATE_LIMIT_SSO
+	//   -> RateLimitSso
+	envRateLimitSso = "GOTRUE_RATE_LIMIT_SSO"
+	fieldSSO        = "SSO"
+
+	// GOTRUE_RATE_LIMIT_TOKEN_REFRESH
+	//   -> RateLimitTokenRefresh
+	envRateLimitTokenRefresh = "GOTRUE_RATE_LIMIT_TOKEN_REFRESH"
+	fieldToken               = "Token"
+
+	// GOTRUE_RATE_LIMIT_VERIFY
+	//   -> RateLimitVerify
+	envRateLimitVerify = "GOTRUE_RATE_LIMIT_VERIFY"
+	fieldVerify        = "Verify"
+
+	// GOTRUE_RATE_LIMIT_WEB3
+	//   -> RateLimitWeb3
+	envRateLimitWeb3 = "GOTRUE_RATE_LIMIT_WEB3"
+	fieldWeb3        = "Web3"
+)
+
+var ratelimitFieldsToEnv = map[string]string{
+	fieldEmail: envRateLimitEmailSent,
+	fieldPhone: envRateLimitSmsSent,
+}
+
+var tollboothFieldsToEnv = map[string]string{
+	fieldAnonymousSignIns:      envRateLimitAnonymousUsers,
+	fieldFactorChallenge:       envMFARateLimitChallengeAndVerify,
+	fieldFactorVerify:          envMFARateLimitChallengeAndVerify,
+	fieldMagicLink:             envRateLimitOtp,
+	fieldOtp:                   envRateLimitOtp,
+	fieldRecover:               envRateLimitOtp,
+	fieldResend:                envRateLimitOtp,
+	fieldSignups:               envRateLimitOtp,
+	fieldUser:                  envRateLimitOtp,
+	fieldOAuthClientRegister:   envRateLimitOAuthDynamicClientRegister,
+	fieldPasskeyAuthentication: envRateLimitPasskey,
+	fieldSAMLAssertion:         envSAMLRateLimitAssertion,
+	fieldSSO:                   envRateLimitSso,
+	fieldToken:                 envRateLimitTokenRefresh,
+	fieldVerify:                envRateLimitVerify,
+	fieldWeb3:                  envRateLimitWeb3,
+}
+
+var fieldsToEnv = func() map[string]string {
+	n := len(ratelimitFieldsToEnv) + len(tollboothFieldsToEnv)
+	out := make(map[string]string, n)
+	maps.Insert(out, maps.All(ratelimitFieldsToEnv))
+	maps.Insert(out, maps.All(tollboothFieldsToEnv))
+	return out
+}()
+
+var envsToFields = func() map[string][]string {
+	out := make(map[string][]string)
+	for field, env := range fieldsToEnv {
+		out[env] = append(out[env], field)
+	}
+	for _, fields := range out {
+		slices.Sort(fields)
+	}
+	return out
+}()
+
+type Limiter struct {
+	cfg *conf.GlobalConfiguration
+
+	// GOTRUE_RATE_LIMIT_EMAIL_SENT
+	//   -> RateLimitEmailSent
+	Email ratelimit.Limiter
+
+	// GOTRUE_RATE_LIMIT_SMS_SENT
+	//   -> RateLimitSmsSent
+	Phone ratelimit.Limiter
+
+	// GOTRUE_RATE_LIMIT_ANONYMOUS_USERS
+	//  -> RateLimitAnonymousUsers
+	AnonymousSignIns *limiter.Limiter
+
+	// GOTRUE_MFA_RATE_LIMIT_CHALLENGE_AND_VERIFY
+	//   -> MFA.RateLimitChallengeAndVerify
+	FactorChallenge *limiter.Limiter
+	FactorVerify    *limiter.Limiter
+
+	// GOTRUE_RATE_LIMIT_OTP
+	//   -> RateLimitOtp
+	MagicLink *limiter.Limiter
+	Otp       *limiter.Limiter
+	Recover   *limiter.Limiter
+	Resend    *limiter.Limiter
+	Signups   *limiter.Limiter
+	User      *limiter.Limiter
+
+	// GOTRUE_RATE_LIMIT_OAUTH_DYNAMIC_CLIENT_REGISTER
+	//   -> RateLimitOAuthDynamicClientRegister
+	OAuthClientRegister *limiter.Limiter
+
+	// GOTRUE_RATE_LIMIT_PASSKEY
+	//   -> RateLimitPasskey
+	PasskeyAuthentication *limiter.Limiter
+
+	// GOTRUE_SAML_RATE_LIMIT_ASSERTION
+	//   -> SAML.RateLimitAssertion
+	SAMLAssertion *limiter.Limiter
+
+	// GOTRUE_RATE_LIMIT_SSO
+	//   -> RateLimitSso
+	SSO *limiter.Limiter
+
+	// GOTRUE_RATE_LIMIT_TOKEN_REFRESH
+	//   -> RateLimitTokenRefresh
+	Token *limiter.Limiter
+
+	// GOTRUE_RATE_LIMIT_VERIFY
+	//   -> RateLimitVerify
+	Verify *limiter.Limiter
+
+	// GOTRUE_RATE_LIMIT_WEB3
+	//   -> RateLimitWeb3
+	Web3 *limiter.Limiter
+}
+
+func New(gc *conf.GlobalConfiguration) *Limiter {
+	o := &Limiter{
+		cfg: gc,
+	}
+
+	o.Email = ratelimit.New(gc.RateLimitEmailSent)
+	o.Phone = ratelimit.New(gc.RateLimitSmsSent)
+
+	o.AnonymousSignIns = tollbooth.NewLimiter(gc.RateLimitAnonymousUsers/(60*60),
+		&limiter.ExpirableOptions{
+			DefaultExpirationTTL: time.Hour,
+		}).SetBurst(int(gc.RateLimitAnonymousUsers)).SetMethods([]string{"POST"})
+
+	o.Token = tollbooth.NewLimiter(gc.RateLimitTokenRefresh/(60*5),
+		&limiter.ExpirableOptions{
+			DefaultExpirationTTL: time.Hour,
+		}).SetBurst(30)
+
+	o.Verify = tollbooth.NewLimiter(gc.RateLimitVerify/(60*5),
+		&limiter.ExpirableOptions{
+			DefaultExpirationTTL: time.Hour,
+		}).SetBurst(30)
+
+	o.FactorVerify = tollbooth.NewLimiter(gc.MFA.RateLimitChallengeAndVerify/60,
+		&limiter.ExpirableOptions{
+			DefaultExpirationTTL: time.Minute,
+		}).SetBurst(30)
+
+	o.FactorChallenge = tollbooth.NewLimiter(gc.MFA.RateLimitChallengeAndVerify/60,
+		&limiter.ExpirableOptions{
+			DefaultExpirationTTL: time.Minute,
+		}).SetBurst(30)
+
+	o.SSO = tollbooth.NewLimiter(gc.RateLimitSso/(60*5),
+		&limiter.ExpirableOptions{
+			DefaultExpirationTTL: time.Hour,
+		}).SetBurst(30)
+
+	o.SAMLAssertion = tollbooth.NewLimiter(gc.SAML.RateLimitAssertion/(60*5),
+		&limiter.ExpirableOptions{
+			DefaultExpirationTTL: time.Hour,
+		}).SetBurst(30)
+
+	o.Web3 = tollbooth.NewLimiter(gc.RateLimitWeb3/(60*5),
+		&limiter.ExpirableOptions{
+			DefaultExpirationTTL: time.Hour,
+		}).SetBurst(30)
+
+	// These all use the OTP limit per 5 min with 1hour ttl and burst of 30.
+	o.Recover = newLimiterPer5mOver1h(gc.RateLimitOtp)
+	o.Resend = newLimiterPer5mOver1h(gc.RateLimitOtp)
+	o.MagicLink = newLimiterPer5mOver1h(gc.RateLimitOtp)
+	o.Otp = newLimiterPer5mOver1h(gc.RateLimitOtp)
+	o.User = newLimiterPer5mOver1h(gc.RateLimitOtp)
+	o.Signups = newLimiterPer5mOver1h(gc.RateLimitOtp)
+	o.OAuthClientRegister = newLimiterPer5mOver1h(gc.RateLimitOAuthDynamicClientRegister)
+	o.PasskeyAuthentication = newLimiterPer5mOver1h(gc.RateLimitPasskey)
+	return o
+}
+
+func (o *Limiter) Copy() *Limiter {
+	return &Limiter{
+		cfg: o.cfg,
+
+		Email: o.Email,
+		Phone: o.Phone,
+
+		AnonymousSignIns:      o.AnonymousSignIns,
+		FactorChallenge:       o.FactorChallenge,
+		FactorVerify:          o.FactorVerify,
+		MagicLink:             o.MagicLink,
+		OAuthClientRegister:   o.OAuthClientRegister,
+		Otp:                   o.Otp,
+		PasskeyAuthentication: o.PasskeyAuthentication,
+		Recover:               o.Recover,
+		Resend:                o.Resend,
+		SAMLAssertion:         o.SAMLAssertion,
+		Signups:               o.Signups,
+		SSO:                   o.SSO,
+		Token:                 o.Token,
+		User:                  o.User,
+		Verify:                o.Verify,
+		Web3:                  o.Web3,
+	}
+}
+
+func (o *Limiter) Update(
+	le *logrus.Entry,
+	nextCfg *conf.GlobalConfiguration,
+) *Limiter {
+	prevCfg := o.cfg
+
+	v := o.Copy()
+	v.cfg = nextCfg
+
+	if !ratelimit.Equal(v.Email, nextCfg.RateLimitEmailSent) {
+		v.Email = ratelimit.New(nextCfg.RateLimitEmailSent)
+		logEnvUpdates(le, envRateLimitEmailSent,
+			o.Email.Config().GetRateValue(),
+			v.Email.Config().GetRateValue())
+	}
+
+	if !ratelimit.Equal(v.Phone, nextCfg.RateLimitSmsSent) {
+		v.Phone = ratelimit.New(nextCfg.RateLimitSmsSent)
+		logEnvUpdates(le, envRateLimitSmsSent,
+			o.Phone.Config().GetRateValue(),
+			v.Phone.Config().GetRateValue())
+	}
+
+	if a, b := prevCfg.RateLimitAnonymousUsers, nextCfg.RateLimitAnonymousUsers; a != b {
+		v.AnonymousSignIns = newTollbooth(
+			b/(60*60), int(b), time.Hour).SetMethods([]string{"POST"})
+		logEnvUpdates(le, envRateLimitAnonymousUsers, a, b)
+	}
+
+	if a, b := prevCfg.MFA.RateLimitChallengeAndVerify, nextCfg.MFA.RateLimitChallengeAndVerify; a != b {
+		v.FactorChallenge = newTollbooth(b/60, 30, time.Minute)
+		v.FactorVerify = newTollbooth(b/60, 30, time.Minute)
+		logEnvUpdates(le, envMFARateLimitChallengeAndVerify, a, b)
+	}
+
+	if a, b := prevCfg.RateLimitOtp, nextCfg.RateLimitOtp; a != b {
+		v.MagicLink = newLimiterPer5mOver1h(b)
+		v.Otp = newLimiterPer5mOver1h(b)
+		v.Recover = newLimiterPer5mOver1h(b)
+		v.Resend = newLimiterPer5mOver1h(b)
+		v.Signups = newLimiterPer5mOver1h(b)
+		v.User = newLimiterPer5mOver1h(b)
+		logEnvUpdates(le, envRateLimitOtp, a, b)
+	}
+
+	if a, b := prevCfg.RateLimitOAuthDynamicClientRegister, nextCfg.RateLimitOAuthDynamicClientRegister; a != b {
+		v.OAuthClientRegister = newLimiterPer5mOver1h(b)
+		logEnvUpdates(le, envRateLimitOAuthDynamicClientRegister, a, b)
+	}
+
+	if a, b := prevCfg.RateLimitPasskey, nextCfg.RateLimitPasskey; a != b {
+		v.PasskeyAuthentication = newLimiterPer5mOver1h(b)
+		logEnvUpdates(le, envRateLimitPasskey, a, b)
+	}
+
+	if a, b := prevCfg.SAML.RateLimitAssertion, nextCfg.SAML.RateLimitAssertion; a != b {
+		v.SAMLAssertion = newLimiterPer5mOver1h(b)
+		logEnvUpdates(le, envSAMLRateLimitAssertion, a, b)
+	}
+
+	if a, b := prevCfg.RateLimitSso, nextCfg.RateLimitSso; a != b {
+		v.SSO = newLimiterPer5mOver1h(b)
+		logEnvUpdates(le, envRateLimitSso, a, b)
+	}
+
+	if a, b := prevCfg.RateLimitTokenRefresh, nextCfg.RateLimitTokenRefresh; a != b {
+		v.Token = newLimiterPer5mOver1h(b)
+		logEnvUpdates(le, envRateLimitTokenRefresh, a, b)
+	}
+
+	if a, b := prevCfg.RateLimitVerify, nextCfg.RateLimitVerify; a != b {
+		v.Verify = newLimiterPer5mOver1h(b)
+		logEnvUpdates(le, envRateLimitVerify, a, b)
+	}
+
+	if a, b := prevCfg.RateLimitWeb3, nextCfg.RateLimitWeb3; a != b {
+		v.Web3 = newLimiterPer5mOver1h(b)
+		logEnvUpdates(le, envRateLimitWeb3, a, b)
+	}
+	return v
+}
+
+func newTollbooth(freq float64, burst int, ttl time.Duration) *limiter.Limiter {
+	return tollbooth.NewLimiter(freq, &limiter.ExpirableOptions{
+		DefaultExpirationTTL: ttl,
+	}).SetBurst(burst)
+}
+
+func newLimiterPer5mOver1h(rate float64) *limiter.Limiter {
+	freq := rate / (60 * 5)
+	lim := tollbooth.NewLimiter(freq, &limiter.ExpirableOptions{
+		DefaultExpirationTTL: time.Hour,
+	}).SetBurst(30)
+	return lim
+}
+
+func logEnvUpdates(
+	le *logrus.Entry,
+	env string,
+	prevVal, nextVal any,
+) {
+	for _, field := range envsToFields[env] {
+		logUpdate(le, field, prevVal, nextVal)
+	}
+}
+
+func logUpdate(
+	le *logrus.Entry,
+	field string,
+	prevVal, nextVal any,
+) {
+	envName := fieldsToEnv[field]
+	lf := logrus.Fields{
+		"rate_limit_field": field,
+		"rate_limit_env":   envName,
+		"rate_limit_old":   prevVal,
+		"rate_limit_new":   nextVal,
+	}
+	le.WithFields(lf).Infof(
+		"env %v changed, updating %v limiter from %v to %v",
+		envName, field, prevVal, nextVal)
+}

--- a/internal/api/apilimiter/apilimiter.go
+++ b/internal/api/apilimiter/apilimiter.go
@@ -51,7 +51,7 @@ const (
 
 	// GOTRUE_RATE_LIMIT_PASSKEY
 	//   -> RateLimitPasskey
-	envRateLimitPasskey        = "GOTRUE_RATE_LIMIT_PASSKEY"
+	envRateLimitPasskey        = "GOTRUE_RATE_LIMIT_PASSKEY" // #nosec G101
 	fieldPasskeyAuthentication = "PasskeyAuthentication"
 
 	// GOTRUE_SAML_RATE_LIMIT_ASSERTION
@@ -66,7 +66,7 @@ const (
 
 	// GOTRUE_RATE_LIMIT_TOKEN_REFRESH
 	//   -> RateLimitTokenRefresh
-	envRateLimitTokenRefresh = "GOTRUE_RATE_LIMIT_TOKEN_REFRESH"
+	envRateLimitTokenRefresh = "GOTRUE_RATE_LIMIT_TOKEN_REFRESH" // #nosec G101
 	fieldToken               = "Token"
 
 	// GOTRUE_RATE_LIMIT_VERIFY

--- a/internal/api/apilimiter/apilimiter_test.go
+++ b/internal/api/apilimiter/apilimiter_test.go
@@ -1,0 +1,269 @@
+package apilimiter
+
+import (
+	"maps"
+	"slices"
+	"testing"
+
+	"github.com/didip/tollbooth/v5/limiter"
+	"github.com/sirupsen/logrus"
+	"github.com/supabase/auth/internal/conf"
+	"github.com/supabase/auth/internal/e2e"
+	"github.com/supabase/auth/internal/ratelimit"
+)
+
+func TestLimiter(t *testing.T) {
+
+	// Expect equal configs to produce equal limiter
+	{
+		gc1 := e2e.Must(e2e.Config())
+		l1 := New(gc1)
+
+		gc2 := e2e.Must(e2e.Config())
+		l2 := New(gc2)
+
+		fs := getUpdatedFields(l1, l2)
+		for _, field := range fs {
+			t.Errorf("field %v was updated unexpectedly", field)
+		}
+		if exp, got := 0, len(fs); exp != got {
+			t.Fatalf("expected %v field updates, got %v", exp, got)
+		}
+	}
+
+	// Expect equal configs to produce equal updates
+	{
+		gc1 := e2e.Must(e2e.Config())
+		l1 := New(gc1)
+
+		gc2 := e2e.Must(e2e.Config())
+		l2 := l1.Update(logrus.NewEntry(logrus.New()), gc2)
+
+		fs := getUpdatedFields(l1, l2)
+		for _, field := range fs {
+			t.Errorf("field %v was updated unexpectedly", field)
+		}
+		if exp, got := 0, len(fs); exp != got {
+			t.Fatalf("expected %v field updates, got %v", exp, got)
+		}
+	}
+
+	// Exhaustively check all ratelimiter fields
+	for _, field := range slices.Sorted(maps.Keys(ratelimitFieldsToEnv)) {
+		env, ok := ratelimitFieldsToEnv[field]
+		if !ok {
+			panic("missing field from mappings")
+		}
+		t.Logf("test updates for field %v (ENV: %v)", field, env)
+
+		gc1 := e2e.Must(e2e.Config())
+		l1 := New(gc1)
+
+		gc2 := e2e.Must(e2e.Config())
+		fieldCfg := ratelimitCfgByField(gc2, field)
+		*fieldCfg = helpStrToRate(t, "123456/231h")
+
+		l2 := l1.Update(logrus.NewEntry(logrus.New()), gc2)
+		fs := getUpdatedFields(l1, l2)
+
+		// determine the number of fields that config value will change
+		fields := envsToFields[env]
+		if exp, got := len(fields), len(fs); exp != got {
+			t.Fatalf("expected %v field updates, got %v (%q)", exp, got, fs)
+		}
+
+		for _, exp := range fields {
+			if !slices.Contains(fs, field) {
+				t.Fatalf("expected field %v to appear in (%q)", exp, fs)
+			}
+		}
+	}
+
+	// Exhaustively check all tollbooth fields
+	for _, field := range slices.Sorted(maps.Keys(tollboothFieldsToEnv)) {
+		env, ok := tollboothFieldsToEnv[field]
+		if !ok {
+			panic("missing field from mappings")
+		}
+		t.Logf("test updates for field %v (ENV: %v)", field, env)
+
+		gc1 := e2e.Must(e2e.Config())
+		l1 := New(gc1)
+
+		gc2 := e2e.Must(e2e.Config())
+		fieldCfg := tollboothCfgByField(gc2, field)
+		*fieldCfg = *fieldCfg * 2
+
+		l2 := l1.Update(logrus.NewEntry(logrus.New()), gc2)
+		fs := getUpdatedFields(l1, l2)
+
+		// determine the number of fields that config value will change
+		fields := envsToFields[env]
+		if exp, got := len(fields), len(fs); exp != got {
+			t.Fatalf("expected %v field updates, got %v (%q)", exp, got, fs)
+		}
+
+		for _, exp := range fields {
+			if !slices.Contains(fs, field) {
+				t.Fatalf("expected field %v to appear in (%q)", exp, fs)
+			}
+		}
+	}
+}
+
+func getUpdatedFields(l1, l2 *Limiter) []string {
+	var s []string
+	for field := range ratelimitFieldsToEnv {
+		v1 := ratelimitByField(l1, field)
+		v2 := ratelimitByField(l2, field)
+		if !ratelimit.Equal(v1, v2) {
+			s = append(s, field)
+		}
+	}
+
+	for field := range tollboothFieldsToEnv {
+		v1 := tollboothByField(l1, field)
+		v2 := tollboothByField(l2, field)
+		if !tollboothEqual(v1, v2) {
+			s = append(s, field)
+		}
+	}
+	return s
+}
+
+func ratelimitByField(o *Limiter, field string) ratelimit.Limiter {
+	switch field {
+	case fieldEmail:
+		return o.Email
+	case fieldPhone:
+		return o.Phone
+	default:
+		panic("unknown field")
+	}
+}
+
+func ratelimitCfgByField(gc *conf.GlobalConfiguration, field string) *conf.Rate {
+	switch field {
+	case fieldEmail:
+		return &gc.RateLimitEmailSent
+	case fieldPhone:
+		return &gc.RateLimitSmsSent
+	default:
+		panic("unknown field")
+	}
+}
+
+func tollboothByField(o *Limiter, field string) *limiter.Limiter {
+	switch field {
+	case fieldAnonymousSignIns:
+		return o.AnonymousSignIns
+	case fieldFactorChallenge:
+		return o.FactorChallenge
+	case fieldFactorVerify:
+		return o.FactorVerify
+	case fieldMagicLink:
+		return o.MagicLink
+	case fieldOtp:
+		return o.Otp
+	case fieldRecover:
+		return o.Recover
+	case fieldResend:
+		return o.Resend
+	case fieldSignups:
+		return o.Signups
+	case fieldUser:
+		return o.User
+	case fieldOAuthClientRegister:
+		return o.OAuthClientRegister
+	case fieldPasskeyAuthentication:
+		return o.PasskeyAuthentication
+	case fieldSAMLAssertion:
+		return o.SAMLAssertion
+	case fieldSSO:
+		return o.SSO
+	case fieldToken:
+		return o.Token
+	case fieldVerify:
+		return o.Verify
+	case fieldWeb3:
+		return o.Web3
+	default:
+		panic("unknown field")
+	}
+}
+
+func tollboothCfgByField(gc *conf.GlobalConfiguration, field string) *float64 {
+	switch field {
+	case fieldAnonymousSignIns:
+		return &gc.RateLimitAnonymousUsers
+	case fieldFactorChallenge:
+		return &gc.MFA.RateLimitChallengeAndVerify
+	case fieldFactorVerify:
+		return &gc.MFA.RateLimitChallengeAndVerify
+	case fieldMagicLink:
+		return &gc.RateLimitOtp
+	case fieldOtp:
+		return &gc.RateLimitOtp
+	case fieldRecover:
+		return &gc.RateLimitOtp
+	case fieldResend:
+		return &gc.RateLimitOtp
+	case fieldSignups:
+		return &gc.RateLimitOtp
+	case fieldUser:
+		return &gc.RateLimitOtp
+	case fieldOAuthClientRegister:
+		return &gc.RateLimitOAuthDynamicClientRegister
+	case fieldPasskeyAuthentication:
+		return &gc.RateLimitPasskey
+	case fieldSAMLAssertion:
+		return &gc.SAML.RateLimitAssertion
+	case fieldSSO:
+		return &gc.RateLimitSso
+	case fieldToken:
+		return &gc.RateLimitTokenRefresh
+	case fieldVerify:
+		return &gc.RateLimitVerify
+	case fieldWeb3:
+		return &gc.RateLimitWeb3
+	default:
+		panic("unknown field")
+	}
+}
+
+func tollboothEqual(a, b *limiter.Limiter) bool {
+	// Tollbooth provides no way to get that initial expiration time passed. The
+	// calls to all the Get* methods that return durations are somehow always
+	// zero. So this had to be manually verified for now. In the future we
+	// should just get rid of that library, looking into it we could get very
+	// similar rate limit behavior through the ratelimit package. In the short
+	// term we could consider at least wrapping the tollbooth limiter so it
+	// matches the ratelimit.Limiter interface and can carry the cfg values.
+	switch {
+	case a.GetBurst() != b.GetBurst():
+		return false
+	case a.GetMax() != b.GetMax():
+		return false
+	case a.GetBasicAuthExpirationTTL() != b.GetBasicAuthExpirationTTL():
+		return false
+	case a.GetContextValueEntryExpirationTTL() != b.GetContextValueEntryExpirationTTL():
+		return false
+	case a.GetHeaderEntryExpirationTTL() != b.GetHeaderEntryExpirationTTL():
+		return false
+	case a.GetTokenBucketExpirationTTL() != b.GetTokenBucketExpirationTTL():
+		return false
+	case !slices.Equal(a.GetMethods(), b.GetMethods()):
+		return false
+	default:
+		return true
+	}
+}
+
+func helpStrToRate(t *testing.T, rateStr string) conf.Rate {
+	var r conf.Rate
+	err := r.Decode(rateStr)
+	if err != nil {
+		t.Fatalf("exp nil err; got %v", err)
+	}
+	return r
+}

--- a/internal/api/options.go
+++ b/internal/api/options.go
@@ -1,13 +1,8 @@
 package api
 
 import (
-	"time"
-
-	"github.com/didip/tollbooth/v5"
-	"github.com/didip/tollbooth/v5/limiter"
-	"github.com/supabase/auth/internal/conf"
+	"github.com/supabase/auth/internal/api/apilimiter"
 	"github.com/supabase/auth/internal/mailer"
-	"github.com/supabase/auth/internal/ratelimit"
 	"github.com/supabase/auth/internal/security"
 	"github.com/supabase/auth/internal/tokens"
 )
@@ -38,93 +33,8 @@ func WithCaptchaVerifier(v security.CaptchaVerifier) Option {
 	})
 }
 
-type LimiterOptions struct {
-	Email ratelimit.Limiter
-	Phone ratelimit.Limiter
-
-	Signups               *limiter.Limiter
-	AnonymousSignIns      *limiter.Limiter
-	Recover               *limiter.Limiter
-	Resend                *limiter.Limiter
-	MagicLink             *limiter.Limiter
-	Otp                   *limiter.Limiter
-	Token                 *limiter.Limiter
-	Verify                *limiter.Limiter
-	User                  *limiter.Limiter
-	FactorVerify          *limiter.Limiter
-	FactorChallenge       *limiter.Limiter
-	SSO                   *limiter.Limiter
-	SAMLAssertion         *limiter.Limiter
-	Web3                  *limiter.Limiter
-	OAuthClientRegister   *limiter.Limiter
-	PasskeyAuthentication *limiter.Limiter
-}
-
-func (lo *LimiterOptions) apply(a *API) { a.limiterOpts = lo }
-
-func NewLimiterOptions(gc *conf.GlobalConfiguration) *LimiterOptions {
-	o := &LimiterOptions{}
-
-	o.Email = ratelimit.New(gc.RateLimitEmailSent)
-	o.Phone = ratelimit.New(gc.RateLimitSmsSent)
-
-	o.AnonymousSignIns = tollbooth.NewLimiter(gc.RateLimitAnonymousUsers/(60*60),
-		&limiter.ExpirableOptions{
-			DefaultExpirationTTL: time.Hour,
-		}).SetBurst(int(gc.RateLimitAnonymousUsers)).SetMethods([]string{"POST"})
-
-	o.Token = tollbooth.NewLimiter(gc.RateLimitTokenRefresh/(60*5),
-		&limiter.ExpirableOptions{
-			DefaultExpirationTTL: time.Hour,
-		}).SetBurst(30)
-
-	o.Verify = tollbooth.NewLimiter(gc.RateLimitVerify/(60*5),
-		&limiter.ExpirableOptions{
-			DefaultExpirationTTL: time.Hour,
-		}).SetBurst(30)
-
-	o.FactorVerify = tollbooth.NewLimiter(gc.MFA.RateLimitChallengeAndVerify/60,
-		&limiter.ExpirableOptions{
-			DefaultExpirationTTL: time.Minute,
-		}).SetBurst(30)
-
-	o.FactorChallenge = tollbooth.NewLimiter(gc.MFA.RateLimitChallengeAndVerify/60,
-		&limiter.ExpirableOptions{
-			DefaultExpirationTTL: time.Minute,
-		}).SetBurst(30)
-
-	o.SSO = tollbooth.NewLimiter(gc.RateLimitSso/(60*5),
-		&limiter.ExpirableOptions{
-			DefaultExpirationTTL: time.Hour,
-		}).SetBurst(30)
-
-	o.SAMLAssertion = tollbooth.NewLimiter(gc.SAML.RateLimitAssertion/(60*5),
-		&limiter.ExpirableOptions{
-			DefaultExpirationTTL: time.Hour,
-		}).SetBurst(30)
-
-	o.Web3 = tollbooth.NewLimiter(gc.RateLimitWeb3/(60*5),
-		&limiter.ExpirableOptions{
-			DefaultExpirationTTL: time.Hour,
-		}).SetBurst(30)
-
-	// These all use the OTP limit per 5 min with 1hour ttl and burst of 30.
-	o.Recover = newLimiterPer5mOver1h(gc.RateLimitOtp)
-	o.Resend = newLimiterPer5mOver1h(gc.RateLimitOtp)
-	o.MagicLink = newLimiterPer5mOver1h(gc.RateLimitOtp)
-	o.Otp = newLimiterPer5mOver1h(gc.RateLimitOtp)
-	o.User = newLimiterPer5mOver1h(gc.RateLimitOtp)
-	o.Signups = newLimiterPer5mOver1h(gc.RateLimitOtp)
-	o.OAuthClientRegister = newLimiterPer5mOver1h(gc.RateLimitOAuthDynamicClientRegister)
-	o.PasskeyAuthentication = newLimiterPer5mOver1h(gc.RateLimitPasskey)
-
-	return o
-}
-
-func newLimiterPer5mOver1h(rate float64) *limiter.Limiter {
-	freq := rate / (60 * 5)
-	lim := tollbooth.NewLimiter(freq, &limiter.ExpirableOptions{
-		DefaultExpirationTTL: time.Hour,
-	}).SetBurst(30)
-	return lim
+func WithLimiter(v *apilimiter.Limiter) Option {
+	return optionFunc(func(a *API) {
+		a.limiterOpts = v
+	})
 }

--- a/internal/api/options_test.go
+++ b/internal/api/options_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/supabase/auth/internal/api/apilimiter"
 	"github.com/supabase/auth/internal/conf"
 )
 
@@ -11,7 +12,7 @@ func TestNewLimiterOptions(t *testing.T) {
 	cfg := &conf.GlobalConfiguration{}
 	cfg.ApplyDefaults()
 
-	rl := NewLimiterOptions(cfg)
+	rl := apilimiter.New(cfg)
 	assert.NotNil(t, rl.Email)
 	assert.NotNil(t, rl.Phone)
 	assert.NotNil(t, rl.Signups)

--- a/internal/conf/rate.go
+++ b/internal/conf/rate.go
@@ -17,7 +17,8 @@ const (
 type Rate struct {
 	Events   float64       `json:"events,omitempty"`
 	OverTime time.Duration `json:"over_time,omitempty"`
-	typ      string
+	typ      string        `json:"-"`
+	val      string        `json:"-"`
 }
 
 func (r *Rate) GetRateType() string {
@@ -31,6 +32,7 @@ func (r *Rate) GetRateType() string {
 func (r *Rate) Decode(value string) error {
 	if f, err := strconv.ParseFloat(value, 64); err == nil {
 		r.typ = IntervalRateType
+		r.val = value
 		r.Events = f
 		r.OverTime = defaultOverTime
 		return nil
@@ -54,8 +56,11 @@ func (r *Rate) Decode(value string) error {
 	r.typ = BurstRateType
 	r.Events = float64(e)
 	r.OverTime = d
+	r.val = value
 	return nil
 }
+
+func (r Rate) GetRateValue() string { return r.val }
 
 func (r *Rate) String() string {
 	if r.OverTime == 0 {

--- a/internal/conf/rate_test.go
+++ b/internal/conf/rate_test.go
@@ -14,15 +14,15 @@ func TestRateDecode(t *testing.T) {
 		err string
 	}{
 		{str: "1800",
-			exp: Rate{Events: 1800, OverTime: time.Hour, typ: IntervalRateType}},
+			exp: Rate{val: "1800", Events: 1800, OverTime: time.Hour, typ: IntervalRateType}},
 		{str: "1800.0",
-			exp: Rate{Events: 1800, OverTime: time.Hour, typ: IntervalRateType}},
+			exp: Rate{val: "1800.0", Events: 1800, OverTime: time.Hour, typ: IntervalRateType}},
 		{str: "3600/1h",
-			exp: Rate{Events: 3600, OverTime: time.Hour, typ: BurstRateType}},
+			exp: Rate{val: "3600/1h", Events: 3600, OverTime: time.Hour, typ: BurstRateType}},
 		{str: "3600/1h0m0s",
-			exp: Rate{Events: 3600, OverTime: time.Hour, typ: BurstRateType}},
+			exp: Rate{val: "3600/1h0m0s", Events: 3600, OverTime: time.Hour, typ: BurstRateType}},
 		{str: "100/24h",
-			exp: Rate{Events: 100, OverTime: time.Hour * 24, typ: BurstRateType}},
+			exp: Rate{val: "100/24h", Events: 100, OverTime: time.Hour * 24, typ: BurstRateType}},
 		{str: "", exp: Rate{},
 			err: `rate: value does not match`},
 		{str: "1h", exp: Rate{},
@@ -40,9 +40,9 @@ func TestRateDecode(t *testing.T) {
 
 		// zero events
 		{str: "0/1h",
-			exp: Rate{Events: 0, OverTime: time.Hour, typ: BurstRateType}},
+			exp: Rate{val: "0/1h", Events: 0, OverTime: time.Hour, typ: BurstRateType}},
 		{str: "0/24h",
-			exp: Rate{Events: 0, OverTime: time.Hour * 24, typ: BurstRateType}},
+			exp: Rate{val: "0/24h", Events: 0, OverTime: time.Hour * 24, typ: BurstRateType}},
 	}
 	for idx, tc := range cases {
 		t.Logf("test #%v - duration str %v", idx, tc.str)

--- a/internal/ratelimit/burst.go
+++ b/internal/ratelimit/burst.go
@@ -11,7 +11,8 @@ const defaultOverTime = time.Hour
 
 // BurstLimiter wraps the golang.org/x/time/rate package.
 type BurstLimiter struct {
-	rl *rate.Limiter
+	rl  *rate.Limiter
+	cfg conf.Rate
 }
 
 // NewBurstLimiter returns a rate limiter configured using the given conf.Rate.
@@ -25,7 +26,9 @@ type BurstLimiter struct {
 //   - 1/2s   is 1 events per 2  seconds with burst of 1.
 //   - 10/10s is 1 events per 10 seconds with burst of 10.
 //
-// If Rate.Events is <= 0, the burst amount will be set to 1.
+// If Rate.Events is <= 0, the burst amount will be set to 0. Since b is the
+// initial size of the token bucket this means no events will be permitted at
+// all.
 //
 // See Example_newBurstLimiter for a visualization.
 func NewBurstLimiter(r conf.Rate) *BurstLimiter {
@@ -43,7 +46,8 @@ func NewBurstLimiter(r conf.Rate) *BurstLimiter {
 	// BurstLimiter will have an initial token bucket of size `e`. It will
 	// be refilled at a rate of 1 per duration `d` indefinitely.
 	rl := &BurstLimiter{
-		rl: rate.NewLimiter(rate.Every(d), int(e)),
+		rl:  rate.NewLimiter(rate.Every(d), int(e)),
+		cfg: r,
 	}
 	return rl
 }
@@ -58,3 +62,7 @@ func (l *BurstLimiter) Allow() bool {
 func (l *BurstLimiter) AllowAt(at time.Time) bool {
 	return l.rl.AllowN(at, 1)
 }
+
+func (l *BurstLimiter) String() string { return "BurstLimiter" }
+
+func (l *BurstLimiter) Config() conf.Rate { return l.cfg }

--- a/internal/ratelimit/interval.go
+++ b/internal/ratelimit/interval.go
@@ -9,9 +9,10 @@ import (
 
 // IntervalLimiter will limit the number of calls to Allow per interval.
 type IntervalLimiter struct {
-	mu    sync.Mutex
-	ival  time.Duration // Count is reset and time updated every ival.
-	limit int           // Limit calls to Allow() per ival.
+	mu     sync.Mutex
+	cfg    conf.Rate
+	ival   time.Duration // Count is reset and time updated every ival.
+	events int           // Events allowed per ival.
 
 	// Guarded by mu.
 	last  time.Time // When the limiter was last reset.
@@ -21,9 +22,10 @@ type IntervalLimiter struct {
 // NewIntervalLimiter returns a rate limiter using the given conf.Rate.
 func NewIntervalLimiter(r conf.Rate) *IntervalLimiter {
 	return &IntervalLimiter{
-		ival:  r.OverTime,
-		limit: int(r.Events),
-		last:  time.Now(),
+		ival:   r.OverTime,
+		events: int(r.Events),
+		last:   time.Now(),
+		cfg:    r,
 	}
 }
 
@@ -55,9 +57,13 @@ func (rl *IntervalLimiter) allowAt(at time.Time) bool {
 		rl.last = rl.last.Add(time.Duration(ivals) * rl.ival)
 		rl.count = 0
 	}
-	if rl.count < rl.limit {
+	if rl.count < rl.events {
 		rl.count++
 		return true
 	}
 	return false
 }
+
+func (l *IntervalLimiter) String() string { return "IntervalLimiter" }
+
+func (l *IntervalLimiter) Config() conf.Rate { return l.cfg }

--- a/internal/ratelimit/ratelimit.go
+++ b/internal/ratelimit/ratelimit.go
@@ -18,6 +18,35 @@ type Limiter interface {
 	// AllowAt should return true if an event should be allowed at the given
 	// time, or false otherwise.
 	AllowAt(at time.Time) bool
+
+	// Config returns the underlying config value
+	Config() conf.Rate
+}
+
+// Equal checks to see if two limiters / vals / cfgs are both valid and equal.
+func Equal(a, b any) bool {
+	return a != nil && b != nil && toRate(a) == toRate(b)
+}
+
+func toRate(v any) conf.Rate {
+	switch T := v.(type) {
+	case *BurstLimiter:
+		return T.Config()
+	case *IntervalLimiter:
+		return T.Config()
+	case *conf.Rate:
+		return *T
+	case conf.Rate:
+		return T
+	case string:
+		var r conf.Rate
+		if err := r.Decode(T); err == nil {
+			return r
+		}
+		return conf.Rate{}
+	default:
+		return conf.Rate{}
+	}
 }
 
 // New returns a new Limiter based on the given config.

--- a/internal/ratelimit/ratelimit_test.go
+++ b/internal/ratelimit/ratelimit_test.go
@@ -1,50 +1,95 @@
 package ratelimit
 
 import (
+	"fmt"
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	"github.com/supabase/auth/internal/conf"
 )
 
 func TestNew(t *testing.T) {
-
-	// IntervalLimiter
-	{
+	fromRateStr := func(rateStr string) Limiter {
 		var r conf.Rate
-		err := r.Decode("100")
+		err := r.Decode(rateStr)
 		if err != nil {
 			t.Fatalf("exp nil err; got %v", err)
 		}
-
-		rl := New(r)
-		if _, ok := rl.(*IntervalLimiter); !ok {
-			t.Fatalf("exp type *IntervalLimiter; got %T", rl)
-		}
-	}
-	{
-		var r conf.Rate
-		err := r.Decode("100.123")
-		if err != nil {
-			t.Fatalf("exp nil err; got %v", err)
-		}
-
-		rl := New(r)
-		if _, ok := rl.(*IntervalLimiter); !ok {
-			t.Fatalf("exp type *IntervalLimiter; got %T", rl)
-		}
+		return New(r)
 	}
 
-	// BurstLimiter
-	{
-		var r conf.Rate
-		err := r.Decode("20/200s")
-		if err != nil {
-			t.Fatalf("exp nil err; got %v", err)
-		}
+	// Limits & Burst equality
+	tests := []struct {
+		from string
+		str  string
+	}{
+		{
+			from: "13.5",
+			str:  "IntervalLimiter",
+		},
+		{
+			from: "3600",
+			str:  "IntervalLimiter",
+		},
+		{
+			from: "0",
+			str:  "IntervalLimiter",
+		},
+		{
+			from: "10/1s",
+			str:  "BurstLimiter",
+		},
+		{
+			from: "1/1h",
+			str:  "BurstLimiter",
+		},
+		{
+			from: "0/1s",
+			str:  "BurstLimiter",
+		},
+	}
 
-		rl := New(r)
-		if _, ok := rl.(*BurstLimiter); !ok {
-			t.Fatalf("exp type *BurstLimiter; got %T", rl)
+	for idx, test := range tests {
+		t.Logf("test #%d from %v exp String(%q)",
+			idx+1, test.from, test.str)
+		rl := fromRateStr(test.from)
+		require.Equal(t, test.str, fmt.Sprint(rl))
+		require.True(t, Equal(rl, fromRateStr(test.from)),
+			"rate should be equal to itself")
+		require.True(t, Equal(rl, fromRateStr(test.from).Config()),
+			"rate should be equal to it's own config")
+
+		for _, t2 := range tests {
+			if test.from == t2.from {
+				continue
+			}
+			require.NotEqual(t, Equal(rl, fromRateStr(t2.from)),
+				"%v should not be equal to %v", test.from, t2.from)
 		}
+	}
+
+	{
+		a := fromRateStr("3600/1h")
+		cfg := a.Config()
+
+		// To be extra careful for now I intentionally treat two rate limiters with
+		// a different config value as inequal, even if they result in the same
+		// underlying limiter.
+		require.False(t, Equal(a, false))
+		require.False(t, Equal(a, "1/1s"))
+		require.False(t, Equal(a, fromRateStr("1/1s")))
+		require.False(t, Equal(a, fromRateStr("60/1m")))
+		require.False(t, Equal(a, "invalid"))
+		require.False(t, Equal(a, nil))
+		require.False(t, Equal(nil, a))
+
+		// as a special case two nils returns false
+		require.False(t, Equal(nil, nil))
+
+		require.True(t, Equal(a, "3600/1h"))
+		require.True(t, Equal(a, "3600/1h"))
+		require.True(t, Equal(a, fromRateStr("3600/1h")))
+		require.True(t, Equal(a, cfg))
+		require.True(t, Equal(a, &cfg))
 	}
 }

--- a/internal/ratelimit/ratelimit_test.go
+++ b/internal/ratelimit/ratelimit_test.go
@@ -63,7 +63,7 @@ func TestNew(t *testing.T) {
 			if test.from == t2.from {
 				continue
 			}
-			require.NotEqual(t, Equal(rl, fromRateStr(t2.from)),
+			require.False(t, Equal(rl, fromRateStr(t2.from)),
 				"%v should not be equal to %v", test.from, t2.from)
 		}
 	}


### PR DESCRIPTION
Move API limiter setup out of internal/api and into a dedicated internal/api/apilimiter package, then wire it into serve-time config reloads so rate limit changes are picked up without restarting the service.

This change replaces the old LimiterOptions type with an apilimiter.Limiter instance passed through api.WithLimiter(...). API construction now defaults to apilimiter.New(...) when no limiter is injected, and tests are updated to use the new option-based wiring.

The new apilimiter package centralizes:
- construction of all ratelimit and tollbooth limiters
- mapping between config/env vars and limiter fields
- copy/update logic for reusing existing limiter state where possible
- structured logging for limiter changes during config reload

On config reload in serve():
- keep track of the previously active limiter set
- call previousLim.Update(...) against the latest config
- build the new API with the updated limiter set
- store the new API, reload apiworker config, and retain the latest limiter for the next reload cycle

This fixes the prior behavior where hot config reload rebuilt the API but kept stale limiter settings, meaning rate-limit changes were not applied until process restart.

Additional ratelimit changes:
- persist the original parsed conf.Rate value in conf.Rate via val
- add GetRateValue() for logging/comparison purposes
- extend ratelimit.Limiter with Config() so limiters can expose their backing configuration
- add ratelimit.Equal(...) helper to compare limiters, configs, and rate strings consistently
- store conf.Rate on BurstLimiter and IntervalLimiter and expose Config()
- add String() methods to identify limiter type in tests/debug output
- rename IntervalLimiter.limit to events for clarity

Behavioral note:
- BurstLimiter documentation now matches implementation for non-positive event counts: burst size becomes 0, so no events are allowed

Tests:
- update API tests to inject limiters through api.WithLimiter
- update options tests to validate apilimiter.New
- expand ratelimit tests to cover type identification and equality semantics
- add dedicated apilimiter tests that verify only the expected fields change when each config/env-backed limiter value is modified
