### PR TITLE
Add SiteURL to notification email templates

### DIFF
--- a/internal/mailer/templatemailer/templatemailer.go
+++ b/internal/mailer/templatemailer/templatemailer.go
@@ -425,14 +425,16 @@ func (m *Mailer) GetEmailActionLink(user *models.User, actionType, referrerURL s
 
 func (m *Mailer) PasswordChangedNotificationMail(r *http.Request, user *models.User) error {
 	data := map[string]any{
-		"Email": user.Email,
-		"Data":  user.UserMetaData,
+		"SiteURL": m.cfg.SiteURL,
+		"Email":   user.Email,
+		"Data":    user.UserMetaData,
 	}
 	return m.mail(r.Context(), m.cfg, PasswordChangedNotificationTemplate, user.GetEmail(), data)
 }
 
 func (m *Mailer) EmailChangedNotificationMail(r *http.Request, user *models.User, oldEmail string) error {
 	data := map[string]any{
+		"SiteURL":  m.cfg.SiteURL,
 		"Email":    user.GetEmail(), // the new email address that has been set on the account
 		"OldEmail": oldEmail,        // the old email address that was on the account before the change
 		"Data":     user.UserMetaData,
@@ -442,6 +444,7 @@ func (m *Mailer) EmailChangedNotificationMail(r *http.Request, user *models.User
 
 func (m *Mailer) PhoneChangedNotificationMail(r *http.Request, user *models.User, oldPhone string) error {
 	data := map[string]any{
+		"SiteURL":  m.cfg.SiteURL,
 		"Email":    user.GetEmail(),
 		"Phone":    user.GetPhone(), // the new phone number that has been set on the account
 		"OldPhone": oldPhone,        // the old phone number that was on the account before the change
@@ -452,6 +455,7 @@ func (m *Mailer) PhoneChangedNotificationMail(r *http.Request, user *models.User
 
 func (m *Mailer) IdentityLinkedNotificationMail(r *http.Request, user *models.User, provider string) error {
 	data := map[string]any{
+		"SiteURL":  m.cfg.SiteURL,
 		"Email":    user.GetEmail(),
 		"Provider": provider, // the provider of the newly linked identity
 		"Data":     user.UserMetaData,
@@ -461,6 +465,7 @@ func (m *Mailer) IdentityLinkedNotificationMail(r *http.Request, user *models.Us
 
 func (m *Mailer) IdentityUnlinkedNotificationMail(r *http.Request, user *models.User, provider string) error {
 	data := map[string]any{
+		"SiteURL":  m.cfg.SiteURL,
 		"Email":    user.GetEmail(),
 		"Provider": provider, // the provider of the unlinked identity
 		"Data":     user.UserMetaData,
@@ -470,6 +475,7 @@ func (m *Mailer) IdentityUnlinkedNotificationMail(r *http.Request, user *models.
 
 func (m *Mailer) MFAFactorEnrolledNotificationMail(r *http.Request, user *models.User, factorType string) error {
 	data := map[string]any{
+		"SiteURL":    m.cfg.SiteURL,
 		"Email":      user.GetEmail(),
 		"FactorType": factorType,
 		"Data":       user.UserMetaData,
@@ -479,6 +485,7 @@ func (m *Mailer) MFAFactorEnrolledNotificationMail(r *http.Request, user *models
 
 func (m *Mailer) MFAFactorUnenrolledNotificationMail(r *http.Request, user *models.User, factorType string) error {
 	data := map[string]any{
+		"SiteURL":    m.cfg.SiteURL,
 		"Email":      user.GetEmail(),
 		"FactorType": factorType,
 		"Data":       user.UserMetaData,

--- a/internal/mailer/templatemailer/templatemailer_test.go
+++ b/internal/mailer/templatemailer/templatemailer_test.go
@@ -1,11 +1,24 @@
 package templatemailer
 
 import (
+	"context"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 	"github.com/supabase/auth/internal/conf"
+	"github.com/supabase/auth/internal/models"
 )
+
+type captureClient struct {
+	subject string
+}
+
+func (c *captureClient) Mail(_ context.Context, _ string, subject string, _ string, _ map[string][]string, _ string) error {
+	c.subject = subject
+	return nil
+}
 
 func TestTemplateHeaders(t *testing.T) {
 	cases := []struct {
@@ -60,5 +73,79 @@ func TestTemplateHeaders(t *testing.T) {
 
 		hdrs := mailer.Headers(mailer.cfg, tc.typ)
 		require.Equal(t, hdrs, tc.exp)
+	}
+}
+
+func TestNotificationMailSiteURL(t *testing.T) {
+	const siteURL = "https://example.com"
+
+	user := &models.User{}
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+
+	cases := []struct {
+		name string
+		subj func(cfg *conf.GlobalConfiguration)
+		send func(m *Mailer) error
+	}{
+		{
+			name: "PasswordChangedNotificationMail",
+			subj: func(cfg *conf.GlobalConfiguration) {
+				cfg.Mailer.Subjects.PasswordChangedNotification = "{{ .SiteURL }}"
+			},
+			send: func(m *Mailer) error { return m.PasswordChangedNotificationMail(r, user) },
+		},
+		{
+			name: "EmailChangedNotificationMail",
+			subj: func(cfg *conf.GlobalConfiguration) {
+				cfg.Mailer.Subjects.EmailChangedNotification = "{{ .SiteURL }}"
+			},
+			send: func(m *Mailer) error { return m.EmailChangedNotificationMail(r, user, "") },
+		},
+		{
+			name: "PhoneChangedNotificationMail",
+			subj: func(cfg *conf.GlobalConfiguration) {
+				cfg.Mailer.Subjects.PhoneChangedNotification = "{{ .SiteURL }}"
+			},
+			send: func(m *Mailer) error { return m.PhoneChangedNotificationMail(r, user, "") },
+		},
+		{
+			name: "IdentityLinkedNotificationMail",
+			subj: func(cfg *conf.GlobalConfiguration) {
+				cfg.Mailer.Subjects.IdentityLinkedNotification = "{{ .SiteURL }}"
+			},
+			send: func(m *Mailer) error { return m.IdentityLinkedNotificationMail(r, user, "") },
+		},
+		{
+			name: "IdentityUnlinkedNotificationMail",
+			subj: func(cfg *conf.GlobalConfiguration) {
+				cfg.Mailer.Subjects.IdentityUnlinkedNotification = "{{ .SiteURL }}"
+			},
+			send: func(m *Mailer) error { return m.IdentityUnlinkedNotificationMail(r, user, "") },
+		},
+		{
+			name: "MFAFactorEnrolledNotificationMail",
+			subj: func(cfg *conf.GlobalConfiguration) {
+				cfg.Mailer.Subjects.MFAFactorEnrolledNotification = "{{ .SiteURL }}"
+			},
+			send: func(m *Mailer) error { return m.MFAFactorEnrolledNotificationMail(r, user, "") },
+		},
+		{
+			name: "MFAFactorUnenrolledNotificationMail",
+			subj: func(cfg *conf.GlobalConfiguration) {
+				cfg.Mailer.Subjects.MFAFactorUnenrolledNotification = "{{ .SiteURL }}"
+			},
+			send: func(m *Mailer) error { return m.MFAFactorUnenrolledNotificationMail(r, user, "") },
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cc := &captureClient{}
+			cfg := &conf.GlobalConfiguration{SiteURL: siteURL}
+			tc.subj(cfg)
+			m := New(cfg, cc, NewCache())
+			require.NoError(t, tc.send(m))
+			require.Equal(t, siteURL, cc.subject)
+		})
 	}
 }


### PR DESCRIPTION
Fixes #2468

SiteURL wasn't available in the notification email templates. Added it to the data map so templates like password changed, email changed, phone changed, and the identity/MFA ones can reference {{.SiteURL}}. Includes tests for the new functionality.