### PR TITLE
fix(passkeys): modify the passkeys request and response shapes

### DIFF
--- a/internal/api/passkey_authentication.go
+++ b/internal/api/passkey_authentication.go
@@ -17,15 +17,15 @@ import (
 
 // PasskeyAuthenticationOptionsResponse is the response body for POST /passkeys/authentication/options.
 type PasskeyAuthenticationOptionsResponse struct {
-	ChallengeID string                        `json:"challenge_id"`
-	Options     *protocol.CredentialAssertion `json:"options"`
-	ExpiresAt   int64                         `json:"expires_at"`
+	ChallengeID string                                      `json:"challenge_id"`
+	Options     *protocol.PublicKeyCredentialRequestOptions `json:"options"`
+	ExpiresAt   int64                                       `json:"expires_at"`
 }
 
 // PasskeyAuthenticationVerifyParams is the request body for POST /passkeys/authentication/verify.
 type PasskeyAuthenticationVerifyParams struct {
-	ChallengeID        string          `json:"challenge_id"`
-	CredentialResponse json.RawMessage `json:"credential_response"`
+	ChallengeID string          `json:"challenge_id"`
+	Credential  json.RawMessage `json:"credential"`
 }
 
 // PasskeyAuthenticationOptions handles POST /passkeys/authentication/options.
@@ -59,7 +59,7 @@ func (a *API) PasskeyAuthenticationOptions(w http.ResponseWriter, r *http.Reques
 
 	return sendJSON(w, http.StatusOK, &PasskeyAuthenticationOptionsResponse{
 		ChallengeID: challenge.ID.String(),
-		Options:     options,
+		Options:     &options.Response,
 		ExpiresAt:   expiresAt.Unix(),
 	})
 }
@@ -83,8 +83,8 @@ func (a *API) PasskeyAuthenticationVerify(w http.ResponseWriter, r *http.Request
 	if params.ChallengeID == "" {
 		return apierrors.NewBadRequestError(apierrors.ErrorCodeValidationFailed, "challenge_id is required")
 	}
-	if params.CredentialResponse == nil {
-		return apierrors.NewBadRequestError(apierrors.ErrorCodeValidationFailed, "credential_response is required")
+	if params.Credential == nil {
+		return apierrors.NewBadRequestError(apierrors.ErrorCodeValidationFailed, "credential is required")
 	}
 
 	challengeID, err := uuid.FromString(params.ChallengeID)
@@ -105,7 +105,7 @@ func (a *API) PasskeyAuthenticationVerify(w http.ResponseWriter, r *http.Request
 		return apierrors.NewBadRequestError(apierrors.ErrorCodeWebAuthnChallengeExpired, "Challenge has expired")
 	}
 
-	parsedResponse, err := parseCredentialAssertionResponse(params.CredentialResponse)
+	parsedResponse, err := parseCredentialAssertionResponse(params.Credential)
 	if err != nil {
 		return apierrors.NewBadRequestError(apierrors.ErrorCodeWebAuthnVerificationFailed, "Invalid credential response").WithInternalError(err)
 	}

--- a/internal/api/passkey_authentication_test.go
+++ b/internal/api/passkey_authentication_test.go
@@ -27,7 +27,7 @@ func (ts *PasskeyTestSuite) TestDiscoverableAuthenticationHappyPath() {
 	ts.NotZero(optionsResp.ExpiresAt)
 
 	// Verify allowCredentials is empty (discoverable)
-	ts.Empty(optionsResp.Options.Response.AllowedCredentials)
+	ts.Empty(optionsResp.Options.AllowedCredentials)
 
 	// Step 2: Simulate the authenticator creating an assertion
 	assertionResp, err := authenticator.getAssertion(optionsResp.Options)
@@ -35,8 +35,8 @@ func (ts *PasskeyTestSuite) TestDiscoverableAuthenticationHappyPath() {
 
 	// Step 3: Verify the authentication
 	w = ts.makeRequest(http.MethodPost, "http://localhost/passkeys/authentication/verify", map[string]any{
-		"challenge_id":        optionsResp.ChallengeID,
-		"credential_response": json.RawMessage(assertionResp.JSON),
+		"challenge_id": optionsResp.ChallengeID,
+		"credential":   json.RawMessage(assertionResp.JSON),
 	})
 	ts.Require().Equal(http.StatusOK, w.Code)
 
@@ -71,8 +71,8 @@ func (ts *PasskeyTestSuite) TestDiscoverableAuthenticationUnconfirmedEmail() {
 
 	// Verify — should fail with email_not_confirmed
 	w = ts.makeRequest(http.MethodPost, "http://localhost/passkeys/authentication/verify", map[string]any{
-		"challenge_id":        optionsResp.ChallengeID,
-		"credential_response": json.RawMessage(assertionResp.JSON),
+		"challenge_id": optionsResp.ChallengeID,
+		"credential":   json.RawMessage(assertionResp.JSON),
 	})
 	ts.Equal(http.StatusForbidden, w.Code)
 	var errResp map[string]any
@@ -100,8 +100,8 @@ func (ts *PasskeyTestSuite) TestDiscoverableAuthenticationBannedUser() {
 
 	// Verify — should fail with user_banned
 	w = ts.makeRequest(http.MethodPost, "http://localhost/passkeys/authentication/verify", map[string]any{
-		"challenge_id":        optionsResp.ChallengeID,
-		"credential_response": json.RawMessage(assertionResp.JSON),
+		"challenge_id": optionsResp.ChallengeID,
+		"credential":   json.RawMessage(assertionResp.JSON),
 	})
 	ts.Equal(http.StatusForbidden, w.Code)
 	var errResp map[string]any
@@ -120,8 +120,8 @@ func (ts *PasskeyTestSuite) TestDiscoverableAuthenticationChallengeExpired() {
 	require.NoError(ts.T(), ts.API.db.Create(challenge))
 
 	w := ts.makeRequest(http.MethodPost, "http://localhost/passkeys/authentication/verify", map[string]any{
-		"challenge_id":        challenge.ID.String(),
-		"credential_response": map[string]any{},
+		"challenge_id": challenge.ID.String(),
+		"credential":   map[string]any{},
 	})
 	ts.Equal(http.StatusBadRequest, w.Code)
 	var errResp map[string]any
@@ -132,8 +132,8 @@ func (ts *PasskeyTestSuite) TestDiscoverableAuthenticationChallengeExpired() {
 // TestDiscoverableAuthenticationChallengeNotFound tests that a missing challenge is rejected.
 func (ts *PasskeyTestSuite) TestDiscoverableAuthenticationChallengeNotFound() {
 	w := ts.makeRequest(http.MethodPost, "http://localhost/passkeys/authentication/verify", map[string]any{
-		"challenge_id":        uuid.Must(uuid.NewV4()).String(),
-		"credential_response": map[string]any{},
+		"challenge_id": uuid.Must(uuid.NewV4()).String(),
+		"credential":   map[string]any{},
 	})
 	ts.Equal(http.StatusBadRequest, w.Code)
 	var errResp map[string]any
@@ -154,8 +154,8 @@ func (ts *PasskeyTestSuite) TestDiscoverableAuthenticationInvalidAssertion() {
 
 	// Send garbage as credential response
 	w = ts.makeRequest(http.MethodPost, "http://localhost/passkeys/authentication/verify", map[string]any{
-		"challenge_id":        optionsResp.ChallengeID,
-		"credential_response": map[string]any{"garbage": true},
+		"challenge_id": optionsResp.ChallengeID,
+		"credential":   map[string]any{"garbage": true},
 	})
 	ts.Equal(http.StatusBadRequest, w.Code)
 	var errResp map[string]any
@@ -176,7 +176,7 @@ func (ts *PasskeyTestSuite) TestDiscoverableAuthenticationUnknownCredential() {
 	// because the userHandle points to a non-existent user.
 	w = ts.makeRequest(http.MethodPost, "http://localhost/passkeys/authentication/verify", map[string]any{
 		"challenge_id": optionsResp.ChallengeID,
-		"credential_response": map[string]any{
+		"credential": map[string]any{
 			"id":    "ZmFrZS1jcmVkZW50aWFsLWlk",
 			"type":  "public-key",
 			"rawId": "ZmFrZS1jcmVkZW50aWFsLWlk",
@@ -307,8 +307,8 @@ func (ts *PasskeyTestSuite) registerPasskey() (*virtualAuthenticator, *PasskeyMe
 	require.NoError(ts.T(), err)
 
 	w = ts.makeRequest(http.MethodPost, "http://localhost/passkeys/registration/verify", map[string]any{
-		"challenge_id":        optionsResp.ChallengeID,
-		"credential_response": json.RawMessage(credResp.JSON),
+		"challenge_id": optionsResp.ChallengeID,
+		"credential":   json.RawMessage(credResp.JSON),
 	}, withBearerToken(token))
 	ts.Require().Equal(http.StatusOK, w.Code)
 

--- a/internal/api/passkey_registration.go
+++ b/internal/api/passkey_registration.go
@@ -19,25 +19,22 @@ type PasskeyRegistrationOptionsParams struct{}
 
 // PasskeyRegistrationOptionsResponse is the response body for POST /passkeys/registration/options.
 type PasskeyRegistrationOptionsResponse struct {
-	ChallengeID string                       `json:"challenge_id"`
-	Options     *protocol.CredentialCreation `json:"options"`
-	ExpiresAt   int64                        `json:"expires_at"`
+	ChallengeID string                                       `json:"challenge_id"`
+	Options     *protocol.PublicKeyCredentialCreationOptions `json:"options"`
+	ExpiresAt   int64                                        `json:"expires_at"`
 }
 
 // PasskeyRegistrationVerifyParams is the request body for POST /passkeys/registration/verify.
 type PasskeyRegistrationVerifyParams struct {
-	ChallengeID        string          `json:"challenge_id"`
-	CredentialResponse json.RawMessage `json:"credential_response"`
+	ChallengeID string          `json:"challenge_id"`
+	Credential  json.RawMessage `json:"credential"`
 }
 
 // PasskeyMetadataResponse is the response body for successful passkey creation.
 type PasskeyMetadataResponse struct {
-	ID             string                            `json:"id"`
-	FriendlyName   string                            `json:"friendly_name,omitempty"`
-	CreatedAt      time.Time                         `json:"created_at"`
-	BackupEligible bool                              `json:"backup_eligible"`
-	BackedUp       bool                              `json:"backed_up"`
-	Transports     []protocol.AuthenticatorTransport `json:"transports"`
+	ID           string    `json:"id"`
+	FriendlyName string    `json:"friendly_name,omitempty"`
+	CreatedAt    time.Time `json:"created_at"`
 }
 
 // PasskeyRegistrationOptions handles POST /passkeys/registration/options.
@@ -100,7 +97,7 @@ func (a *API) PasskeyRegistrationOptions(w http.ResponseWriter, r *http.Request)
 
 	return sendJSON(w, http.StatusOK, &PasskeyRegistrationOptionsResponse{
 		ChallengeID: challenge.ID.String(),
-		Options:     options,
+		Options:     &options.Response,
 		ExpiresAt:   expiresAt.Unix(),
 	})
 }
@@ -129,8 +126,8 @@ func (a *API) PasskeyRegistrationVerify(w http.ResponseWriter, r *http.Request) 
 	if params.ChallengeID == "" {
 		return apierrors.NewBadRequestError(apierrors.ErrorCodeValidationFailed, "challenge_id is required")
 	}
-	if params.CredentialResponse == nil {
-		return apierrors.NewBadRequestError(apierrors.ErrorCodeValidationFailed, "credential_response is required")
+	if params.Credential == nil {
+		return apierrors.NewBadRequestError(apierrors.ErrorCodeValidationFailed, "credential is required")
 	}
 
 	challengeID, err := uuid.FromString(params.ChallengeID)
@@ -153,7 +150,7 @@ func (a *API) PasskeyRegistrationVerify(w http.ResponseWriter, r *http.Request) 
 	}
 
 	// Parse the credential creation response from the JSON params
-	parsedResponse, err := parseCredentialCreationResponse(params.CredentialResponse)
+	parsedResponse, err := parseCredentialCreationResponse(params.Credential)
 	if err != nil {
 		return apierrors.NewBadRequestError(apierrors.ErrorCodeWebAuthnVerificationFailed, "Invalid credential response").WithInternalError(err)
 	}
@@ -213,12 +210,9 @@ func (a *API) PasskeyRegistrationVerify(w http.ResponseWriter, r *http.Request) 
 	}
 
 	return sendJSON(w, http.StatusOK, &PasskeyMetadataResponse{
-		ID:             passkeyCredential.ID.String(),
-		FriendlyName:   passkeyCredential.FriendlyName,
-		CreatedAt:      passkeyCredential.CreatedAt,
-		BackupEligible: passkeyCredential.BackupEligible,
-		BackedUp:       passkeyCredential.BackedUp,
-		Transports:     []protocol.AuthenticatorTransport(passkeyCredential.Transports),
+		ID:           passkeyCredential.ID.String(),
+		FriendlyName: passkeyCredential.FriendlyName,
+		CreatedAt:    passkeyCredential.CreatedAt,
 	})
 }
 

--- a/internal/api/passkey_registration_test.go
+++ b/internal/api/passkey_registration_test.go
@@ -35,8 +35,8 @@ func (ts *PasskeyTestSuite) TestRegisterPasskeyHappyPath() {
 
 	// Step 3: Verify the registration
 	w = ts.makeRequest(http.MethodPost, "http://localhost/passkeys/registration/verify", map[string]any{
-		"challenge_id":        optionsResp.ChallengeID,
-		"credential_response": json.RawMessage(credResp.JSON),
+		"challenge_id": optionsResp.ChallengeID,
+		"credential":   json.RawMessage(credResp.JSON),
 	}, withBearerToken(token))
 	ts.Require().Equal(http.StatusOK, w.Code)
 
@@ -109,8 +109,8 @@ func (ts *PasskeyTestSuite) TestRegistrationOptionsWithExistingPasskeys() {
 
 	// The exclusion list should contain the existing credential
 	ts.Require().NotNil(resp.Options)
-	ts.Require().NotNil(resp.Options.Response.CredentialExcludeList)
-	ts.Len(resp.Options.Response.CredentialExcludeList, 1)
+	ts.Require().NotNil(resp.Options.CredentialExcludeList)
+	ts.Len(resp.Options.CredentialExcludeList, 1)
 }
 
 // TestRegistrationOptionsTooManyPasskeys tests that the limit is enforced.
@@ -204,15 +204,15 @@ func (ts *PasskeyTestSuite) TestRegisterVerifyCapEnforcedAtVerifyTime() {
 
 	// Verify the first challenge — should succeed
 	v1 := ts.makeRequest(http.MethodPost, "http://localhost/passkeys/registration/verify", map[string]any{
-		"challenge_id":        opts1.ChallengeID,
-		"credential_response": json.RawMessage(cred1.JSON),
+		"challenge_id": opts1.ChallengeID,
+		"credential":   json.RawMessage(cred1.JSON),
 	}, withBearerToken(token))
 	ts.Require().Equal(http.StatusOK, v1.Code)
 
 	// Verify the second challenge — should fail with too_many_passkeys
 	v2 := ts.makeRequest(http.MethodPost, "http://localhost/passkeys/registration/verify", map[string]any{
-		"challenge_id":        opts2.ChallengeID,
-		"credential_response": json.RawMessage(cred2.JSON),
+		"challenge_id": opts2.ChallengeID,
+		"credential":   json.RawMessage(cred2.JSON),
 	}, withBearerToken(token))
 	ts.Equal(http.StatusUnprocessableEntity, v2.Code)
 	var errResp map[string]any
@@ -224,8 +224,8 @@ func (ts *PasskeyTestSuite) TestRegisterVerifyCapEnforcedAtVerifyTime() {
 func (ts *PasskeyTestSuite) TestRegisterVerifyChallengeNotFound() {
 	token := ts.generateToken(ts.TestUser, &ts.TestSession.ID)
 	w := ts.makeRequest(http.MethodPost, "http://localhost/passkeys/registration/verify", map[string]any{
-		"challenge_id":        uuid.Must(uuid.NewV4()).String(),
-		"credential_response": map[string]any{},
+		"challenge_id": uuid.Must(uuid.NewV4()).String(),
+		"credential":   map[string]any{},
 	}, withBearerToken(token))
 
 	ts.Equal(http.StatusBadRequest, w.Code)
@@ -246,8 +246,8 @@ func (ts *PasskeyTestSuite) TestRegisterVerifyChallengeExpired() {
 
 	token := ts.generateToken(ts.TestUser, &ts.TestSession.ID)
 	w := ts.makeRequest(http.MethodPost, "http://localhost/passkeys/registration/verify", map[string]any{
-		"challenge_id":        challenge.ID.String(),
-		"credential_response": map[string]any{},
+		"challenge_id": challenge.ID.String(),
+		"credential":   map[string]any{},
 	}, withBearerToken(token))
 
 	ts.Equal(http.StatusBadRequest, w.Code)
@@ -272,8 +272,8 @@ func (ts *PasskeyTestSuite) TestRegisterVerifyWrongUser() {
 
 	token := ts.generateToken(ts.TestUser, &ts.TestSession.ID)
 	w := ts.makeRequest(http.MethodPost, "http://localhost/passkeys/registration/verify", map[string]any{
-		"challenge_id":        challenge.ID.String(),
-		"credential_response": map[string]any{},
+		"challenge_id": challenge.ID.String(),
+		"credential":   map[string]any{},
 	}, withBearerToken(token))
 
 	ts.Equal(http.StatusBadRequest, w.Code)
@@ -293,11 +293,11 @@ func (ts *PasskeyTestSuite) TestRegisterVerifyMissingFields() {
 		{
 			desc: "missing challenge_id",
 			body: map[string]any{
-				"credential_response": map[string]any{},
+				"credential": map[string]any{},
 			},
 		},
 		{
-			desc: "missing credential_response",
+			desc: "missing credential",
 			body: map[string]any{
 				"challenge_id": uuid.Must(uuid.NewV4()).String(),
 			},
@@ -316,8 +316,8 @@ func (ts *PasskeyTestSuite) TestRegisterVerifyMissingFields() {
 func (ts *PasskeyTestSuite) TestRegisterVerifyInvalidChallengeID() {
 	token := ts.generateToken(ts.TestUser, &ts.TestSession.ID)
 	w := ts.makeRequest(http.MethodPost, "http://localhost/passkeys/registration/verify", map[string]any{
-		"challenge_id":        "not-a-uuid",
-		"credential_response": map[string]any{},
+		"challenge_id": "not-a-uuid",
+		"credential":   map[string]any{},
 	}, withBearerToken(token))
 
 	ts.Equal(http.StatusBadRequest, w.Code)
@@ -335,8 +335,8 @@ func (ts *PasskeyTestSuite) TestRegisterVerifyWrongChallengeType() {
 
 	token := ts.generateToken(ts.TestUser, &ts.TestSession.ID)
 	w := ts.makeRequest(http.MethodPost, "http://localhost/passkeys/registration/verify", map[string]any{
-		"challenge_id":        challenge.ID.String(),
-		"credential_response": map[string]any{},
+		"challenge_id": challenge.ID.String(),
+		"credential":   map[string]any{},
 	}, withBearerToken(token))
 
 	ts.Equal(http.StatusBadRequest, w.Code)
@@ -345,8 +345,8 @@ func (ts *PasskeyTestSuite) TestRegisterVerifyWrongChallengeType() {
 // TestRegisterVerifyUnauthenticated tests that unauthenticated requests are rejected.
 func (ts *PasskeyTestSuite) TestRegisterVerifyUnauthenticated() {
 	w := ts.makeRequest(http.MethodPost, "http://localhost/passkeys/registration/verify", map[string]any{
-		"challenge_id":        uuid.Must(uuid.NewV4()).String(),
-		"credential_response": map[string]any{},
+		"challenge_id": uuid.Must(uuid.NewV4()).String(),
+		"credential":   map[string]any{},
 	})
 	ts.Equal(http.StatusUnauthorized, w.Code)
 }
@@ -358,8 +358,8 @@ func (ts *PasskeyTestSuite) TestRegisterVerifySSOUser() {
 
 	token := ts.generateToken(ts.TestUser, &ts.TestSession.ID)
 	w := ts.makeRequest(http.MethodPost, "http://localhost/passkeys/registration/verify", map[string]any{
-		"challenge_id":        uuid.Must(uuid.NewV4()).String(),
-		"credential_response": map[string]any{},
+		"challenge_id": uuid.Must(uuid.NewV4()).String(),
+		"credential":   map[string]any{},
 	}, withBearerToken(token))
 
 	ts.Equal(http.StatusUnprocessableEntity, w.Code)

--- a/internal/api/passkey_virtual_authenticator_test.go
+++ b/internal/api/passkey_virtual_authenticator_test.go
@@ -33,20 +33,20 @@ type storedCredential struct {
 
 // virtualCredentialResponse is the result of creating a credential with the virtual authenticator.
 type virtualCredentialResponse struct {
-	// JSON is the raw JSON of the CredentialCreationResponse, ready to be sent as credential_response.
+	// JSON is the raw JSON of the CredentialCreationResponse, ready to be sent as credential.
 	JSON json.RawMessage
 }
 
 // virtualAssertionResponse is the result of getting an assertion with the virtual authenticator.
 type virtualAssertionResponse struct {
-	// JSON is the raw JSON of the CredentialAssertionResponse, ready to be sent as credential_response.
+	// JSON is the raw JSON of the CredentialAssertionResponse, ready to be sent as credential.
 	JSON json.RawMessage
 }
 
 // createCredential builds a valid WebAuthn CredentialCreationResponse for the given
 // registration options. It generates a fresh EC P-256 key pair and uses "none" attestation.
-func (va *virtualAuthenticator) createCredential(options *protocol.CredentialCreation) (*virtualCredentialResponse, error) {
-	challenge := options.Response.Challenge
+func (va *virtualAuthenticator) createCredential(options *protocol.PublicKeyCredentialCreationOptions) (*virtualCredentialResponse, error) {
+	challenge := options.Challenge
 
 	// Generate a fresh P-256 key pair
 	privKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
@@ -108,7 +108,7 @@ func (va *virtualAuthenticator) createCredential(options *protocol.CredentialCre
 	// After JSON round-tripping, User.ID may be a string (base64url encoded)
 	// or URLEncodedBase64/[]byte if used directly from the library.
 	var userHandle []byte
-	switch v := options.Response.User.ID.(type) {
+	switch v := options.User.ID.(type) {
 	case protocol.URLEncodedBase64:
 		userHandle = []byte(v)
 	case []byte:
@@ -131,7 +131,7 @@ func (va *virtualAuthenticator) createCredential(options *protocol.CredentialCre
 // getAssertion builds a valid WebAuthn CredentialAssertionResponse for the given
 // authentication options. It picks the first stored credential (discoverable flow) and signs
 // the authenticator data + client data hash.
-func (va *virtualAuthenticator) getAssertion(options *protocol.CredentialAssertion) (*virtualAssertionResponse, error) {
+func (va *virtualAuthenticator) getAssertion(options *protocol.PublicKeyCredentialRequestOptions) (*virtualAssertionResponse, error) {
 	if len(va.credentials) == 0 {
 		return nil, fmt.Errorf("no stored credentials")
 	}
@@ -143,7 +143,7 @@ func (va *virtualAuthenticator) getAssertion(options *protocol.CredentialAsserti
 		break
 	}
 
-	challenge := options.Response.Challenge
+	challenge := options.Challenge
 
 	clientDataJSON, err := json.Marshal(map[string]string{
 		"type":      "webauthn.get",


### PR DESCRIPTION
Modifies some of the passkeys request/response shapes for a cleaner interface and to better align with industry standards. In particular:

The `/options` endpoints removes unnecessary nesting (a byproduct of serializing the go-webauthn object directly):

```
{
  "challenge_id": "some-challenge-id",
  "options": {
    "publicKey": {
      // ... the public key options
    },
  }
  "expires_at": 1234567890
}
```

becomes:

```
{
  "challenge_id": "some-challenge-id",
  "options": {
    // ... the public key options
  }
  "expires_at": 1234567890
}
```

---

Rename the `credential` in the `/verify` endpoint payload from `credential_response` to `credential`:

```
{
  "challenge_id": "some-challenge-id",
  "credential_response": {
    // ... the response from the client
  }
}
```

becomes

```
{
  "challenge_id": "some-challenge-id",
  "credential": {
    // ... the response from the client
  }
}
```

---

Finally, remove the `backed_up`, `backup_eligible`, and `transports` fields from the `/verify` response upon registration. We can later expose them consistently across the API responses if/when needed.