### PR TITLE
fix: Update redirect URL path for OAuth callback (Issue #2477)

### DIFF
--- a/internal/api/external.go
+++ b/internal/api/external.go
@@ -679,7 +679,7 @@ func (a *API) loadCustomProvider(ctx context.Context, db *storage.Connection, id
 	var pConfig conf.OAuthProviderConfiguration
 
 	// Build the redirect URL
-	redirectURL := config.API.ExternalURL + "/callback"
+	redirectURL := config.API.ExternalURL + "/auth/v1/callback"
 
 	// Parse scopes (space-separated per RFC 6749)
 	var scopeList []string


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix for #2477 

## What is the current behavior?

Redirect URI is incorrectly constructed as just `/callback`; see #2477 

## What is the new behavior?

Redirect URI is fixed to `/auth/v1/callback`

## Additional context

#2477 
