### PR TITLE
fix(indexworker): skip index creation on OrioleDB

### DIFF
--- a/internal/api/apiworker/apiworker.go
+++ b/internal/api/apiworker/apiworker.go
@@ -217,7 +217,7 @@ func (o *Worker) maybeCreateIndexes(
 ) {
 	if cfg.IndexWorker.EnsureUserSearchIndexesExist || cfg.IndexWorker.MaxUsersThreshold > 0 {
 		err := indexworker.CreateIndexes(ctx, cfg, le)
-		if err != nil && !errors.Is(err, indexworker.ErrAdvisoryLockAlreadyAcquired) {
+		if err != nil && !errors.Is(err, indexworker.ErrAdvisoryLockAlreadyAcquired) && !errors.Is(err, indexworker.ErrOrioleDBUnsupported) {
 			le.WithError(err).Error("Failed to create indexes")
 		}
 	}

--- a/internal/indexworker/indexworker.go
+++ b/internal/indexworker/indexworker.go
@@ -16,7 +16,7 @@ import (
 
 // ErrAdvisoryLockAlreadyAcquired is returned when another process already holds the advisory lock
 var ErrAdvisoryLockAlreadyAcquired = errors.New("advisory lock already acquired by another process")
-var ErrExtensionNotFound = errors.New("extension not found")
+var ErrOrioleDBUnsupported = errors.New("index worker does not support OrioleDB tables")
 
 type Outcome string
 
@@ -63,6 +63,19 @@ func CreateIndexes(ctx context.Context, config *conf.GlobalConfiguration, le *lo
 		log.Fatalf("Error checking database connection: %+v", err)
 	}
 	db = db.WithContext(ctx)
+
+	// Check if the users table uses OrioleDB, which does not support
+	// CREATE INDEX CONCURRENTLY or DROP INDEX CONCURRENTLY.
+	isOrioleDB, err := isOrioleDBTable(db, config.DB.Namespace, "users")
+	if err != nil {
+		le.WithError(err).Warn("Failed to check table access method, proceeding with index creation")
+	} else if isOrioleDB {
+		le.WithFields(logrus.Fields{
+			"outcome": OutcomeSkipped,
+			"code":    "orioledb_unsupported",
+		}).Info("Skipping index creation because auth.users uses the OrioleDB storage engine, which does not support CONCURRENTLY operations")
+		return ErrOrioleDBUnsupported
+	}
 
 	// Try to obtain advisory lock to ensure only one index worker is creating indexes at a time
 	lockName := "auth_index_worker"
@@ -304,6 +317,24 @@ func getApproximateUserCount(db *pop.Connection, namespace string) (int64, error
 	}
 
 	return userCount, nil
+}
+
+// isOrioleDBTable checks if the specified table uses the OrioleDB storage engine
+// by examining the table's access method in pg_class.
+func isOrioleDBTable(db *pop.Connection, namespace, tableName string) (bool, error) {
+	query := fmt.Sprintf(`
+		SELECT am.amname
+		FROM pg_class c
+		JOIN pg_am am ON c.relam = am.oid
+		JOIN pg_namespace n ON c.relnamespace = n.oid
+		WHERE n.nspname = '%s' AND c.relname = '%s'
+	`, namespace, tableName)
+
+	var amName string
+	if err := db.RawQuery(query).First(&amName); err != nil {
+		return false, fmt.Errorf("failed to check table access method: %w", err)
+	}
+	return amName == "orioledb", nil
 }
 
 // dropInvalidIndexes drops any invalid indexes from previous interrupted attempts

--- a/internal/indexworker/indexworker_test.go
+++ b/internal/indexworker/indexworker_test.go
@@ -28,6 +28,7 @@ type IndexWorkerTestSuite struct {
 	logger                       *logrus.Entry
 	maxUsersThreshold            int64
 	ensureUserSearchIndexesExist bool
+	isOrioleDB                   bool
 }
 
 func (ts *IndexWorkerTestSuite) SetupSuite() {
@@ -58,6 +59,14 @@ func (ts *IndexWorkerTestSuite) SetupSuite() {
 	require.NoError(ts.T(), err)
 	require.NoError(ts.T(), popConn.Open())
 	ts.popDB = popConn
+
+	// Detect if the users table uses OrioleDB
+	isOrioleDB, err := isOrioleDBTable(popConn, config.DB.Namespace, "users")
+	if err != nil {
+		ts.T().Logf("Failed to detect OrioleDB, assuming standard PostgreSQL: %v", err)
+	} else {
+		ts.isOrioleDB = isOrioleDB
+	}
 
 	// Ensure we have a clean state for testing
 	ts.cleanupIndexes()
@@ -90,6 +99,9 @@ func (ts *IndexWorkerTestSuite) cleanupIndexes() {
 }
 
 func (ts *IndexWorkerTestSuite) TestCreateIndexesHappyPath() {
+	if ts.isOrioleDB {
+		ts.T().Skip("OrioleDB does not support CREATE INDEX CONCURRENTLY")
+	}
 	ctx := context.Background()
 
 	err := CreateIndexes(ctx, ts.config, ts.logger)
@@ -132,6 +144,9 @@ func (ts *IndexWorkerTestSuite) TestGetIndexStatuses() {
 }
 
 func (ts *IndexWorkerTestSuite) TestIdempotency() {
+	if ts.isOrioleDB {
+		ts.T().Skip("OrioleDB does not support CREATE INDEX CONCURRENTLY")
+	}
 	ctx := context.Background()
 
 	// First run - create all indexes
@@ -188,6 +203,9 @@ func (ts *IndexWorkerTestSuite) TestIdempotency() {
 
 // If an index is removed out of band, it will be created when the method is called
 func (ts *IndexWorkerTestSuite) TestOutOfBandIndexRemoval() {
+	if ts.isOrioleDB {
+		ts.T().Skip("OrioleDB does not support CREATE INDEX CONCURRENTLY")
+	}
 	ctx := context.Background()
 
 	// First, create all indexes
@@ -235,6 +253,9 @@ func (ts *IndexWorkerTestSuite) TestOutOfBandIndexRemoval() {
 
 // Test concurrent access - workers coordinate via advisory lock
 func (ts *IndexWorkerTestSuite) TestConcurrentWorkers() {
+	if ts.isOrioleDB {
+		ts.T().Skip("OrioleDB does not support CREATE INDEX CONCURRENTLY")
+	}
 	ctx := context.Background()
 
 	numWorkers := 5
@@ -292,6 +313,9 @@ func getIndexNames(indexes []struct {
 // TestMaxUsersThresholdSkipsIndexCreation verifies when EnsureUserSearchIndexesExist=false and MaxUsersThreshold > 0,
 // index creation is skipped if user count exceeds the threshold.
 func (ts *IndexWorkerTestSuite) TestMaxUsersThresholdSkipsIndexCreation() {
+	if ts.isOrioleDB {
+		ts.T().Skip("OrioleDB does not support CREATE INDEX CONCURRENTLY")
+	}
 	ctx := context.Background()
 
 	// No explicit user opt-in - rely on threshold behavior
@@ -328,6 +352,9 @@ func (ts *IndexWorkerTestSuite) TestMaxUsersThresholdSkipsIndexCreation() {
 // TestUserOptInAlwaysCreatesIndexes verifies that when EnsureUserSearchIndexesExist=true,
 // indexes are always created regardless of user count or threshold setting.
 func (ts *IndexWorkerTestSuite) TestUserOptInAlwaysCreatesIndexes() {
+	if ts.isOrioleDB {
+		ts.T().Skip("OrioleDB does not support CREATE INDEX CONCURRENTLY")
+	}
 	ctx := context.Background()
 
 	// Insert test users so there's a non-zero user count
@@ -361,6 +388,9 @@ func (ts *IndexWorkerTestSuite) TestUserOptInAlwaysCreatesIndexes() {
 // TestUserOptInWithZeroThreshold verifies that EnsureUserSearchIndexesExist=true
 // with MaxUsersThreshold=0 (disabled) still creates indexes.
 func (ts *IndexWorkerTestSuite) TestUserOptInWithZeroThreshold() {
+	if ts.isOrioleDB {
+		ts.T().Skip("OrioleDB does not support CREATE INDEX CONCURRENTLY")
+	}
 	ctx := context.Background()
 
 	ts.config.IndexWorker.EnsureUserSearchIndexesExist = true
@@ -383,6 +413,9 @@ func (ts *IndexWorkerTestSuite) TestUserOptInWithZeroThreshold() {
 // This test simulates a scenario where indexes become invalid (e.g., from interrupted CONCURRENT creation)
 // and verifies that CreateIndexes properly handles them by dropping and recreating.
 func (ts *IndexWorkerTestSuite) TestCreateIndexesWithInvalidIndexes() {
+	if ts.isOrioleDB {
+		ts.T().Skip("OrioleDB does not support CREATE INDEX CONCURRENTLY")
+	}
 	ctx := context.Background()
 
 	// Step 1: Run CreateIndexes to create all indexes
@@ -475,6 +508,27 @@ func (ts *IndexWorkerTestSuite) TestCreateIndexesWithInvalidIndexes() {
 	}
 
 	ts.logger.Infof("Successfully recovered from %d invalid indexes", len(indexesToInvalidate))
+}
+
+func (ts *IndexWorkerTestSuite) TestIsOrioleDBTableNonExistentTable() {
+	_, err := isOrioleDBTable(ts.popDB, ts.namespace, "nonexistent_table")
+	assert.Error(ts.T(), err, "Should return error for non-existent table")
+}
+
+func (ts *IndexWorkerTestSuite) TestCreateIndexesSkipsOnOrioleDB() {
+	if !ts.isOrioleDB {
+		ts.T().Skip("Test only runs on OrioleDB")
+	}
+	ctx := context.Background()
+
+	err := CreateIndexes(ctx, ts.config, ts.logger)
+	require.ErrorIs(ts.T(), err, ErrOrioleDBUnsupported)
+
+	// Verify no indexes were created
+	indexes := getUsersIndexes(ts.namespace)
+	existingIndexes, err := getIndexStatuses(ts.popDB, ts.namespace, getIndexNames(indexes))
+	require.NoError(ts.T(), err)
+	assert.Empty(ts.T(), existingIndexes, "No indexes should be created when OrioleDB is detected")
 }
 
 // Run the test suite


### PR DESCRIPTION
OrioleDB does not support `CREATE INDEX CONCURRENTLY`. Detect the table's storage engine via `pg_am` before acquiring the advisory lock and skip index creation when OrioleDB is detected.