### PR TITLE
fix: source WebAuthn RP config from env vars

### DIFF
--- a/internal/api/mfa.go
+++ b/internal/api/mfa.go
@@ -4,10 +4,8 @@ import (
 	"bytes"
 	"crypto/subtle"
 	"encoding/json"
-	"fmt"
 	"net/http"
 	"net/url"
-	"strings"
 	"time"
 
 	"github.com/aaronarduino/goqrsvg"
@@ -77,8 +75,6 @@ type WebAuthnChallengeData struct {
 }
 
 type WebAuthnParams struct {
-	RPID               string          `json:"rpId,omitempty"`
-	RPOrigins          []string        `json:"rpOrigins,omitempty"`
 	Type               string          `json:"type"` // "create" or "request"
 	CredentialResponse json.RawMessage `json:"credential_response"`
 }
@@ -87,39 +83,14 @@ type UnenrollFactorResponse struct {
 	ID uuid.UUID `json:"id"`
 }
 
-func (w *WebAuthnParams) ToConfig() (*webauthn.WebAuthn, error) {
-	if w.RPID == "" {
-		return nil, fmt.Errorf("webAuthn RP ID cannot be empty")
-	}
+func (a *API) getWebAuthnMFA() (*webauthn.WebAuthn, error) {
+	rpConfig := a.config.WebAuthn
 
-	if len(w.RPOrigins) == 0 {
-		return nil, fmt.Errorf("webAuthn RP Origins cannot be empty")
-	}
-
-	var validOrigins []string
-	var invalidOrigins []string
-
-	for _, origin := range w.RPOrigins {
-		parsedURL, err := url.Parse(origin)
-		if err != nil || (parsedURL.Scheme != "https" && !(parsedURL.Scheme == "http" && parsedURL.Hostname() == "localhost")) || parsedURL.Host == "" {
-			invalidOrigins = append(invalidOrigins, origin)
-		} else {
-			validOrigins = append(validOrigins, origin)
-		}
-	}
-
-	if len(invalidOrigins) > 0 {
-		return nil, fmt.Errorf("invalid RP origins: %s", strings.Join(invalidOrigins, ", "))
-	}
-
-	wconfig := &webauthn.Config{
-		// DisplayName is optional in spec but required to be non-empty in libary, we use the RPID as a placeholder.
-		RPDisplayName: w.RPID,
-		RPID:          w.RPID,
-		RPOrigins:     validOrigins,
-	}
-
-	return webauthn.New(wconfig)
+	return webauthn.New(&webauthn.Config{
+		RPDisplayName: rpConfig.RPDisplayName,
+		RPID:          rpConfig.RPID,
+		RPOrigins:     rpConfig.RPOrigins,
+	})
 }
 
 const (
@@ -500,10 +471,7 @@ func (a *API) challengeWebAuthnFactor(w http.ResponseWriter, r *http.Request) er
 	if err := retrieveRequestParams(r, params); err != nil {
 		return err
 	}
-	if params.WebAuthn == nil {
-		return apierrors.NewBadRequestError(apierrors.ErrorCodeValidationFailed, "web_authn config required")
-	}
-	webAuthn, err := params.WebAuthn.ToConfig()
+	webAuthn, err := a.getWebAuthnMFA()
 	if err != nil {
 		return err
 	}
@@ -917,7 +885,7 @@ func (a *API) verifyWebAuthnFactor(w http.ResponseWriter, r *http.Request, param
 	case params.WebAuthn.CredentialResponse == nil:
 		return apierrors.NewBadRequestError(apierrors.ErrorCodeValidationFailed, "credential_response required")
 	default:
-		webAuthn, err = params.WebAuthn.ToConfig()
+		webAuthn, err = a.getWebAuthnMFA()
 		if err != nil {
 			return err
 		}

--- a/internal/api/mfa_test.go
+++ b/internal/api/mfa_test.go
@@ -94,6 +94,12 @@ func (ts *MFATestSuite) SetupTest() {
 
 	ts.Config.MFA.WebAuthn.EnrollEnabled = true
 	ts.Config.MFA.WebAuthn.VerifyEnabled = true
+	ts.Config.WebAuthn = conf.WebAuthnConfiguration{
+		RPID:                    "localhost",
+		RPDisplayName:           "Test App",
+		RPOrigins:               []string{"http://localhost:3000"},
+		ChallengeExpiryDuration: 5 * time.Minute,
+	}
 
 	key, err := totp.Generate(totp.GenerateOpts{
 		Issuer:      ts.TestDomain,
@@ -721,13 +727,9 @@ func (ts *MFATestSuite) TestMFAFollowedByPasswordSignIn() {
 
 func (ts *MFATestSuite) TestChallengeWebAuthnFactor() {
 	factor := models.NewWebAuthnFactor(ts.TestUser, "WebAuthnfactor")
-	validWebAuthnConfiguration := &WebAuthnParams{
-		RPID:      "localhost",
-		RPOrigins: []string{"http://localhost:3000"},
-	}
 	require.NoError(ts.T(), ts.API.db.Create(factor), "Error saving new test factor")
 	token := ts.generateAAL1Token(ts.TestUser, &ts.TestSession.ID)
-	w := performChallengeWebAuthnFlow(ts, factor.ID, token, validWebAuthnConfiguration)
+	w := performChallengeWebAuthnFlow(ts, factor.ID, token, &WebAuthnParams{})
 	require.Equal(ts.T(), http.StatusOK, w.Code)
 }
 

--- a/internal/conf/configuration.go
+++ b/internal/conf/configuration.go
@@ -1333,7 +1333,7 @@ func (c *GlobalConfiguration) Validate() error {
 		}
 	}
 
-	if c.Passkey.Enabled {
+	if c.Passkey.Enabled || c.MFA.WebAuthn.EnrollEnabled || c.MFA.WebAuthn.VerifyEnabled {
 		if err := c.WebAuthn.Validate(); err != nil {
 			return err
 		}

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1040,21 +1040,6 @@ paths:
                   enum:
                     - sms
                     - whatsapp
-                webauthn:
-                  type: object
-                  required:
-                    - rpId
-                    - rpOrigins
-                  properties:
-                    rpId:
-                      type: string
-                      description: The relying party identifier (usually the domain)
-                    rpOrigins:
-                      type: array
-                      items:
-                        type: string
-                      minItems: 1
-                      description: List of allowed origins for WebAuthn
 
       responses:
         200:
@@ -1103,20 +1088,9 @@ paths:
                 webauthn:
                   type: object
                   required:
-                    - rpId
-                    - rpOrigins
                     - type
                     - credential_response
                   properties:
-                    rpId:
-                      type: string
-                      description: The relying party identifier
-                    rpOrigins:
-                      type: array
-                      items:
-                        type: string
-                      minItems: 1
-                      description: List of allowed origins for WebAuthn
                     type:
                       type: string
                       enum: [create, request]


### PR DESCRIPTION
Requires relying party configuration to be set in environment variables.

- MFA WebAuthn challenge and verify no longer accept `rpId` / `rpOrigins` from the request body.
- Validates `GOTRUE_WEBAUTHN_RP_*` at startup whenever MFA WebAuthn enroll or verify environment vars are enabled.

`rpId` and `rpOrigins` under the `webauthn` object on `POST /factors/{factor_id}/challenge` and `POST /factors/{factor_id}/verify` are now silently ignored — they must no longer be sent in the request bodies.

`GOTRUE_WEBAUTHN_RP_ID`, `GOTRUE_WEBAUTHN_RP_ORIGINS`, and `GOTRUE_WEBAUTHN_RP_DISPLAY_NAME` must be set if MFA WebAuthn enroll or verify are enabled.