### PR TITLE
fix: exempt PKCE recovery sessions from require-current-password check

### DIFF
--- a/internal/api/user.go
+++ b/internal/api/user.go
@@ -168,16 +168,16 @@ func (a *API) UserUpdate(w http.ResponseWriter, r *http.Request) error {
 			if user.HasPassword() {
 				// current password required when updating password
 				if config.Security.UpdatePasswordRequireCurrentPassword {
-					// user may be in a password reset flow, where they do not have a currentPassword
-					isRecoverySession := false
-					for _, claim := range session.AMRClaims {
-						// password recovery flows can be via otp or a magic link, check if the current session
-						// was created with one of those
-						if claim.GetAuthenticationMethod() == "otp" || claim.GetAuthenticationMethod() == "magiclink" {
-							isRecoverySession = true
-							break
-						}
+				// user may be in a password reset flow, where they do not have a currentPassword
+				isRecoverySession := false
+				for _, claim := range session.AMRClaims {
+					// password recovery flows can be via otp, a magic link, or the
+					// PKCE recovery flow (which sets the AMR to "recovery")
+					if claim.GetAuthenticationMethod() == "otp" || claim.GetAuthenticationMethod() == "magiclink" || claim.GetAuthenticationMethod() == "recovery" {
+						isRecoverySession = true
+						break
 					}
+				}
 					if !isRecoverySession {
 						if params.CurrentPassword == nil || *params.CurrentPassword == "" {
 							return apierrors.NewBadRequestError(apierrors.ErrorCodeCurrentPasswordRequired, "Current password required when setting new password.")

--- a/internal/api/user_test.go
+++ b/internal/api/user_test.go
@@ -435,6 +435,12 @@ func (ts *UserTestSuite) TestUserUpdatePasswordViaRecovery() {
 			expected:     expected{code: http.StatusOK, isAuthenticated: true},
 		},
 		{
+			desc:         "Current password not required in PKCE recovery flow",
+			newPassword:  "newpassword789",
+			recoveryType: models.Recovery,
+			expected:     expected{code: http.StatusOK, isAuthenticated: true},
+		},
+		{
 			desc:         "Current password required for any other claim",
 			newPassword:  "newpassword456",
 			recoveryType: models.EmailChange,


### PR DESCRIPTION
## Bug
`UpdatePasswordRequireCurrentPassword` in `user.go` only exempts sessions with `otp` or `magiclink` AMR claims from the current-password requirement. The PKCE recovery flow (the default path for the JS client) issues sessions with the `recovery` AMR claim:
- `recover.go:60` creates the flow state with `models.Recovery.String()` (`"recovery"`)
- `token.go:256` parses it via `ParseAuthenticationMethod(flowState.AuthenticationMethod)`
- `token.go:265` issues the refresh token with `models.Recovery`
The resulting JWT has `"amr": [{"method": "recovery", ...}]`, which doesn't match `"otp"` or `"magiclink"`. If the setting is enabled, `updateUser({ password })` rejects the request with "Current password required" even though the user just came from a password reset email.
## Fix
Add `"recovery"` to the AMR exemption check in `user.go:176`.
## Test
Added a test case for `models.Recovery` AMR confirming current password is not required in PKCE recovery flow.