### PR TITLE
feat(apple): expose given_name and family_name in user metadata

### DIFF
--- a/internal/api/provider/apple.go
+++ b/internal/api/provider/apple.go
@@ -175,5 +175,7 @@ func (p AppleProvider) ParseUser(data string, userData *UserProvidedData) error 
 
 	userData.Metadata.Name = strings.TrimSpace(u.Name.FirstName + " " + u.Name.LastName)
 	userData.Metadata.FullName = strings.TrimSpace(u.Name.FirstName + " " + u.Name.LastName)
+	userData.Metadata.GivenName = u.Name.FirstName
+	userData.Metadata.FamilyName = u.Name.LastName
 	return nil
 }

--- a/internal/api/provider/apple_test.go
+++ b/internal/api/provider/apple_test.go
@@ -1,0 +1,60 @@
+package provider
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAppleProvider_ParseUser(t *testing.T) {
+	t.Run("populates all name fields when firstName and lastName present", func(t *testing.T) {
+		p := AppleProvider{}
+		userData := &UserProvidedData{Metadata: &Claims{}}
+		err := p.ParseUser(`{"name":{"firstName":"Test","lastName":"User"},"email":"test@example.com"}`, userData)
+		require.NoError(t, err)
+		require.Equal(t, "Test", userData.Metadata.GivenName)
+		require.Equal(t, "User", userData.Metadata.FamilyName)
+		require.Equal(t, "Test User", userData.Metadata.Name)
+		require.Equal(t, "Test User", userData.Metadata.FullName)
+	})
+
+	t.Run("populates given name only when lastName missing", func(t *testing.T) {
+		p := AppleProvider{}
+		userData := &UserProvidedData{Metadata: &Claims{}}
+		err := p.ParseUser(`{"name":{"firstName":"Cher"},"email":"cher@example.com"}`, userData)
+		require.NoError(t, err)
+		require.Equal(t, "Cher", userData.Metadata.GivenName)
+		require.Empty(t, userData.Metadata.FamilyName)
+		require.Equal(t, "Cher", userData.Metadata.Name)
+		require.Equal(t, "Cher", userData.Metadata.FullName)
+	})
+
+	t.Run("populates family name only when firstName missing", func(t *testing.T) {
+		p := AppleProvider{}
+		userData := &UserProvidedData{Metadata: &Claims{}}
+		err := p.ParseUser(`{"name":{"lastName":"User"},"email":"user@example.com"}`, userData)
+		require.NoError(t, err)
+		require.Empty(t, userData.Metadata.GivenName)
+		require.Equal(t, "User", userData.Metadata.FamilyName)
+		require.Equal(t, "User", userData.Metadata.Name)
+		require.Equal(t, "User", userData.Metadata.FullName)
+	})
+
+	t.Run("leaves name fields empty when name object absent", func(t *testing.T) {
+		p := AppleProvider{}
+		userData := &UserProvidedData{Metadata: &Claims{}}
+		err := p.ParseUser(`{"email":"anonymous@example.com"}`, userData)
+		require.NoError(t, err)
+		require.Empty(t, userData.Metadata.GivenName)
+		require.Empty(t, userData.Metadata.FamilyName)
+		require.Empty(t, userData.Metadata.Name)
+		require.Empty(t, userData.Metadata.FullName)
+	})
+
+	t.Run("returns error on invalid JSON", func(t *testing.T) {
+		p := AppleProvider{}
+		userData := &UserProvidedData{Metadata: &Claims{}}
+		err := p.ParseUser(`not-json`, userData)
+		require.Error(t, err)
+	})
+}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

## What is the current behavior?

Missing given and family names from Apple. Only full name is passed through to user metadata currently.

## What is the new behavior?

`given_name` and `family_name` will be included in the user metadata when using SIWA OAuth. We already had the values, but were concatenating it to one string. The `given_name` and `family_name` match existing json values in provider.go:

https://github.com/supabase/auth/blob/bb521e48f3114b2f65093eae80127726fe7047c8/internal/api/provider/provider.go#L96-L97

## Additional context

This will be more reliable and correct than trying to full names down into first names and last names.
