### PR TITLE
feat(google): populate given_name, family_name, and locale in user metadata

### DIFF
--- a/internal/api/external_google_test.go
+++ b/internal/api/external_google_test.go
@@ -12,9 +12,9 @@ import (
 )
 
 const (
-	googleUser           string = `{"id":"googleTestId","name":"Google Test","picture":"http://example.com/avatar","email":"google@example.com","verified_email":true}}`
-	googleUserWrongEmail string = `{"id":"googleTestId","name":"Google Test","picture":"http://example.com/avatar","email":"other@example.com","verified_email":true}}`
-	googleUserNoEmail    string = `{"id":"googleTestId","name":"Google Test","picture":"http://example.com/avatar","verified_email":false}}`
+	googleUser           string = `{"id":"googleTestId","name":"Google Test","given_name":"Google","family_name":"Test","picture":"http://example.com/avatar","email":"google@example.com","verified_email":true,"locale":"en"}`
+	googleUserWrongEmail string = `{"id":"googleTestId","name":"Google Test","given_name":"Google","family_name":"Test","picture":"http://example.com/avatar","email":"other@example.com","verified_email":true,"locale":"en"}`
+	googleUserNoEmail    string = `{"id":"googleTestId","name":"Google Test","given_name":"Google","family_name":"Test","picture":"http://example.com/avatar","verified_email":false}`
 )
 
 func (ts *ExternalTestSuite) TestSignupExternalGoogle() {

--- a/internal/api/provider/google.go
+++ b/internal/api/provider/google.go
@@ -15,11 +15,14 @@ type googleUser struct {
 	Subject       string `json:"sub"`
 	Issuer        string `json:"iss"`
 	Name          string `json:"name"`
+	GivenName     string `json:"given_name"`
+	FamilyName    string `json:"family_name"`
 	AvatarURL     string `json:"picture"`
 	Email         string `json:"email"`
 	VerifiedEmail bool   `json:"verified_email"`
 	EmailVerified bool   `json:"email_verified"`
 	HostedDomain  string `json:"hd"`
+	Locale        string `json:"locale"`
 }
 
 func (u googleUser) IsEmailVerified() bool {
@@ -122,9 +125,12 @@ func (g googleProvider) GetUserData(ctx context.Context, tok *oauth2.Token) (*Us
 		Issuer:        internalUserInfoEndpointGoogle,
 		Subject:       u.ID,
 		Name:          u.Name,
+		GivenName:     u.GivenName,
+		FamilyName:    u.FamilyName,
 		Picture:       u.AvatarURL,
 		Email:         u.Email,
 		EmailVerified: u.IsEmailVerified(),
+		Locale:        u.Locale,
 
 		// To be deprecated
 		AvatarURL:  u.AvatarURL,

--- a/internal/api/provider/oidc.go
+++ b/internal/api/provider/oidc.go
@@ -105,10 +105,15 @@ func parseGoogleIDToken(token *oidc.IDToken) (*oidc.IDToken, *UserProvidedData, 
 	}
 
 	data.Metadata = &Claims{
-		Issuer:  claims.Issuer,
-		Subject: claims.Subject,
-		Name:    claims.Name,
-		Picture: claims.AvatarURL,
+		Issuer:        claims.Issuer,
+		Subject:       claims.Subject,
+		Name:          claims.Name,
+		GivenName:     claims.GivenName,
+		FamilyName:    claims.FamilyName,
+		Picture:       claims.AvatarURL,
+		Email:         claims.Email,
+		EmailVerified: claims.IsEmailVerified(),
+		Locale:        claims.Locale,
 
 		// To be deprecated
 		AvatarURL:  claims.AvatarURL,


### PR DESCRIPTION
## Summary

Google's OIDC ID token includes `given_name`, `family_name`, and `locale` as [standard claims](https://developers.google.com/identity/openid-connect/openid-connect#an-id-tokens-payload), but the Google provider silently drops them. The `Claims` struct already has fields for all three (`GivenName`, `FamilyName`, `Locale`) and the LinkedIn provider correctly populates them — but the Google provider never did.

This PR:
- Adds `GivenName`, `FamilyName`, and `Locale` fields to the `googleUser` struct so they are deserialized from the ID token / userinfo response
- Maps them into `Claims` metadata in both `parseGoogleIDToken` (ID token path) and `GetUserData` (legacy userinfo endpoint fallback)
- Also populates `Email` and `EmailVerified` in `parseGoogleIDToken`, which were previously missing from the ID token path (the legacy path already had them)
- Updates test fixtures to include the new fields

## Root Cause

Two issues:

1. **`googleUser` struct missing fields** ([`google.go` L13–L23](https://github.com/supabase/auth/blob/bb521e48f3114b2f65093eae80127726fe7047c8/internal/api/provider/google.go#L13-L23)) — the struct had no `given_name`, `family_name`, or `locale` JSON tags, so Go's `json.Unmarshal` silently discarded them.

2. **`parseGoogleIDToken` never mapped them** ([`oidc.go` L68–L99](https://github.com/supabase/auth/blob/bb521e48f3114b2f65093eae80127726fe7047c8/internal/api/provider/oidc.go#L68-L99)) — even if the struct had the fields, the `Claims` metadata construction only set `Name`, `Picture`, `AvatarURL`, `FullName`, and `ProviderId`.

The LinkedIn provider (`parseLinkedinIDToken` in the same file) demonstrates the correct pattern — its claims struct includes these fields and maps them into `Claims`.

## Impact

Every Supabase project using Google OAuth is affected. `raw_user_meta_data` is permanently missing structured name data that Google provides. Applications needing first/last name must resort to unreliable string splitting of `full_name`.

## Related

- [supabase/auth PR #2498](https://github.com/supabase/auth/pull/2498) — Open PR fixing the identical issue for Apple Sign-In
- [Supabase Discussion #27154](https://github.com/orgs/supabase/discussions/27154) — Community report of missing `given_name`/`family_name` in Google metadata