### PR TITLE
fix(otp): respect minimum_password_length when generating dummy password

### DIFF
--- a/internal/api/magic_link.go
+++ b/internal/api/magic_link.go
@@ -83,8 +83,10 @@ func (a *API) MagicLink(w http.ResponseWriter, r *http.Request) error {
 	}
 	if isNewUser {
 		// User either doesn't exist or hasn't completed the signup process.
-		// Sign them up with temporary password.
-		password := crypto.GeneratePassword(config.Password.RequiredCharacters, 33)
+		// Sign them up with temporary password that satisfies the configured
+		// minimum password length, clamped to the bcrypt limit.
+		passwordLen := min(max(33, config.Password.MinLength), MaxPasswordLength)
+		password := crypto.GeneratePassword(config.Password.RequiredCharacters, passwordLen)
 
 		signUpParams := &SignupParams{
 			Email:               params.Email,

--- a/internal/api/otp.go
+++ b/internal/api/otp.go
@@ -138,8 +138,10 @@ func (a *API) SmsOtp(w http.ResponseWriter, r *http.Request) error {
 	}
 	if isNewUser {
 		// User either doesn't exist or hasn't completed the signup process.
-		// Sign them up with temporary password.
-		password, err := password.Generate(64, 10, 1, false, true)
+		// Sign them up with temporary password that satisfies the configured
+		// minimum password length, clamped to the bcrypt limit.
+		passwordLen := min(max(64, config.Password.MinLength), MaxPasswordLength)
+		password, err := password.Generate(passwordLen, 10, 1, false, true)
 		if err != nil {
 			return apierrors.NewInternalServerError("error creating user").WithInternalError(err)
 		}

--- a/internal/api/otp_test.go
+++ b/internal/api/otp_test.go
@@ -262,6 +262,28 @@ func (ts *OtpTestSuite) TestNoSignupsForOtp() {
 	})
 }
 
+func (ts *OtpTestSuite) TestOtpRespectsMinPasswordLength() {
+	// Regression test for https://github.com/supabase/auth/issues/2456.
+	// OTP signup internally generates a temporary password that must satisfy
+	// the configured minimum password length, otherwise the signup call fails
+	// with a 422 WeakPasswordError even though the caller never supplied a
+	// password.
+	ts.Config.Password.MinLength = 40
+
+	var buffer bytes.Buffer
+	require.NoError(ts.T(), json.NewEncoder(&buffer).Encode(map[string]interface{}{
+		"email": "min-length@example.com",
+	}))
+
+	req := httptest.NewRequest(http.MethodPost, "/otp", &buffer)
+	req.Header.Set("Content-Type", "application/json")
+
+	w := httptest.NewRecorder()
+	ts.API.handler.ServeHTTP(w, req)
+
+	require.Equal(ts.T(), http.StatusOK, w.Code)
+}
+
 func (ts *OtpTestSuite) TestSubsequentOtp() {
 	ts.Config.SMTP.MaxFrequency = 0
 	userEmail := "foo@example.com"


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix.

## What is the current behavior?

`signInWithOtp({ email })` and `signInWithOtp({ phone })` return `422 Unprocessable Entity` with a `WeakPasswordError` when `GOTRUE_PASSWORD_MIN_LENGTH` is configured above the hardcoded temporary-password lengths (33 for magic link, 64 for SMS OTP), even though the caller never supplies a password.

Closes #2456.

### Reproduction

1. Set `minimum_password_length = 100` in `config.toml` under `[auth]`
2. Enable OTP signup via `enable_signup = true` under `[auth.email]`
3. Call `signInWithOtp({ email: "test@example.com" })`
4. Receive `422 Unprocessable Entity` with `"Password should be at least 100 characters"`

### Root cause

Both `MagicLink` (email OTP) and `SmsOtp` (phone OTP) generate a temporary password for new users and then invoke `Signup`, which calls `checkPasswordStrength` and enforces `config.Password.MinLength`. The generated passwords are hardcoded at 33 and 64 characters respectively, so any `MinLength` above those values breaks OTP signup.

## What is the new behavior?

The generated password length is now `min(max(base, config.Password.MinLength), MaxPasswordLength)` where `base` is the previous hardcoded value (33 or 64) and `MaxPasswordLength` is the existing 72-char bcrypt ceiling. This preserves existing behavior when `MinLength ≤ base` and satisfies strength validation for realistic higher values.

Admin and invite flows (`admin.go`, `verify.go`) also generate temporary passwords but bypass `checkPasswordStrength`, so they are unaffected and intentionally not changed.

## Additional context

- Added regression test `TestOtpRespectsMinPasswordLength` in `internal/api/otp_test.go`
- `make test` passes locally against Postgres 15 (TestOtp, TestSignup, TestVerify, TestRecover, TestMagicLink, TestPasswordStrengthChecks all green)
- No API changes, no migration required