### PR TITLE
fix(provider): preserve non-standard claims in generic OIDC parser

### DIFF
--- a/internal/api/provider/oidc.go
+++ b/internal/api/provider/oidc.go
@@ -442,11 +442,36 @@ func parseVercelMarketplaceIDToken(token *oidc.IDToken) (*oidc.IDToken, *UserPro
 	return token, &data, nil
 }
 
+// standardClaimsForGenericOIDC contains the list of claims to be removed
+// from the CustomClaims map by parseGenericIDToken.
+var standardClaimsForGenericOIDC = []string{
+	"iss", "sub", "aud", "iat", "exp", "nbf", "jti",
+	"name", "family_name", "given_name", "middle_name", "nickname",
+	"preferred_username", "profile", "picture", "website",
+	"gender", "birthdate", "zoneinfo", "locale", "updated_at",
+	"email", "email_verified", "phone", "phone_verified",
+	"custom_claims",
+	"full_name", "avatar_url", "slug", "provider_id", "user_name",
+	"azp", "amr", "auth_time", "nonce", "at_hash", "c_hash", "sid",
+	"client_id", "ver", "rh", "uti", "aio",
+}
+
 func parseGenericIDToken(token *oidc.IDToken) (*oidc.IDToken, *UserProvidedData, error) {
 	var data UserProvidedData
 
 	if err := token.Claims(&data.Metadata); err != nil {
 		return nil, nil, err
+	}
+
+	data.Metadata.CustomClaims = make(map[string]interface{})
+	if err := token.Claims(&data.Metadata.CustomClaims); err != nil {
+		return nil, nil, err
+	}
+	for _, k := range standardClaimsForGenericOIDC {
+		delete(data.Metadata.CustomClaims, k)
+	}
+	if len(data.Metadata.CustomClaims) < 1 {
+		data.Metadata.CustomClaims = nil
 	}
 
 	if data.Metadata.Email != "" {

--- a/internal/api/provider/oidc_zitadel_test.go
+++ b/internal/api/provider/oidc_zitadel_test.go
@@ -1,0 +1,111 @@
+package provider
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/coreos/go-oidc/v3/oidc"
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/stretchr/testify/require"
+)
+
+// Regression test for supabase/auth#2494: the generic OIDC parser must
+// preserve URN-namespaced claims like Zitadel's role claims.
+func TestParseGenericIDTokenPreservesURNNamespacedClaims(t *testing.T) {
+	privKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	const keyID = "test-key-1"
+
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/.well-known/openid-configuration":
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprintf(w,
+				`{"issuer":%q,"authorization_endpoint":%q,"token_endpoint":%q,"jwks_uri":%q,"id_token_signing_alg_values_supported":["RS256"]}`,
+				server.URL, server.URL+"/authorize", server.URL+"/token", server.URL+"/jwks",
+			)
+		case "/jwks":
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(buildJWKSResponse(&privKey.PublicKey, keyID)))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	zitadelRoleClaim := map[string]any{
+		"admin": map[string]string{
+			"370187779914661893": "zitadel.host.docker.internal",
+		},
+	}
+	claims := jwt.MapClaims{
+		"iss":                               server.URL,
+		"sub":                               "user-123",
+		"aud":                               "test-client-id",
+		"iat":                               time.Now().Unix(),
+		"exp":                               time.Now().Add(time.Hour).Unix(),
+		"email":                             "testuser@example.com",
+		"email_verified":                    true,
+		"name":                              "Test User",
+		"urn:zitadel:iam:org:project:roles": zitadelRoleClaim,
+		"urn:zitadel:iam:org:project:370187906414804997:roles": zitadelRoleClaim,
+	}
+	tok := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+	tok.Header["kid"] = keyID
+	signed, err := tok.SignedString(privKey)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	oidcProvider, err := oidc.NewProvider(ctx, server.URL)
+	require.NoError(t, err)
+
+	_, data, err := ParseIDToken(ctx, oidcProvider, &oidc.Config{
+		SkipClientIDCheck: true,
+	}, signed, ParseIDTokenOptions{
+		SkipAccessTokenCheck: true,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, data)
+	require.NotNil(t, data.Metadata)
+
+	require.Equal(t, "testuser@example.com", data.Metadata.Email)
+	require.True(t, data.Metadata.EmailVerified)
+	require.Equal(t, "user-123", data.Metadata.Subject)
+
+	require.NotNil(t, data.Metadata.CustomClaims)
+	require.Contains(t, data.Metadata.CustomClaims, "urn:zitadel:iam:org:project:roles")
+	require.Contains(t, data.Metadata.CustomClaims, "urn:zitadel:iam:org:project:370187906414804997:roles")
+
+	for _, k := range []string{"iss", "sub", "aud", "iat", "exp", "email", "email_verified", "name"} {
+		require.NotContains(t, data.Metadata.CustomClaims, k)
+	}
+}
+
+func buildJWKSResponse(pub *rsa.PublicKey, keyID string) string {
+	n := base64.RawURLEncoding.EncodeToString(pub.N.Bytes())
+	e := base64.RawURLEncoding.EncodeToString(big.NewInt(int64(pub.E)).Bytes())
+	jwks := map[string]any{
+		"keys": []map[string]any{
+			{
+				"kty": "RSA",
+				"kid": keyID,
+				"use": "sig",
+				"alg": "RS256",
+				"n":   n,
+				"e":   e,
+			},
+		},
+	}
+	out, _ := json.Marshal(jwks)
+	return string(out)
+}


### PR DESCRIPTION
## What

Fixes #2494.

`parseGenericIDToken` (`internal/api/provider/oidc.go`) unmarshals the ID token into the strongly-typed `Claims` struct, which has no catch-all field. JSON unmarshal silently drops every key that is not declared as a struct field. For Zitadel, that means the role claims emitted under URN-namespaced keys (`urn:zitadel:iam:org:project:roles`, `urn:zitadel:iam:org:project:<projectId>:roles`) never reach `data.Metadata.CustomClaims`, never get serialized into `raw_user_meta_data`, and never appear in the session returned by `supabase.auth.getSession()`.

The same path also drops standard OIDC claims that custom providers commonly emit (`amr`, `auth_time`, `azp`, `sid`, `at_hash`) for any issuer that does not match one of the named cases in `ParseIDToken`.

## How

Mirror the two-pass pattern `parseAzureIDToken` already uses (oidc.go:329-365):

1. Parse the token into the typed `Claims` struct so OIDC standard fields land in their typed homes.
2. Re-parse the token into a `map[string]interface{}` to capture every key the JWT carries.
3. Strip the registered JWT claims and the OIDC claims that already have explicit fields on `Claims`.
4. Retain whatever remains in `data.Metadata.CustomClaims`.

This is exactly what Azure and Apple parsers do today; the generic path was missing it.

## Empirical evidence (Zitadel ID token before vs after)

Reproduced locally with `supabase/auth` running against a fresh Zitadel instance and a custom OIDC provider configured for it.

**Raw claims Zitadel emits (18 keys):**
```
amr, at_hash, aud, auth_time, azp, client_id, email, email_verified,
exp, family_name, given_name, iat, iss, locale, name, preferred_username,
sid, sub, updated_at,
urn:zitadel:iam:org:project:roles,
urn:zitadel:iam:org:project:370187906414804997:roles
```

**`data.Metadata` after the strongly-typed unmarshal — before this fix:**
```
iss, sub, aud, iat, exp, name, family_name, given_name,
preferred_username, updated_at, email, email_verified
```
6 standard OIDC claims and both URN role claims dropped.

**`data.Metadata.CustomClaims` after this fix:**
```json
{
  "urn:zitadel:iam:org:project:roles": {"admin": {"<orgId>": "<orgDomain>"}},
  "urn:zitadel:iam:org:project:<projectId>:roles": {"admin": {"<orgId>": "<orgDomain>"}}
}
```

After running the OAuth flow end to end, `auth.users.raw_user_meta_data.custom_claims` now contains both URN keys, which is what `getSession()` returns to the client.

## Tests

Adds `internal/api/provider/oidc_zitadel_test.go` with `TestParseGenericIDTokenPreservesURNNamespacedClaims`. The test:

- Generates an in-memory RSA keypair and signs a Zitadel-shaped ID token containing both URN role variants plus standard OIDC claims.
- Spins up an `httptest.Server` exposing `/.well-known/openid-configuration` and `/jwks` so `oidc.NewProvider` can perform real discovery.
- Runs the token through `ParseIDToken`, asserts both URN claims are preserved in `CustomClaims`, and asserts standard claims (`iss`, `sub`, `email`, etc.) do not leak into `CustomClaims`.

This is a self-contained alternative to the captured real tokens used elsewhere in `oidc_test.go`, which avoids the key-rotation flakiness already flagged in that file.

`make test` passes locally; `gofmt -l` is clean on touched files; `go vet ./...` is clean.

## Notes for review

- **No new provider added.** The CONTRIBUTING.md note about not accepting new OAuth provider contributions does not apply — this fixes claim handling in the existing `CustomOIDCProvider` path.
- **Behavior change implication.** Generic OIDC providers will now flow non-standard claims through `user_metadata.custom_claims` and into the JWT access token via `tokens/service.go`. This is consistent with the existing Apple and Azure behaviors, not a new failure surface.
- **Out of scope but related.** The named provider parsers (`parseGoogleIDToken`, `parseLinkedinIDToken`, `parseKakaoIDToken`, `parseFacebookIDToken`, `parseSnapchatIDToken`, `parseVercelMarketplaceIDToken`) drop unknown claims the same way. The same fix pattern would apply, but each is a separate semantic change for that provider's user base. Happy to follow up in separate PRs if you'd like.