### PR TITLE
fix(api): default OIDC discovery issuer to API_EXTERNAL_URL

### DIFF
--- a/internal/api/jwks.go
+++ b/internal/api/jwks.go
@@ -66,6 +66,9 @@ type OpenIDConfigurationResponse struct {
 func (a *API) WellKnownOpenID(w http.ResponseWriter, r *http.Request) error {
 	config := a.config
 	issuer := config.JWT.Issuer
+	if issuer == "" {
+		issuer = config.API.ExternalURL
+	}
 
 	// Ensure issuer doesn't end with a slash to avoid double slashes in URLs
 	for len(issuer) > 0 && issuer[len(issuer)-1] == '/' {
@@ -73,7 +76,7 @@ func (a *API) WellKnownOpenID(w http.ResponseWriter, r *http.Request) error {
 	}
 
 	response := OpenIDConfigurationResponse{
-		Issuer:                config.JWT.Issuer,
+		Issuer:                issuer,
 		AuthorizationEndpoint: issuer + "/oauth/authorize",
 		TokenEndpoint:         issuer + "/oauth/token",
 		JWKSURL:               issuer + "/.well-known/jwks.json",

--- a/internal/api/jwks_test.go
+++ b/internal/api/jwks_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/lestrrat-go/jwx/v2/jwk"
@@ -76,4 +77,48 @@ func TestJwks(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestWellKnownOpenIDIssuerFallbackToExternalURL(t *testing.T) {
+	mockAPI, _, err := setupAPIForTest()
+	require.NoError(t, err)
+
+	mockAPI.config.JWT.Issuer = ""
+	mockAPI.config.API.ExternalURL = "https://auth.example.com"
+
+	req := httptest.NewRequest(http.MethodGet, "/.well-known/openid-configuration", nil)
+	w := httptest.NewRecorder()
+	mockAPI.handler.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var resp OpenIDConfigurationResponse
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+
+	require.Equal(t, "https://auth.example.com", resp.Issuer)
+	require.True(t, strings.HasPrefix(resp.AuthorizationEndpoint, "https://auth.example.com/"), "authorization_endpoint should be absolute, got %q", resp.AuthorizationEndpoint)
+	require.True(t, strings.HasPrefix(resp.TokenEndpoint, "https://auth.example.com/"), "token_endpoint should be absolute, got %q", resp.TokenEndpoint)
+	require.True(t, strings.HasPrefix(resp.JWKSURL, "https://auth.example.com/"), "jwks_uri should be absolute, got %q", resp.JWKSURL)
+	require.True(t, strings.HasPrefix(resp.UserInfoEndpoint, "https://auth.example.com/"), "userinfo_endpoint should be absolute, got %q", resp.UserInfoEndpoint)
+}
+
+func TestWellKnownOpenIDIssuerStripsTrailingSlash(t *testing.T) {
+	mockAPI, _, err := setupAPIForTest()
+	require.NoError(t, err)
+
+	mockAPI.config.JWT.Issuer = "https://auth.example.com/"
+	mockAPI.config.API.ExternalURL = "https://something-else.example.com"
+
+	req := httptest.NewRequest(http.MethodGet, "/.well-known/openid-configuration", nil)
+	w := httptest.NewRecorder()
+	mockAPI.handler.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var resp OpenIDConfigurationResponse
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+
+	require.Equal(t, "https://auth.example.com", resp.Issuer)
+	require.Equal(t, "https://auth.example.com/oauth/authorize", resp.AuthorizationEndpoint)
+	require.Equal(t, "https://auth.example.com/oauth/token", resp.TokenEndpoint)
+	require.Equal(t, "https://auth.example.com/.well-known/jwks.json", resp.JWKSURL)
+	require.Equal(t, "https://auth.example.com/oauth/userinfo", resp.UserInfoEndpoint)
 }


### PR DESCRIPTION
## What

Fixes supabase/supabase#46019.

The `/.well-known/openid-configuration` handler in `internal/api/jwks.go` reads `config.JWT.Issuer` directly. When self-hosted operators configure `API_EXTERNAL_URL` (which is `required:"true"` per `internal/conf/configuration.go`) but leave `GOTRUE_JWT_ISSUER` unset, the response comes back with an empty `issuer` field and relative endpoint URLs. That violates OpenID Connect Discovery 1.0 section 4.2 (issuer MUST be a non-empty URL) and RFC 8414 section 3 (endpoint URLs MUST be absolute).

A second smaller bug: even when `JWT.Issuer` IS set, the response uses the un-cleaned config value at `jwks.go:76` instead of the trailing-slash-stripped local variable that the endpoint URLs at lines 77-80 use, so `issuer` and the endpoint paths can drift apart on configs with a trailing slash.

## How to reproduce on master (for reviewers)

```bash
# 1. Bring up auth via the standard dev compose
cd auth
cp example.docker.env .env.docker
# Edit .env.docker: set GOTRUE_JWT_SECRET to a 32+ char string.
# Leave GOTRUE_JWT_ISSUER unset. API_EXTERNAL_URL stays as http://localhost:9999.
make dev
# In another shell:
make migrate_dev

# 2. Hit the discovery endpoint
curl -s http://localhost:9999/.well-known/openid-configuration | python3 -m json.tool
```

You will see this response on master:

```json
{
  "issuer": "",
  "authorization_endpoint": "/oauth/authorize",
  "token_endpoint": "/oauth/token",
  "jwks_uri": "/.well-known/jwks.json",
  "userinfo_endpoint": "/oauth/userinfo",
  ...
}
```

Empty `issuer` + relative endpoints. That is the bug.

## Root cause

`internal/api/jwks.go`, function `WellKnownOpenID`:
- Line 68: `issuer := config.JWT.Issuer` reads the issuer with no fallback. If `JWT.Issuer` is empty, `issuer` is empty for the rest of the function.
- Line 76: the response struct sets `Issuer: config.JWT.Issuer` rather than `Issuer: issuer`, so the trailing-slash strip at lines 71-73 never reaches the response field.

## Fix

Two-line change in `WellKnownOpenID`:
- Default `issuer` to `config.API.ExternalURL` when `JWT.Issuer` is empty (`API.ExternalURL` is already `required:"true"` so it is always populated).
- Change `Issuer: config.JWT.Issuer` to `Issuer: issuer` so it picks up the cleaned value.

## How to verify the fix manually (for reviewers)

After applying this PR's diff:

```bash
# 1. Stop and restart auth (CompileDaemon does the rebuild on file save in dev mode)
# Or restart explicitly:
docker compose -f docker-compose-dev.yml restart auth

# 2. Hit the same endpoint
curl -s http://localhost:9999/.well-known/openid-configuration | python3 -m json.tool
```

Expected response:

```json
{
  "issuer": "http://localhost:9999",
  "authorization_endpoint": "http://localhost:9999/oauth/authorize",
  "token_endpoint": "http://localhost:9999/oauth/token",
  "jwks_uri": "http://localhost:9999/.well-known/jwks.json",
  "userinfo_endpoint": "http://localhost:9999/oauth/userinfo",
  ...
}
```

To verify the trailing-slash handling specifically, set `GOTRUE_JWT_ISSUER="https://auth.example.com/"` in `.env.docker` (note the trailing slash), restart, and the response `issuer` should come back as `https://auth.example.com` without the slash.

## Automated tests

`internal/api/jwks_test.go` (added in this PR):

- `TestWellKnownOpenIDIssuerFallbackToExternalURL` — asserts the response `issuer` and endpoint URLs are absolute and rooted at `API.ExternalURL` when `JWT.Issuer` is empty. Fails on master, passes after this fix.
- `TestWellKnownOpenIDIssuerStripsTrailingSlash` — sets `JWT.Issuer = "https://auth.example.com/"` and asserts the response `issuer` is `https://auth.example.com`. Fails on master, passes after this fix.

Run them:

```bash
go test ./internal/api/ -run TestWellKnownOpenID -v -count=1
```

## Verification I ran locally

- `go test ./internal/api/ -run TestWellKnownOpenID -v -count=1` — both new cases red on master, green after the fix
- `go test ./... -count=1 -p 1 -race` — full module suite green
- `gofmt -l internal/api/jwks.go internal/api/jwks_test.go` — empty
- `go vet ./...` — empty
- Live curl roundtrip against running auth shows empty issuer / relative endpoints before, absolute URLs after

## Behavior change

- Self-hosted operators who set only `API_EXTERNAL_URL`: discovery now returns spec-compliant absolute URLs. Previous behavior was a spec violation.
- Operators who set `GOTRUE_JWT_ISSUER` explicitly: behavior unchanged, except trailing slashes are now stripped from `issuer` (already stripped from endpoints). Returning the stripped value matches what the endpoints already use, eliminating an inconsistency.