### PR TITLE
fix(siwe): normalize Ethereum address to lowercase to prevent duplicate identities

### DIFF
--- a/internal/utilities/siwe/parser.go
+++ b/internal/utilities/siwe/parser.go
@@ -57,6 +57,16 @@ func ParseMessage(raw string) (*SIWEMessage, error) {
 		return nil, ErrInvalidAddress
 	}
 
+	// Ethereum addresses are protocol-level case-insensitive: 0xABC... and
+	// 0xabc... are the same wallet. EIP-55 mixed-case is a visual checksum,
+	// not a distinct identifier. We normalize to lowercase here so callers
+	// (notably web3GrantEthereum, which uses Address as part of the
+	// identity provider_id) see a single canonical form and the same
+	// wallet cannot create duplicate auth.identities rows by signing in
+	// with different case variants. See issue #2264. This mirrors the
+	// existing email lowercase-normalization in models.Identity.BeforeUpdate.
+	address = strings.ToLower(address)
+
 	msg := &SIWEMessage{
 		Raw:     raw,
 		Domain:  domain,

--- a/internal/utilities/siwe/parser_test.go
+++ b/internal/utilities/siwe/parser_test.go
@@ -116,7 +116,10 @@ func TestParseMessage(t *testing.T) {
 
 			require.Nil(t, err)
 			require.Equal(t, "example.com", parsed.Domain)
-			require.Equal(t, "0x196a28d05bA75C8dC35B0F6e71DD622D1aC82b7E", parsed.Address)
+			// Address is normalized to lowercase regardless of input casing.
+			// Ethereum addresses are protocol-level case-insensitive; EIP-55
+			// mixed-case is a visual checksum, not a distinct identifier.
+			require.Equal(t, "0x196a28d05ba75c8dc35b0f6e71dd622d1ac82b7e", parsed.Address)
 
 			if i == 0 {
 				require.Equal(t, "Sign in to Example App", *parsed.Statement)
@@ -132,5 +135,51 @@ func TestParseMessage(t *testing.T) {
 
 			require.Equal(t, true, parsed.VerifySignature((example.signature)))
 		})
+	}
+}
+
+// TestParseMessageAddressNormalization asserts that ParseMessage lowercases
+// the Ethereum address regardless of the input casing. Ethereum addresses
+// are protocol-level case-insensitive (EIP-55 mixed-case is a visual checksum
+// only), so storing them verbatim allowed the same wallet signing in with
+// different casings to create duplicate auth.identities rows. See #2264.
+func TestParseMessageAddressNormalization(t *testing.T) {
+	const lowerAddress = "0x196a28d05ba75c8dc35b0f6e71dd622d1ac82b7e"
+	const upperHexAddress = "0x196A28D05BA75C8DC35B0F6E71DD622D1AC82B7E"
+	const checksumAddress = "0x196a28d05bA75C8dC35B0F6e71DD622D1aC82b7E"
+
+	makeMessage := func(addr string) string {
+		return "example.com wants you to sign in with your Ethereum account:\n" +
+			addr +
+			"\n\nURI: https://example.com\nVersion: 1\nChain ID: 1\nNonce: 12345678\nIssued At: 2025-01-01T00:00:00.000Z"
+	}
+
+	cases := []struct {
+		name  string
+		input string
+	}{
+		{name: "lowercase", input: lowerAddress},
+		{name: "uppercase hex", input: upperHexAddress},
+		{name: "EIP-55 checksum mixed case", input: checksumAddress},
+	}
+
+	parsedAddresses := make([]string, 0, len(cases))
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			parsed, err := ParseMessage(makeMessage(tc.input))
+			require.Nil(t, err)
+			require.Equal(t, lowerAddress, parsed.Address,
+				"parser must lowercase Ethereum address so case-variant sign-ins do not create duplicate identities")
+		})
+		// Re-parse outside the subtest to collect for the equality assertion below.
+		parsed, err := ParseMessage(makeMessage(tc.input))
+		require.Nil(t, err)
+		parsedAddresses = append(parsedAddresses, parsed.Address)
+	}
+
+	// All case variants of the same wallet must yield the exact same Address.
+	for i := 1; i < len(parsedAddresses); i++ {
+		require.Equal(t, parsedAddresses[0], parsedAddresses[i],
+			"all case variants of the same Ethereum address must parse to the same value")
 	}
 }


### PR DESCRIPTION
## What

Fixes #2264. Ethereum addresses are protocol-level case-insensitive; EIP-55 mixed-case encoding is a visual checksum only, not a distinct identifier. The SIWE parser was storing the address verbatim from the message body, which let the same wallet create two separate `auth.identities` rows by signing in with different case variants of its address.

## Reproduction

A unit test on master, before the fix, fails as follows:

```
=== RUN   TestParseMessageAddressNormalization/EIP-55_checksum_mixed_case
    parser_test.go:171:
        Error:      Not equal:
                    expected: "0x196a28d05ba75c8dc35b0f6e71dd622d1ac82b7e"
                    actual  : "0x196a28d05bA75C8dC35B0F6e71DD622D1aC82b7E"
        Messages:   parser must lowercase Ethereum address so case-variant sign-ins do not create duplicate identities
=== RUN   TestParseMessageAddressNormalization/uppercase_hex
    parser_test.go:171:
        Error:      Not equal:
                    expected: "0x196a28d05ba75c8dc35b0f6e71dd622d1ac82b7e"
                    actual  : "0x196A28D05BA75C8DC35B0F6E71DD622D1AC82B7E"
--- FAIL: TestParseMessageAddressNormalization (0.00s)
    --- PASS: TestParseMessageAddressNormalization/lowercase
    --- FAIL: TestParseMessageAddressNormalization/uppercase_hex
    --- FAIL: TestParseMessageAddressNormalization/EIP-55_checksum_mixed_case
```

End-to-end repro: sign in via the SIWE flow with `0xABC...`, then sign in again with `0xabc...` for the same wallet. Two distinct rows appear in `auth.identities` because `models.FindIdentityByIdAndProvider` does case-sensitive equality on `provider_id`, and `web3GrantEthereum` builds `provider_id` directly from the parsed address string.

## Root cause

- `internal/utilities/siwe/parser.go:55-58` accepts addresses matching `^0x[a-fA-F0-9]{40}$` and assigns the raw matched string to `SIWEMessage.Address` with no normalization.
- `internal/api/web3.go:264-268` joins `parsedMessage.Address` directly into the identity `provider_id` (`web3:ethereum:<address>`).
- `internal/models/identity.go:78-87` (`FindIdentityByIdAndProvider`) does exact-string equality on `provider_id`.

So two case-variant strings for the same wallet are treated as two different identities.

## Fix

Single `strings.ToLower` at parser entry, immediately after the regex match succeeds. Chosen layer because:

- One canonical form for every caller. No code path that consumes `SIWEMessage.Address` needs to know about normalization.
- Matches the existing precedent in `internal/models/identity.go` `BeforeUpdate`, which already lowercases `identity_data["email"]` for the same reason.
- `VerifySignature` was already case-insensitive (`strings.EqualFold` against the recovered address), so signature verification is unaffected.

## Tests

`internal/utilities/siwe/parser_test.go`:

- New `TestParseMessageAddressNormalization` covers three case variants (all-lowercase, all-uppercase hex, EIP-55 mixed checksum case) of the same address. Each must parse to the lowercase form, and all three must yield identical `Address` values.
- The existing `TestParseMessage` positive examples were updated to assert the now-lowercase canonical form. The positive examples still verify their signatures correctly because `VerifySignature` uses `strings.EqualFold`.

## Operational note

This PR prevents NEW duplicate identities from being created. It does not migrate existing rows. Operators who have already accumulated duplicates from this bug will need a follow-up migration that:

1. Lowercases `auth.identities.provider_id` for `provider = 'ethereum'` rows.
2. Merges any rows that collide after lowercasing (deciding which `user_id` to keep is operator-specific and is why this is out of scope for an automated PR).

Flagged here so this is not lost.

## Why not Solana

Deliberately scoped to SIWE only. SIWS (Solana) addresses are base58-encoded, and base58 is case-sensitive: `1` and `l` are distinct characters in different positions, and lowercasing a valid Solana address would corrupt it. `internal/utilities/siws/parser.go` is untouched.

## Verification

```
$ go test ./internal/utilities/siwe/ -run TestParse -v -count=1
PASS

$ go test ./internal/api/ -run TestWeb3 -v -count=1 -race
PASS

$ go test ./... -count=1 -p 1 -race
ok      github.com/supabase/auth/internal/api                    23.143s
ok      github.com/supabase/auth/internal/utilities/siwe          1.467s
ok      github.com/supabase/auth/internal/utilities/siws          1.603s
... (full suite green)

$ gofmt -l internal/utilities/siwe/parser.go internal/utilities/siwe/parser_test.go
(no output)

$ go vet ./...
(no output)
```