### PR TITLE
fix(siwe): normalize Ethereum address to lowercase to prevent duplicate identities

### DIFF
--- a/internal/utilities/siwe/parser.go
+++ b/internal/utilities/siwe/parser.go
@@ -57,6 +57,16 @@ func ParseMessage(raw string) (*SIWEMessage, error) {
 		return nil, ErrInvalidAddress
 	}
 
+	// Ethereum addresses are protocol-level case-insensitive: 0xABC... and
+	// 0xabc... are the same wallet. EIP-55 mixed-case is a visual checksum,
+	// not a distinct identifier. We normalize to lowercase here so callers
+	// (notably web3GrantEthereum, which uses Address as part of the
+	// identity provider_id) see a single canonical form and the same
+	// wallet cannot create duplicate auth.identities rows by signing in
+	// with different case variants. See issue #2264. This mirrors the
+	// existing email lowercase-normalization in models.Identity.BeforeUpdate.
+	address = strings.ToLower(address)
+
 	msg := &SIWEMessage{
 		Raw:     raw,
 		Domain:  domain,

--- a/internal/utilities/siwe/parser_test.go
+++ b/internal/utilities/siwe/parser_test.go
@@ -116,7 +116,10 @@ func TestParseMessage(t *testing.T) {
 
 			require.Nil(t, err)
 			require.Equal(t, "example.com", parsed.Domain)
-			require.Equal(t, "0x196a28d05bA75C8dC35B0F6e71DD622D1aC82b7E", parsed.Address)
+			// Address is normalized to lowercase regardless of input casing.
+			// Ethereum addresses are protocol-level case-insensitive; EIP-55
+			// mixed-case is a visual checksum, not a distinct identifier.
+			require.Equal(t, "0x196a28d05ba75c8dc35b0f6e71dd622d1ac82b7e", parsed.Address)
 
 			if i == 0 {
 				require.Equal(t, "Sign in to Example App", *parsed.Statement)
@@ -132,5 +135,51 @@ func TestParseMessage(t *testing.T) {
 
 			require.Equal(t, true, parsed.VerifySignature((example.signature)))
 		})
+	}
+}
+
+// TestParseMessageAddressNormalization asserts that ParseMessage lowercases
+// the Ethereum address regardless of the input casing. Ethereum addresses
+// are protocol-level case-insensitive (EIP-55 mixed-case is a visual checksum
+// only), so storing them verbatim allowed the same wallet signing in with
+// different casings to create duplicate auth.identities rows. See #2264.
+func TestParseMessageAddressNormalization(t *testing.T) {
+	const lowerAddress = "0x196a28d05ba75c8dc35b0f6e71dd622d1ac82b7e"
+	const upperHexAddress = "0x196A28D05BA75C8DC35B0F6E71DD622D1AC82B7E"
+	const checksumAddress = "0x196a28d05bA75C8dC35B0F6e71DD622D1aC82b7E"
+
+	makeMessage := func(addr string) string {
+		return "example.com wants you to sign in with your Ethereum account:\n" +
+			addr +
+			"\n\nURI: https://example.com\nVersion: 1\nChain ID: 1\nNonce: 12345678\nIssued At: 2025-01-01T00:00:00.000Z"
+	}
+
+	cases := []struct {
+		name  string
+		input string
+	}{
+		{name: "lowercase", input: lowerAddress},
+		{name: "uppercase hex", input: upperHexAddress},
+		{name: "EIP-55 checksum mixed case", input: checksumAddress},
+	}
+
+	parsedAddresses := make([]string, 0, len(cases))
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			parsed, err := ParseMessage(makeMessage(tc.input))
+			require.Nil(t, err)
+			require.Equal(t, lowerAddress, parsed.Address,
+				"parser must lowercase Ethereum address so case-variant sign-ins do not create duplicate identities")
+		})
+		// Re-parse outside the subtest to collect for the equality assertion below.
+		parsed, err := ParseMessage(makeMessage(tc.input))
+		require.Nil(t, err)
+		parsedAddresses = append(parsedAddresses, parsed.Address)
+	}
+
+	// All case variants of the same wallet must yield the exact same Address.
+	for i := 1; i < len(parsedAddresses); i++ {
+		require.Equal(t, parsedAddresses[0], parsedAddresses[i],
+			"all case variants of the same Ethereum address must parse to the same value")
 	}
 }


### PR DESCRIPTION
## What

Fixes #2264.

Ethereum addresses are protocol-level case-insensitive: `0xABC...` and `0xabc...` are the same wallet. The EIP-55 mixed-case form is a visual checksum, not a distinct identifier. The SIWE parser at `internal/utilities/siwe/parser.go` stores the address verbatim from the signed message, and `web3GrantEthereum` in `internal/api/web3.go` uses that exact string as part of the identity `provider_id`. As a result, the same wallet signing in with two different case representations creates two distinct rows in `auth.users` and `auth.identities`.

## How to reproduce on master (for reviewers)

This requires signing two SIWE messages with the same Ethereum private key, one with a mixed-case address line, one with a lowercase address line, and posting each to `/token?grant_type=web3`. A self-contained Go reproducer is below.

### Step 1: Bring up auth with Web3 enabled

```bash
cd auth
cp example.docker.env .env.docker
# Edit .env.docker:
#   - set GOTRUE_JWT_SECRET to a 32+ char string
#   - add: GOTRUE_EXTERNAL_WEB3_ETHEREUM_ENABLED=true
make dev
# In another shell:
make migrate_dev
```

### Step 2: Save this reproducer to a fresh directory

`siwe-repro/main.go`:

```go
package main

import (
	"bytes"
	"crypto/ecdsa"
	"encoding/hex"
	"encoding/json"
	"fmt"
	"io"
	"net/http"
	"os"
	"strings"
	"time"

	"github.com/ethereum/go-ethereum/accounts"
	"github.com/ethereum/go-ethereum/crypto"
)

const (
	authURL  = "http://localhost:9999/token?grant_type=web3"
	domain   = "localhost"
	uri      = "http://localhost/login"
	version  = "1"
	chainID  = "1"
	fixedKey = "4c0883a69102937d6231471b5dbb6204fe5129617082792ae468d01a3f362318"
)

func main() {
	priv, _ := crypto.HexToECDSA(fixedKey)
	addrChecksum := crypto.PubkeyToAddress(*priv.Public().(*ecdsa.PublicKey)).Hex()
	addrLower := strings.ToLower(addrChecksum)
	fmt.Printf("Wallet (EIP-55):    %s\nWallet (lowercase): %s\n\n", addrChecksum, addrLower)

	t1 := time.Now().UTC().Format(time.RFC3339)
	t2 := time.Now().UTC().Add(time.Second).Format(time.RFC3339)
	id1 := signAndPost(priv, build(addrChecksum, "abcdef0123456789abcdef0123456789", t1), "MIXED-CASE")
	id2 := signAndPost(priv, build(addrLower, "fedcba9876543210fedcba9876543210", t2), "LOWERCASE")

	fmt.Printf("\n=== RESULT ===\nmixed-case user_id: %s\nlowercase user_id:  %s\n", id1, id2)
	if id1 == id2 && id1 != "" {
		fmt.Println("\nSAME user_id — fix is in place.")
	} else {
		fmt.Println("\nDIFFERENT user_ids — bug #2264 confirmed.")
	}
}

func build(address, nonce, issuedAt string) string {
	return fmt.Sprintf("%s wants you to sign in with your Ethereum account:\n%s\n\nURI: %s\nVersion: %s\nChain ID: %s\nNonce: %s\nIssued At: %s",
		domain, address, uri, version, chainID, nonce, issuedAt)
}

func signAndPost(priv *ecdsa.PrivateKey, msg, label string) string {
	hash := accounts.TextHash([]byte(msg))
	sig, _ := crypto.Sign(hash, priv)
	if sig[64] < 27 {
		sig[64] += 27
	}
	body, _ := json.Marshal(map[string]any{"chain": "ethereum", "message": msg, "signature": "0x" + hex.EncodeToString(sig)})
	req, _ := http.NewRequest("POST", authURL, bytes.NewReader(body))
	req.Header.Set("Content-Type", "application/json")
	resp, err := http.DefaultClient.Do(req)
	if err != nil {
		fmt.Fprintln(os.Stderr, err)
		return ""
	}
	defer resp.Body.Close()
	raw, _ := io.ReadAll(resp.Body)
	var parsed map[string]any
	json.Unmarshal(raw, &parsed)
	fmt.Printf("=== POST (%s) === HTTP %d\n", label, resp.StatusCode)
	if u, ok := parsed["user"].(map[string]any); ok {
		id, _ := u["id"].(string)
		fmt.Printf("user.id: %s\n", id)
		return id
	}
	fmt.Printf("response: %s\n", string(raw))
	return ""
}
```

`siwe-repro/go.mod`:

```
module siwerepro

go 1.22

require github.com/ethereum/go-ethereum v1.14.0
```

### Step 3: Run

```bash
cd siwe-repro
go mod tidy
go run main.go
```

You will see two HTTP 200 responses with two different `user.id` values, ending with: `DIFFERENT user_ids — bug #2264 confirmed.`

### Step 4: Inspect the database

```bash
docker exec auth-postgres-1 psql -U supabase_auth_admin -d postgres -c \
  "SELECT user_id, provider_id FROM auth.identities WHERE provider='web3' ORDER BY created_at DESC LIMIT 5;"
```

Two rows for the same wallet, distinguished only by case in `provider_id`.

## Root cause

`internal/utilities/siwe/parser.go` validates the address with `^0x[a-fA-F0-9]{40}$` and stores it verbatim on the parsed `SIWEMessage`. In `internal/api/web3.go`, `web3GrantEthereum` constructs `providerId := "web3:" + chain + ":" + parsedMessage.Address`, and `models.FindIdentityByIdAndProvider` does case-sensitive equality on `provider_id`. So `0xABC...` and `0xabc...` look like distinct identities to the lookup and each path through `createAccountFromExternalIdentity` creates a fresh user.

## Fix

One-line normalization at the parser entry: `address = strings.ToLower(address)` immediately after the regex match succeeds. Single point of truth, no caller changes required. This mirrors the existing email lowercase-normalization pattern in `models.Identity`.

Solana SIWS is intentionally untouched: base58 is case-sensitive and lowercasing it would corrupt valid wallet identifiers.

## How to verify the fix manually (for reviewers)

After applying this PR's diff:

### Step 1: Hot-reload the auth binary

```bash
docker compose -f docker-compose-dev.yml restart auth
```

(Or just save the file — `CompileDaemon` rebuilds within ~10 seconds.)

### Step 2: Clean the duplicate rows from your earlier reproduction run

```bash
docker exec auth-postgres-1 psql -U supabase_auth_admin -d postgres -c \
  "DELETE FROM auth.identities WHERE provider='web3'; \
   DELETE FROM auth.users WHERE raw_user_meta_data->>'sub' LIKE 'web3:%';"
```

### Step 3: Re-run the reproducer

```bash
cd siwe-repro && go run main.go
```

Output now ends with: `SAME user_id — fix is in place.`

### Step 4: Re-inspect the database

```bash
docker exec auth-postgres-1 psql -U supabase_auth_admin -d postgres -c \
  "SELECT user_id, provider_id FROM auth.identities WHERE provider='web3';"
```

Single row for the wallet, `provider_id` in the lowercase canonical form.

## Automated tests

`internal/utilities/siwe/parser_test.go` (added in this PR):

- `TestParseMessageAddressNormalization` — table-driven test with case-variant inputs; asserts they all produce the same lowercase `Address`. Fails on master, passes after this fix.
- Two pre-existing `TestParseMessage/positive_example_*` cases updated so their expected values use the lowercase form (the parser used to return verbatim case; this is a behavior change in the parser's contract).

Run:

```bash
go test ./internal/utilities/siwe/ -count=1 -v
```

## Verification I ran locally

- `go test ./internal/utilities/siwe/ -count=1` — green
- `go test ./internal/api/ -run TestWeb3 -count=1 -race` — all 15 sub-tests green
- `go test ./... -count=1 -p 1 -race` — full module suite green
- `gofmt -l internal/utilities/siwe/parser.go internal/utilities/siwe/parser_test.go` — empty
- `go vet ./...` — empty
- Live before/after Docker roundtrip per the steps above (captured in PR conversation)

## Operational note (out of scope; flagging for ops follow-up)

This PR prevents NEW duplicate identities from being created. Existing rows with mixed-case `provider_id` for `provider='ethereum'` are not migrated by this PR. Operators that have already accumulated duplicates may want a follow-up data migration along the lines of:

```sql
UPDATE auth.identities
   SET provider_id = lower(provider_id)
 WHERE provider = 'ethereum'
   AND provider_id <> lower(provider_id);
```

Plus a strategy for merging the duplicate user rows the case-variant identities point at. That coordination is outside the scope of a parser-level fix.

## Why not also touch SIWS (Solana)

Solana addresses are base58-encoded and case-sensitive. Lowercasing them would corrupt valid wallet identifiers. The change is intentionally Ethereum-only.