### PR TITLE
fix(api): create email identity when setting password on OAuth-only user

### DIFF
--- a/internal/api/user.go
+++ b/internal/api/user.go
@@ -5,9 +5,11 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/fatih/structs"
 	"github.com/gofrs/uuid"
 	"github.com/sirupsen/logrus"
 	"github.com/supabase/auth/internal/api/apierrors"
+	"github.com/supabase/auth/internal/api/provider"
 	"github.com/supabase/auth/internal/api/sms_provider"
 	"github.com/supabase/auth/internal/mailer"
 	"github.com/supabase/auth/internal/models"
@@ -214,6 +216,30 @@ func (a *API) UserUpdate(w http.ResponseWriter, r *http.Request) error {
 
 			if terr := models.NewAuditLogEntry(config.AuditLog, r, tx, user, models.UserUpdatePasswordAction, "", nil); terr != nil {
 				return terr
+			}
+
+			// If the user has an email but no email identity yet (typically a
+			// user whose only identity is from an external OAuth provider),
+			// setting a password establishes email/password as a sign-in
+			// method. Create the email identity so it shows up in
+			// auth.identities and the email provider is reflected in
+			// app_metadata.providers. See #2085.
+			if user.GetEmail() != "" {
+				if _, terr := models.FindIdentityByIdAndProvider(tx, user.ID.String(), "email"); terr != nil {
+					if !models.IsNotFoundError(terr) {
+						return terr
+					}
+					if _, terr := a.createNewIdentity(tx, user, "email", structs.Map(provider.Claims{
+						Subject:       user.ID.String(),
+						Email:         user.GetEmail(),
+						EmailVerified: user.IsConfirmed(),
+					})); terr != nil {
+						return terr
+					}
+					if terr := user.UpdateAppMetaDataProviders(tx); terr != nil {
+						return terr
+					}
+				}
 			}
 
 			// send a Password Changed email notification to the user to inform them that their password has been changed

--- a/internal/api/user_test.go
+++ b/internal/api/user_test.go
@@ -764,3 +764,74 @@ func (ts *UserTestSuite) TestUserUpdatePasswordSendsNotificationEmail() {
 		})
 	}
 }
+
+// TestUserUpdatePasswordCreatesEmailIdentity covers issue #2085: when a user
+// who only has an external (e.g. OAuth) identity sets a password via
+// PUT /user, an `email` identity row should be created so the email/password
+// sign-in method becomes addressable.
+func (ts *UserTestSuite) TestUserUpdatePasswordCreatesEmailIdentity() {
+	// Create a user with an email but only an external (OAuth-style) identity.
+	u, err := models.NewUser("", "oauth-only@example.com", "", ts.Config.JWT.Aud, nil)
+	require.NoError(ts.T(), err)
+	require.NoError(ts.T(), ts.API.db.Create(u))
+
+	now := time.Now()
+	u.EmailConfirmedAt = &now
+	require.NoError(ts.T(), ts.API.db.UpdateOnly(u, "email_confirmed_at"))
+
+	externalIdentity, err := models.NewIdentity(u, "google", map[string]interface{}{
+		"sub":            "ext-provider-sub-123",
+		"email":          u.GetEmail(),
+		"email_verified": true,
+	})
+	require.NoError(ts.T(), err)
+	require.NoError(ts.T(), ts.API.db.Create(externalIdentity))
+
+	// Sanity check: no email identity yet.
+	_, err = models.FindIdentityByIdAndProvider(ts.API.db, u.ID.String(), "email")
+	require.True(ts.T(), models.IsNotFoundError(err), "expected email identity to be absent before password set")
+
+	token := ts.generateAccessTokenAndSession(u)
+	var buffer bytes.Buffer
+	require.NoError(ts.T(), json.NewEncoder(&buffer).Encode(map[string]interface{}{
+		"password": "newpassword12345",
+	}))
+
+	req := httptest.NewRequest(http.MethodPut, "http://localhost/user", &buffer)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
+
+	w := httptest.NewRecorder()
+	ts.API.handler.ServeHTTP(w, req)
+	require.Equal(ts.T(), http.StatusOK, w.Code)
+
+	emailIdentity, err := models.FindIdentityByIdAndProvider(ts.API.db, u.ID.String(), "email")
+	require.NoError(ts.T(), err, "email identity should be created after PUT /user with password")
+	require.Equal(ts.T(), u.GetEmail(), emailIdentity.Email.String())
+	require.Equal(ts.T(), u.ID.String(), emailIdentity.ProviderID)
+
+	// Calling PUT /user with a password again should not duplicate the
+	// email identity. Supply the current password since the user now has
+	// one set.
+	var buffer2 bytes.Buffer
+	require.NoError(ts.T(), json.NewEncoder(&buffer2).Encode(map[string]interface{}{
+		"password":         "anothernewpassword12345",
+		"current_password": "newpassword12345",
+	}))
+	req2 := httptest.NewRequest(http.MethodPut, "http://localhost/user", &buffer2)
+	req2.Header.Set("Content-Type", "application/json")
+	req2.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
+	w2 := httptest.NewRecorder()
+	ts.API.handler.ServeHTTP(w2, req2)
+	require.Equal(ts.T(), http.StatusOK, w2.Code)
+
+	identities, err := models.FindIdentitiesByUserID(ts.API.db, u.ID)
+	require.NoError(ts.T(), err)
+	emailCount := 0
+	for _, id := range identities {
+		if id.Provider == "email" {
+			emailCount++
+		}
+	}
+	require.Equal(ts.T(), 1, emailCount, "expected exactly one email identity, got %d", emailCount)
+}


### PR DESCRIPTION
## What

Fixes #2085.

When a user whose only existing identity is from an external OAuth provider (custom OIDC, Apple, GitHub, etc.) calls `PUT /user` with a `password` field, `UserUpdate` writes the new password hash to the users table but does not create a corresponding `email` identity row in `auth.identities`. After the call, the user's password works, but `app_metadata.providers` still lists only the external provider, `/user/identities` doesn't show an email identity, and downstream code that gates on identity rows treats the user as not having email/password.

The recovery and email-change flows in `verify.go` already do this correctly via `createNewIdentity(tx, user, "email", ...)` plus `UpdateAppMetaDataProviders`. `UserUpdate` was the missing copy.

## How to reproduce on master (for reviewers)

This needs a user whose only identity is non-email. Easiest way is the custom OIDC flow against a local IdP (Zitadel works), but any OAuth provider will do. Steps:

```bash
# 1. Bring up auth via the dev compose
cd auth
cp example.docker.env .env.docker
# Edit .env.docker: set GOTRUE_JWT_SECRET to a 32+ char value.
make dev
# In another shell:
make migrate_dev
```

Now create an OAuth-only user. The fastest path is the unit-style reproducer below, but anyone with a working OIDC provider can drive this through `/authorize?provider=...` and complete the OAuth dance.

```bash
# Generate a service_role JWT (signed with the same GOTRUE_JWT_SECRET).
JWT_SECRET="..."
NOW=$(date +%s); EXP=$((NOW + 3600))
JWT=$( ... )  # standard HS256 JWT with role=service_role, iat, exp

# Create a user that has an email but only an external identity, mimicking
# what an OAuth provider sign-in would produce.
USER_ID=$(curl -s -X POST http://localhost:9999/admin/users \
  -H "Authorization: Bearer $JWT" -H "Content-Type: application/json" \
  -d '{"email":"oauth-only@example.com","email_confirm":true}' \
  | python3 -c "import json,sys;print(json.load(sys.stdin)['id'])")

# Add an external identity for that user (simulating Apple / Google / custom OIDC).
curl -s -X POST http://localhost:9999/admin/users/$USER_ID/identities \
  -H "Authorization: Bearer $JWT" -H "Content-Type: application/json" \
  -d "{\"provider\":\"google\",\"provider_id\":\"ext-sub-123\",\"identity_data\":{\"sub\":\"ext-sub-123\",\"email\":\"oauth-only@example.com\",\"email_verified\":true}}" || true

# Sign that user in (e.g. via a session-mint admin path or by driving the
# OAuth flow). For evidence in this PR I drove the full custom-OIDC
# roundtrip against a local Zitadel instance and captured the access
# token from the redirect URL fragment.
ACCESS_TOKEN=...

# Inspect identities. Expected: only the external provider is present.
curl -s -H "Authorization: Bearer $ACCESS_TOKEN" http://localhost:9999/user \
  | python3 -c "import json,sys;d=json.load(sys.stdin);print([i['provider'] for i in d.get('identities',[])])"
# => ['google']     (or whatever external provider was used)

# Set a password.
curl -s -X PUT http://localhost:9999/user \
  -H "Authorization: Bearer $ACCESS_TOKEN" -H "Content-Type: application/json" \
  -d '{"password":"NewPassword12345!"}'

# Re-inspect identities. On master: still only the external provider.
curl -s -H "Authorization: Bearer $ACCESS_TOKEN" http://localhost:9999/user \
  | python3 -c "import json,sys;d=json.load(sys.stdin);print([i['provider'] for i in d.get('identities',[])])"
# => ['google']     (BUG: email identity was not created)
```

DB inspection on master:

```sql
SELECT user_id, provider FROM auth.identities WHERE user_id = '<USER_ID>';
-- Returns one row, provider='google'. No email identity.
```

## Live reproduction I ran

Drove the full custom-OIDC flow against a local Zitadel instance configured as a custom OIDC provider in auth, captured the access token, ran the above PUT, and confirmed:

- BEFORE: `identities = ['custom:zitadel']`
- After PUT /user with password (HTTP 200)
- AFTER on master: `identities = ['custom:zitadel']`  ← BUG
- AFTER with this fix: `identities = ['custom:zitadel', 'email']`  ← FIXED

The DB row added by the fix has `provider='email'`, `provider_id=<user.ID>`, `identity_data` containing `sub`, `email`, and `email_verified` mirroring the user record.

## Root cause

`internal/api/user.go::UserUpdate`. After `user.UpdatePassword(tx, sessionID)` succeeds, the function continues with audit log + notification but never creates an email identity. Compare with the recovery and email-change flows in `internal/api/verify.go` which call `createNewIdentity(tx, user, "email", structs.Map(provider.Claims{...}))` on the same condition.

## Fix

In the password-update branch of the transaction in `UserUpdate`, after the audit log and password-changed notification, look up `models.FindIdentityByIdAndProvider(tx, user.ID.String(), "email")`. If the user has an email and no email identity exists, create one via `a.createNewIdentity(tx, user, "email", structs.Map(provider.Claims{...}))` and call `user.UpdateAppMetaDataProviders(tx)` so `app_metadata.providers` reflects the new provider. Idempotent for callers that already have an email identity.

## How to verify the fix manually (for reviewers)

Apply this PR's diff, hot-reload auth (`docker compose -f docker-compose-dev.yml restart auth` or just save the file under CompileDaemon), and re-run the PUT step from the reproduction. The `/user` response now lists the email identity. The DB:

```sql
SELECT user_id, provider FROM auth.identities WHERE user_id = '<USER_ID>';
-- Now two rows: the external provider AND email.
```

## Automated tests

`internal/api/user_test.go` adds `TestUserUpdatePasswordCreatesEmailIdentity`:

- Creates a user with an email but only an external (Google-shaped) identity
- Asserts no email identity exists
- Drives `PUT /user` with `{"password": "..."}`
- Asserts an email identity is created and points at the user
- Drives a second `PUT /user` with `{"password": "...", "current_password": "..."}` and asserts the email identity is not duplicated

Run:

```bash
go test ./internal/api/ -run TestUser/TestUserUpdatePasswordCreatesEmailIdentity -v -count=1
```

Fails on master (`require.NoError` on the post-PUT identity lookup), passes after this fix.

## Verification I ran locally

- `go test ./internal/api/ -run TestUser -v -count=1` — green (existing TestUserUpdatePassword* cases unchanged + new case passes)
- `go test ./... -count=1 -p 1 -race` — full module suite green
- `gofmt -l internal/api/user.go internal/api/user_test.go` — empty
- `go vet ./...` — empty
- Live before/after Docker roundtrip per the steps above

## Notes for review

- Idempotent for users who already have an email identity: the lookup returns one and the create branch is skipped.
- No password change without an email is required: the create branch is gated on `user.GetEmail() != ""`.
- `EmailVerified` on the new identity reflects `user.IsConfirmed()` so an unverified email stays unverified.
- Mirrors the existing pattern in `internal/api/verify.go::recoverVerify` and `emailChangeVerify` so a reader will recognize the shape.