### PR TITLE
chore(utilities): add tests for previously-uncovered helpers

### DIFF
--- a/internal/utilities/context_test.go
+++ b/internal/utilities/context_test.go
@@ -1,0 +1,84 @@
+package utilities
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestContextKeyString(t *testing.T) {
+	require.Equal(t, "gotrue api context key request_id", contextKey("request_id").String())
+	require.Equal(t, "gotrue api context key ", contextKey("").String())
+}
+
+func TestRequestIDRoundtrip(t *testing.T) {
+	t.Run("set then read", func(t *testing.T) {
+		ctx := WithRequestID(context.Background(), "abc-123")
+		require.Equal(t, "abc-123", GetRequestID(ctx))
+	})
+
+	t.Run("missing key returns empty string", func(t *testing.T) {
+		require.Equal(t, "", GetRequestID(context.Background()))
+	})
+
+	t.Run("set replaces previous value", func(t *testing.T) {
+		ctx := WithRequestID(context.Background(), "first")
+		ctx = WithRequestID(ctx, "second")
+		require.Equal(t, "second", GetRequestID(ctx))
+	})
+
+	t.Run("derived context inherits value", func(t *testing.T) {
+		ctx := WithRequestID(context.Background(), "parent-id")
+		child, cancel := context.WithCancel(ctx)
+		defer cancel()
+		require.Equal(t, "parent-id", GetRequestID(child))
+	})
+}
+
+func TestWaitForCleanup(t *testing.T) {
+	t.Run("returns when wait group is done", func(t *testing.T) {
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go func() {
+			time.Sleep(10 * time.Millisecond)
+			wg.Done()
+		}()
+
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			WaitForCleanup(context.Background(), &wg)
+		}()
+
+		select {
+		case <-done:
+		case <-time.After(time.Second):
+			t.Fatal("WaitForCleanup did not return after wg.Done()")
+		}
+	})
+
+	t.Run("returns when context is cancelled before wait group is done", func(t *testing.T) {
+		var wg sync.WaitGroup
+		wg.Add(1)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			WaitForCleanup(ctx, &wg)
+		}()
+
+		cancel()
+
+		select {
+		case <-done:
+		case <-time.After(time.Second):
+			t.Fatal("WaitForCleanup did not return after context cancellation")
+		}
+
+		wg.Done()
+	})
+}

--- a/internal/utilities/io_test.go
+++ b/internal/utilities/io_test.go
@@ -1,0 +1,50 @@
+package utilities
+
+import (
+	"errors"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type closerFunc func() error
+
+func (f closerFunc) Close() error { return f() }
+
+func TestSafeClose(t *testing.T) {
+	tests := []struct {
+		name      string
+		closer    io.Closer
+		closerErr error
+	}{
+		{
+			name:      "happy path: Close returns nil",
+			closerErr: nil,
+		},
+		{
+			name:      "Close returns error: SafeClose must not panic",
+			closerErr: errors.New("close failed"),
+		},
+		{
+			name:   "io.NopCloser: SafeClose must not panic",
+			closer: io.NopCloser(nil),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			closer := tt.closer
+			if closer == nil {
+				called := false
+				closer = closerFunc(func() error {
+					called = true
+					return tt.closerErr
+				})
+				require.NotPanics(t, func() { SafeClose(closer) })
+				require.True(t, called, "Close should have been invoked")
+				return
+			}
+			require.NotPanics(t, func() { SafeClose(closer) })
+		})
+	}
+}

--- a/internal/utilities/strings_test.go
+++ b/internal/utilities/strings_test.go
@@ -1,0 +1,100 @@
+package utilities
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestStringValue(t *testing.T) {
+	empty := ""
+	hello := "hello"
+	tests := []struct {
+		name string
+		in   *string
+		want string
+	}{
+		{
+			name: "nil pointer returns empty string",
+			in:   nil,
+			want: "",
+		},
+		{
+			name: "pointer to empty string returns empty string",
+			in:   &empty,
+			want: "",
+		},
+		{
+			name: "pointer to non-empty string returns the value",
+			in:   &hello,
+			want: "hello",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, StringValue(tt.in))
+		})
+	}
+}
+
+func TestStringPtr(t *testing.T) {
+	tests := []struct {
+		name        string
+		in          string
+		expectNil   bool
+		wantPointee string
+	}{
+		{
+			name:      "empty string returns nil",
+			in:        "",
+			expectNil: true,
+		},
+		{
+			name:        "non-empty string returns pointer to that value",
+			in:          "hello",
+			wantPointee: "hello",
+		},
+		{
+			name:        "string with whitespace and newline preserved",
+			in:          "  hi\nthere  ",
+			wantPointee: "  hi\nthere  ",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := StringPtr(tt.in)
+			if tt.expectNil {
+				require.Nil(t, got)
+				return
+			}
+			require.NotNil(t, got)
+			require.Equal(t, tt.wantPointee, *got)
+		})
+	}
+
+	t.Run("returned pointer is independent of the input variable", func(t *testing.T) {
+		s := "original"
+		p := StringPtr(s)
+		require.Equal(t, "original", *p)
+		s = "mutated"
+		require.Equal(t, "original", *p)
+	})
+}
+
+func TestStringValueAndStringPtrRoundtrip(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+	}{
+		{name: "empty", in: ""},
+		{name: "ascii", in: "hello"},
+		{name: "with spaces", in: "with spaces"},
+		{name: "with newline", in: "with\nnewline"},
+		{name: "multibyte rune", in: "🦄"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.in, StringValue(StringPtr(tt.in)))
+		})
+	}
+}


### PR DESCRIPTION
## What

Adds unit tests for three small files in `internal/utilities/` that had **zero coverage**:

- `strings.go` — `StringValue` and `StringPtr`
- `context.go` — `contextKey.String`, `WithRequestID`, `GetRequestID`, `WaitForCleanup`
- `io.go` — `SafeClose`

## Why

Coverage of `internal/utilities/` was the lowest among utility-style packages in the module:

```
internal/utilities                   50.8%
internal/utilities/siwe              96.2%
internal/utilities/siws              97.2%
internal/utilities/version          100.0%
internal/crypto                      91.2%
internal/conf                        99.1%
```

Each of the helpers covered by this PR is a pure-ish function used widely across the API layer, so a behavior change here would propagate quickly. Locking the contracts in tests makes the next maintenance pass safer without changing any production code.

## Coverage delta

| Package | Before | After |
|---|---|---|
| `internal/utilities` | 50.8% | **62.4%** |

(+11.6 percentage points, no production code touched.)

## What's tested

### `strings.go`
- `StringValue(nil)` and `StringValue(&"")` both return `""`
- `StringValue(&s)` returns `s` for non-empty `s`
- `StringPtr("")` returns `nil`; `StringPtr(s)` returns `*s` for non-empty
- The pointer returned by `StringPtr` is independent of the input variable (defends against future refactors that take the address of a closure-captured variable)
- `StringValue(StringPtr(c)) == c` round-trip across edge cases (empty, ASCII, whitespace, newline, multi-byte rune)

### `context.go`
- `contextKey.String()` formatting (covers both populated and empty key)
- `WithRequestID` / `GetRequestID` round-trip
- `GetRequestID` returns `""` when key absent
- Replacing a previously-set request ID
- Inheritance through `context.WithCancel` (defends the public-API guarantee that derived contexts see the parent value)
- `WaitForCleanup` returns when the wait group completes
- `WaitForCleanup` returns when the context is cancelled, even if the wait group never completes (covers the leak path)

### `io.go`
- `SafeClose` invokes `Close()` on the underlying closer
- `SafeClose` does not panic when `Close()` returns an error
- `SafeClose` does not panic on `io.NopCloser(nil)`

## How to verify (for reviewers)

```bash
go test ./internal/utilities/ -count=1 -v -run 'TestStringValue|TestStringPtr|TestContextKey|TestRequestID|TestWaitForCleanup|TestSafeClose|TestStringValueAndStringPtr'
go test -cover ./internal/utilities/
```

The `-cover` line should report 62.4%.

## Verification I ran locally

- `go test ./internal/utilities/ -count=1 -v` — all new tests pass
- `go test ./... -count=1 -p 1 -race` — full module suite green
- `gofmt -l` on the three new files — empty
- `go vet ./...` — empty

## Notes

- No production source files were touched; this is purely a test addition.
- Naming follows the existing repo convention (`<file>_test.go` per source file).
- `WaitForCleanup` is exercised end-to-end via real goroutines plus `context.WithCancel`, matching how the production callers use it. No mocking of channels.
- I deliberately stopped at "small simple changes" scope: the package's other low-coverage areas (`postgres.go`, `hibpcache.go`, `request.go::GetBodyBytes`) need real Postgres errors / bloom-filter setup / multipart bodies and would each be its own PR.