### PR TITLE
fix: accept code for PKCE token exchange

### DIFF
--- a/internal/api/token.go
+++ b/internal/api/token.go
@@ -30,6 +30,7 @@ type PasswordGrantParams struct {
 // PKCEGrantParams are the parameters the PKCEGrant method accepts
 type PKCEGrantParams struct {
 	AuthCode     string `json:"auth_code"`
+	Code         string `json:"code"`
 	CodeVerifier string `json:"code_verifier"`
 }
 
@@ -227,11 +228,16 @@ func (a *API) PKCE(ctx context.Context, w http.ResponseWriter, r *http.Request) 
 		return err
 	}
 
-	if params.AuthCode == "" || params.CodeVerifier == "" {
+	authCode := params.Code
+	if authCode == "" {
+		authCode = params.AuthCode
+	}
+
+	if authCode == "" || params.CodeVerifier == "" {
 		return apierrors.NewBadRequestError(apierrors.ErrorCodeValidationFailed, "invalid request: both auth code and code verifier should be non-empty")
 	}
 
-	flowState, err := models.FindFlowStateByAuthCode(db, params.AuthCode)
+	flowState, err := models.FindFlowStateByAuthCode(db, authCode)
 	// Sanity check in case user ID was not set properly
 	if models.IsNotFoundError(err) || flowState.UserID == nil {
 		return apierrors.NewNotFoundError(apierrors.ErrorCodeFlowStateNotFound, "invalid flow state, no valid flow state found")

--- a/internal/api/token_test.go
+++ b/internal/api/token_test.go
@@ -620,7 +620,7 @@ func (ts *TokenTestSuite) TestMagicLinkPKCESignIn() {
 	// Extract token and sign in
 	require.NoError(ts.T(), json.NewEncoder(&buffer).Encode(map[string]interface{}{
 		"code_verifier": codeVerifier,
-		"auth_code":     authCode,
+		"code":          authCode,
 	}))
 	req = httptest.NewRequest(http.MethodPost, "http://localhost/token?grant_type=pkce", &buffer)
 	req.Header.Set("Content-Type", "application/json")

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -99,7 +99,7 @@ paths:
                   refresh_token: 4nYUCw0wZR_DNOTSDbSGMQ
               grant_type=pkce:
                 value:
-                  auth_code: 009e5066-fc11-4eca-8c8c-6fd82aa263f2
+                  code: 009e5066-fc11-4eca-8c8c-6fd82aa263f2
                   code_verifier: ktPNXpR65N6JtgzQA8_5HHtH6PBSAahMNoLKRzQEa0Tzgl.vdV~b6lPk004XOd.4lR0inCde.NoQx5K63xPfzL8o7tJAjXncnhw5Niv9ycQ.QRV9JG.y3VapqbgLfIrJ
               web3_solana:
                 value:
@@ -151,9 +151,15 @@ paths:
                   description: If `provider` is `azure` then you can specify any Azure OIDC issuer string here, which will be used for verification.
                 gotrue_meta_security:
                   $ref: "#/components/schemas/GoTrueSecurity"
+                code:
+                  type: string
+                  format: uuid
+                  description: Authorization code returned in the PKCE redirect URL.
                 auth_code:
                   type: string
                   format: uuid
+                  deprecated: true
+                  description: Deprecated alias for `code`.
                 code_verifier:
                   type: string
                 message:


### PR DESCRIPTION
## Summary
- accept the standard `code` field for PKCE token exchange
- keep `auth_code` as a backward-compatible alias
- update OpenAPI examples and mark `auth_code` as deprecated

Fixes #2306.

## Test plan
- `gofmt` on changed Go files
- `git diff --check`
- `go test ./internal/api -run TestToken/TestMagicLinkPKCESignIn -count=1` (fails locally because PostgreSQL is not running on localhost:5432)