### PR TITLE
fix: custom OAuth2 provider returns "missing provider id" when userinfo lacks `sub` field (#2519)

### DIFF
--- a/internal/api/external.go
+++ b/internal/api/external.go
@@ -169,6 +169,7 @@ func (a *API) internalExternalProviderCallback(w http.ResponseWriter, r *http.Re
 	if err != nil {
 		return err
 	}
+
 	userData := data.userData
 
 	if len(userData.Emails) == 0 && !emailOptional {

--- a/internal/api/external.go
+++ b/internal/api/external.go
@@ -169,7 +169,6 @@ func (a *API) internalExternalProviderCallback(w http.ResponseWriter, r *http.Re
 	if err != nil {
 		return err
 	}
-
 	userData := data.userData
 
 	if len(userData.Emails) == 0 && !emailOptional {

--- a/internal/api/provider/custom_oauth.go
+++ b/internal/api/provider/custom_oauth.go
@@ -65,17 +65,45 @@ func (p *CustomOAuthProvider) AuthCodeURL(state string, opts ...oauth2.AuthCodeO
 func (p *CustomOAuthProvider) GetOAuthToken(ctx context.Context, code string, opts ...oauth2.AuthCodeOption) (*oauth2.Token, error) {
 	return p.config.Exchange(ctx, code, opts...)
 }
+func applyAttributeMappingRaw(raw map[string]interface{}, mapping map[string]interface{}) map[string]interface{} {
+	result := make(map[string]interface{})
+	for k, v := range raw {
+		result[k] = v
+	}
+	for targetField, sourceFieldOrValue := range mapping {
+		switch v := sourceFieldOrValue.(type) {
+		case string:
+			// treat as source field name
+			if value, exists := raw[v]; exists {
+				result[targetField] = value
+			}
+		default:
+			// literal value
+			result[targetField] = v
+		}
+	}
+	return result
+}
 
 // GetUserData fetches user data from the provider's userinfo endpoint
 func (p *CustomOAuthProvider) GetUserData(ctx context.Context, tok *oauth2.Token) (*UserProvidedData, error) {
 	var claims Claims
-	if err := makeRequest(ctx, tok, p.config, p.userinfoURL, &claims); err != nil {
+
+	// Capture raw userinfo for attribute mapping
+	var rawUserinfo map[string]interface{}
+	if err := makeRequest(ctx, tok, p.config, p.userinfoURL, &rawUserinfo); err != nil {
 		return nil, err
 	}
 
-	// Apply attribute mapping if configured
+	// Apply attribute mapping on RAW data BEFORE converting to Claims
 	if len(p.attributeMapping) > 0 {
-		claims = applyAttributeMapping(claims, p.attributeMapping)
+		rawUserinfo = applyAttributeMappingRaw(rawUserinfo, p.attributeMapping)
+	}
+
+	// Now convert to Claims struct
+	rawBytes, _ := json.Marshal(rawUserinfo)
+	if err := json.Unmarshal(rawBytes, &claims); err != nil {
+		return nil, err
 	}
 
 	// Extract emails

--- a/internal/models/identity.go
+++ b/internal/models/identity.go
@@ -41,6 +41,9 @@ func (i *Identity) GetEmail() string {
 func NewIdentity(user *User, provider string, identityData map[string]interface{}) (*Identity, error) {
 	providerId, ok := identityData["sub"]
 	if !ok {
+		providerId, ok = identityData["id"]
+	}
+	if !ok || providerId == nil {
 		return nil, errors.New("error missing provider id")
 	}
 	now := time.Now()

--- a/internal/utilities/url_validator.go
+++ b/internal/utilities/url_validator.go
@@ -48,7 +48,6 @@ func ValidateOAuthURL(urlStr string) error {
 			"URL cannot point to localhost or loopback addresses",
 		)
 	}
-
 	// Resolve hostname to IP addresses
 	ips, err := net.LookupIP(hostname)
 	if err != nil {

--- a/internal/utilities/url_validator.go
+++ b/internal/utilities/url_validator.go
@@ -48,6 +48,7 @@ func ValidateOAuthURL(urlStr string) error {
 			"URL cannot point to localhost or loopback addresses",
 		)
 	}
+
 	// Resolve hostname to IP addresses
 	ips, err := net.LookupIP(hostname)
 	if err != nil {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix #2519 

## What is the current behavior?

When using a custom OAuth2 provider whose userinfo endpoint returns id instead of sub, the authentication flow fails with:
error=server_error
error_description=error missing provider id
This happens even when attribute_mapping: { "sub": "id" } is configured, because the mapping is applied after the raw userinfo JSON has already been unmarshaled into the Claims struct — at which point any field not present in Claims (like id) has already been silently dropped.
Additionally, NewIdentity in identity.go only looks for sub in identityData with no fallback, making it fragile for any non-OIDC provider.

## What is the new behavior?

1).applyAttributeMapping now runs on the raw userinfo JSON before conversion to Claims, so provider-specific fields like id are preserved and correctly remapped to sub

2).NewIdentity now falls back to identityData["id"] if identityData["sub"] is not present, making it more resilient to non-OIDC providers

## Additional context

Files changed:

1).internal/api/provider/custom_oauth.go — apply attribute mapping on raw JSON before Claims conversion, add applyAttributeMappingRaw helper

2).internal/models/identity.go — add id fallback in NewIdentity
