### PR TITLE
fix: catch cancelation errors in bg workers & servers

### DIFF
--- a/cmd/serve_cmd.go
+++ b/cmd/serve_cmd.go
@@ -93,11 +93,11 @@ func serve(ctx context.Context) {
 
 		var err error
 		defer func() {
-			logFn := wrkLog.Info
-			if err != nil {
-				logFn = wrkLog.WithError(err).Error
+			exitFn := wrkLog.Info
+			if err != nil && !errors.Is(err, context.Canceled) {
+				exitFn = wrkLog.WithError(err).Error
 			}
-			logFn("background apiworker is exiting")
+			exitFn("background apiworker is exiting")
 		}()
 
 		// Work exits when ctx is done as in-flight requests do not depend
@@ -125,7 +125,7 @@ func serve(ctx context.Context) {
 			var err error
 			defer func() {
 				exitFn := le.Info
-				if err != nil {
+				if err != nil && !errors.Is(err, context.Canceled) {
 					exitFn = le.WithError(err).Error
 				}
 				exitFn("config reloader is exiting")
@@ -162,9 +162,7 @@ func serve(ctx context.Context) {
 			}
 
 			rl := reloader.NewReloader(rc, watchDir)
-			if err = rl.Watch(ctx, fn); err != nil {
-				log.WithError(err).Error("config reloader is exiting")
-			}
+			err = rl.Watch(ctx, fn)
 		}()
 	}
 

--- a/internal/observability/metrics.go
+++ b/internal/observability/metrics.go
@@ -2,6 +2,7 @@ package observability
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -69,17 +70,17 @@ func enablePrometheusMetrics(ctx context.Context, mc *conf.MetricsConfig) error 
 			shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 5*time.Second)
 			defer shutdownCancel()
 
-			if err := server.Shutdown(shutdownCtx); err != nil {
+			if err := server.Shutdown(shutdownCtx); err != nil && !errors.Is(err, context.Canceled) {
 				logrus.WithError(err).Errorf("prometheus server (%s) failed to gracefully shut down", addr)
 			}
 		}()
 
 		logrus.Infof("prometheus server listening on %s", addr)
 
-		if err := server.ListenAndServe(); err != nil {
-			logrus.WithError(err).Errorf("prometheus server (%s) shut down", addr)
-		} else {
+		if err := server.ListenAndServe(); errors.Is(err, http.ErrServerClosed) {
 			logrus.Info("prometheus metric exporter shut down")
+		} else {
+			logrus.WithError(err).Errorf("prometheus server (%s) shut down", addr)
 		}
 	}()
 


### PR DESCRIPTION
Check for context.ErrCanceled & http.ErrClosed.