### PR TITLE
fix(admin): generate_link: Return correct token for "email_change_new" link

### DIFF
--- a/internal/api/mail.go
+++ b/internal/api/mail.go
@@ -258,7 +258,8 @@ func (a *API) adminGenerateLink(w http.ResponseWriter, r *http.Request) error {
 			if params.Type == "email_change_current" {
 				user.EmailChangeTokenCurrent = hashedToken
 			} else if params.Type == "email_change_new" {
-				user.EmailChangeTokenNew = crypto.GenerateTokenHash(params.NewEmail, otp)
+				hashedToken = crypto.GenerateTokenHash(params.NewEmail, otp)
+				user.EmailChangeTokenNew = hashedToken
 			}
 			terr = tx.UpdateOnly(user, "email_change_token_current", "email_change_token_new", "email_change", "email_change_sent_at", "email_change_confirm_status")
 			if terr != nil {

--- a/internal/api/mail_test.go
+++ b/internal/api/mail_test.go
@@ -237,7 +237,11 @@ func (ts *MailTestSuite) TestGenerateLink() {
 			require.Equal(ts.T(), c.ExpectedResponse["redirect_to"], data["redirect_to"])
 
 			// check if hashed_token matches hash function of email and the raw otp
-			require.Equal(ts.T(), crypto.GenerateTokenHash(c.Body.Email, data["email_otp"].(string)), data["hashed_token"])
+			if c.Body.Type == "email_change_new" {
+				require.Equal(ts.T(), crypto.GenerateTokenHash(c.Body.NewEmail, data["email_otp"].(string)), data["hashed_token"])
+			} else {
+				require.Equal(ts.T(), crypto.GenerateTokenHash(c.Body.Email, data["email_otp"].(string)), data["hashed_token"])
+			}
 
 			// check if the host used in the email link matches the initial request host
 			u, err := url.ParseRequestURI(data["action_link"].(string))


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix.

## What is the current behavior?

I attempted to use the `hashed_token` returned in the `/admin/generate_link` response to verify the email change, however it appears that the token returned is invalid since it references the previous email instead of the new one.

## What is the new behavior?

The newly constructed token is returned in the response instead.

## Additional context

N/A.