### PR TITLE
fix: add pending_password_set claim for invite/recovery sessions

### DIFF
--- a/internal/api/user.go
+++ b/internal/api/user.go
@@ -92,6 +92,13 @@ func (a *API) UserUpdate(w http.ResponseWriter, r *http.Request) error {
 
 	user := getUser(ctx)
 	session := getSession(ctx)
+	claims := getClaims(ctx)
+
+	if claims != nil && claims.PendingPasswordSet {
+		if params.Email != "" || params.Phone != "" || params.Data != nil || params.AppData != nil {
+			return apierrors.NewForbiddenError(apierrors.ErrorCodeUserNotAllowed, "Session requires password to be set before updating other fields")
+		}
+	}
 
 	if err := a.validateUserUpdateParams(ctx, params); err != nil {
 		return err

--- a/internal/tokens/service.go
+++ b/internal/tokens/service.go
@@ -81,6 +81,7 @@ type AccessTokenClaims struct {
 	AuthenticationMethodReference AMRClaim               `json:"amr,omitempty"`
 	SessionId                     string                 `json:"session_id,omitempty"`
 	IsAnonymous                   bool                   `json:"is_anonymous"`
+	PendingPasswordSet            bool                   `json:"pending_password_set,omitempty"`
 	ClientID                      string                 `json:"client_id,omitempty"`
 	Scope                         string                 `json:"scope,omitempty"`
 }
@@ -696,6 +697,10 @@ func (s *Service) GenerateAccessToken(r *http.Request, tx *storage.Connection, p
 		scopes = *session.Scopes
 	}
 
+	userHasPassword := params.User.HasPassword()
+	isPendingPasswordSet := session.IsRecovery() ||
+		(!userHasPassword && params.User.InvitedAt != nil)
+
 	claims := &v0hooks.AccessTokenClaims{
 		RegisteredClaims: jwt.RegisteredClaims{
 			Subject:   params.User.ID.String(),
@@ -713,6 +718,7 @@ func (s *Service) GenerateAccessToken(r *http.Request, tx *storage.Connection, p
 		AuthenticatorAssuranceLevel:   aal.String(),
 		AuthenticationMethodReference: amr,
 		IsAnonymous:                   params.User.IsAnonymous,
+		PendingPasswordSet:            isPendingPasswordSet,
 		ClientID:                      clientID,
 		Scope:                         scopes,
 	}

--- a/internal/tokens/service.go
+++ b/internal/tokens/service.go
@@ -81,6 +81,7 @@ type AccessTokenClaims struct {
 	AuthenticationMethodReference AMRClaim               `json:"amr,omitempty"`
 	SessionId                     string                 `json:"session_id,omitempty"`
 	IsAnonymous                   bool                   `json:"is_anonymous"`
+	PendingPasswordSet            bool                   `json:"pending_password_set,omitempty"`
 	ClientID                      string                 `json:"client_id,omitempty"`
 	Scope                         string                 `json:"scope,omitempty"`
 }
@@ -694,6 +695,10 @@ func (s *Service) GenerateAccessToken(r *http.Request, tx *storage.Connection, p
 		scopes = *session.Scopes
 	}
 
+	userHasPassword := params.User.HasPassword()
+	isPendingPasswordSet := session.IsRecovery() ||
+		(!userHasPassword && params.User.InvitedAt != nil)
+
 	claims := &v0hooks.AccessTokenClaims{
 		RegisteredClaims: jwt.RegisteredClaims{
 			Subject:   params.User.ID.String(),
@@ -711,6 +716,7 @@ func (s *Service) GenerateAccessToken(r *http.Request, tx *storage.Connection, p
 		AuthenticatorAssuranceLevel:   aal.String(),
 		AuthenticationMethodReference: amr,
 		IsAnonymous:                   params.User.IsAnonymous,
+		PendingPasswordSet:            isPendingPasswordSet,
 		ClientID:                      clientID,
 		Scope:                         scopes,
 	}


### PR DESCRIPTION
## Changes

Adds a \pending_password_set\ claim to JWT tokens for sessions created via invite or recovery flows before the user sets their password.

- **\	okens/service.go\**: Added \PendingPasswordSet bool\ to \AccessTokenClaims\. In \GenerateAccessToken()\, sets \PendingPasswordSet = true\ when the session is a recovery session or when the user has no password and was invited.
- **\pi/user.go\**: In \UserUpdate()\, checks \claims.PendingPasswordSet\ and rejects updates to email, phone, data, or app_metadata until the password is set.

## Rationale

When a user is invited or goes through password recovery, the session is created via OTP/recovery verification. Before the password is set, this session should be restricted — only password updates should be allowed. RLS policies can also use the \pending_password_set\ claim to restrict data access.

Fixes #45210