### PR TITLE
fix(config): honour --config-dir in all subcommands via conf.Load

### DIFF
--- a/cmd/root_cmd.go
+++ b/cmd/root_cmd.go
@@ -35,10 +35,7 @@ func loadGlobalConfig(ctx context.Context) *conf.GlobalConfiguration {
 		panic("context must not be nil")
 	}
 
-	config, err := conf.LoadGlobal(configFile)
-	if err != nil {
-		logrus.Fatalf("Failed to load configuration: %+v", err)
-	}
+	config := conf.Load(configFile, watchDir)
 
 	if err := observability.ConfigureLogging(&config.Logging); err != nil {
 		logrus.WithError(err).Error("unable to configure logging")

--- a/cmd/serve_cmd.go
+++ b/cmd/serve_cmd.go
@@ -32,18 +32,7 @@ var serveCmd = cobra.Command{
 }
 
 func serve(ctx context.Context) {
-	if err := conf.LoadFile(configFile); err != nil {
-		logrus.WithError(err).Fatal("unable to load config")
-	}
-
-	if err := conf.LoadDirectory(watchDir); err != nil {
-		logrus.WithError(err).Error("unable to load config from watch dir")
-	}
-
-	config, err := conf.LoadGlobalFromEnv()
-	if err != nil {
-		logrus.WithError(err).Fatal("unable to load config")
-	}
+	config := conf.Load(configFile, watchDir)
 
 	// Include serve ctx which carries cancelation signals so DialContext does
 	// not hang indefinitely at startup.

--- a/internal/conf/configuration.go
+++ b/internal/conf/configuration.go
@@ -934,6 +934,28 @@ func (e *ExtensibilityPointConfiguration) PopulateExtensibilityPoint() error {
 	return nil
 }
 
+// Load applies the standard load sequence used by all gotrue subcommands:
+//
+//  1. configFile — base -c/--config file (godotenv.Overload; godotenv.Load when empty)
+//  2. configDir  — sorted *.env overlays from -d/--config-dir
+//  3. envconfig.Process into a *GlobalConfiguration
+//
+// Hard errors (bad configFile, failed envconfig processing) are fatal.
+// Errors from configDir are logged at Error level but non-fatal.
+func Load(configFile, configDir string) *GlobalConfiguration {
+	if err := LoadFile(configFile); err != nil {
+		logrus.WithError(err).Fatal("unable to load config")
+	}
+	if err := LoadDirectory(configDir); err != nil {
+		logrus.WithError(err).Error("unable to load config from watch dir")
+	}
+	config, err := LoadGlobalFromEnv()
+	if err != nil {
+		logrus.WithError(err).Fatal("unable to load config")
+	}
+	return config
+}
+
 // LoadFile calls godotenv.Load() when the given filename is empty ignoring any
 // errors loading, otherwise it calls godotenv.Overload(filename).
 //


### PR DESCRIPTION
Previously loadGlobalConfig (used by migrate and admin) called
conf.LoadGlobal which only loaded the -c/--config file and ignored
-d/--config-dir, causing required keys like API_EXTERNAL_URL to be
missing when supplied only via --config-dir.

Introduce conf.Load(configFile, configDir) which encapsulates the full
three-step load sequence (LoadFile → LoadDirectory → LoadGlobalFromEnv)
used consistently by every subcommand. Both serve and loadGlobalConfig
now call conf.Load, eliminating the duplication and the bug.
