### PR TITLE
feat: add -failfast to make test command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,7 +112,7 @@ migrate_test: ## Run database migrations for test.
 	hack/migrate.sh postgres
 
 test: auth ## Run tests.
-	go test $(CHECK_FILES) -coverprofile=coverage.out -coverpkg ./... -p 1 -race -v -count=1
+	go test -failfast $(CHECK_FILES) -coverprofile=coverage.out -coverpkg ./... -p 1 -race -v -count=1
 	./hack/coverage.sh
 
 vet: # Vet the code


### PR DESCRIPTION
When builds fail you don't get feedback until all tests finish running. In addtion it is also difficult to find which line failed, even if you know what to search for.

Adding -testfail in the Makefile test target addresses causes tests to stop on the first failure.