### PR TITLE
fix: check session state for admin tokens

### DIFF
--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -195,6 +195,31 @@ func (a *API) requireAdminCredentials(w http.ResponseWriter, req *http.Request) 
 		return nil, err
 	}
 
+	// If the token references a real user session, confirm the session
+	// still exists and is valid in the DB — a JWT remains usable past
+	// logout or revocation otherwise. Sessionless admin tokens (e.g.
+	// service_role) skip this check.
+	claims := getClaims(ctx)
+	if claims != nil && claims.SessionId != "" && claims.SessionId != uuid.Nil.String() {
+		ctx, err = a.maybeLoadUserOrSession(ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		session := getSession(ctx)
+		user := getUser(ctx)
+		if session != nil && user != nil {
+			validity := session.CheckValidity(models.SessionValidityConfig{
+				Timebox:           a.config.Sessions.Timebox,
+				InactivityTimeout: a.config.Sessions.InactivityTimeout,
+				AllowLowAAL:       a.config.Sessions.AllowLowAAL,
+			}, time.Now(), nil, user.HighestPossibleAAL())
+			if validity != models.SessionValid {
+				return nil, apierrors.NewForbiddenError(apierrors.ErrorCodeSessionExpired, "Session is no longer valid")
+			}
+		}
+	}
+
 	return a.requireAdmin(ctx)
 }
 

--- a/internal/api/middleware_test.go
+++ b/internal/api/middleware_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/didip/tollbooth/v5"
 	"github.com/didip/tollbooth/v5/limiter"
+	"github.com/gofrs/uuid"
 	jwt "github.com/golang-jwt/jwt/v5"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -19,6 +20,7 @@ import (
 	"github.com/stretchr/testify/suite"
 	"github.com/supabase/auth/internal/api/apierrors"
 	"github.com/supabase/auth/internal/conf"
+	"github.com/supabase/auth/internal/models"
 	"github.com/supabase/auth/internal/sbff"
 	"github.com/supabase/auth/internal/security"
 	"github.com/supabase/auth/internal/storage"
@@ -830,4 +832,116 @@ func (ts *MiddlewareTestSuite) TestDatabaseCleanup() {
 		})
 	}
 	mockCleanup.AssertNumberOfCalls(ts.T(), "Clean", 1)
+}
+
+func (ts *MiddlewareTestSuite) TestRequireAdminCredentialsSessionCheck() {
+	models.TruncateAll(ts.API.db)
+
+	user, err := models.NewUser("", "admin-session@example.com", "password", ts.Config.JWT.Aud, nil)
+	require.NoError(ts.T(), err)
+	require.NoError(ts.T(), ts.API.db.Create(user))
+
+	session, err := models.NewSession(user.ID, nil)
+	require.NoError(ts.T(), err)
+	require.NoError(ts.T(), ts.API.db.Create(session))
+
+	signClaims := func(claims *AccessTokenClaims) string {
+		signed, err := jwt.NewWithClaims(jwt.SigningMethodHS256, claims).SignedString([]byte(ts.Config.JWT.Secret))
+		require.NoError(ts.T(), err)
+		return signed
+	}
+
+	newRequest := func(token string) *http.Request {
+		req := httptest.NewRequest(http.MethodGet, "http://localhost", nil)
+		req.Header.Set("Authorization", "Bearer "+token)
+		return req
+	}
+
+	ts.Run("admin token with valid session is accepted", func() {
+		token := signClaims(&AccessTokenClaims{
+			Role:      "supabase_admin",
+			SessionId: session.ID.String(),
+			RegisteredClaims: jwt.RegisteredClaims{
+				Subject:   user.ID.String(),
+				ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour)),
+			},
+		})
+
+		_, err := ts.API.requireAdminCredentials(httptest.NewRecorder(), newRequest(token))
+		require.NoError(ts.T(), err)
+	})
+
+	ts.Run("admin token whose session was revoked is rejected", func() {
+		token := signClaims(&AccessTokenClaims{
+			Role:      "supabase_admin",
+			SessionId: session.ID.String(),
+			RegisteredClaims: jwt.RegisteredClaims{
+				Subject:   user.ID.String(),
+				ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour)),
+			},
+		})
+		require.NoError(ts.T(), models.LogoutSession(ts.API.db, session.ID))
+
+		_, err := ts.API.requireAdminCredentials(httptest.NewRecorder(), newRequest(token))
+		require.Error(ts.T(), err)
+		httpErr, ok := err.(*HTTPError)
+		require.True(ts.T(), ok, "expected HTTPError, got %T", err)
+		require.Equal(ts.T(), apierrors.ErrorCodeSessionNotFound, httpErr.ErrorCode)
+	})
+
+	ts.Run("admin token past session timebox is rejected", func() {
+		freshSession, err := models.NewSession(user.ID, nil)
+		require.NoError(ts.T(), err)
+		require.NoError(ts.T(), ts.API.db.Create(freshSession))
+
+		// Backdate the session past the timebox.
+		freshSession.CreatedAt = time.Now().Add(-48 * time.Hour)
+		require.NoError(ts.T(), ts.API.db.Update(freshSession))
+
+		timebox := time.Hour
+		original := ts.Config.Sessions.Timebox
+		ts.Config.Sessions.Timebox = &timebox
+		defer func() { ts.Config.Sessions.Timebox = original }()
+
+		token := signClaims(&AccessTokenClaims{
+			Role:      "supabase_admin",
+			SessionId: freshSession.ID.String(),
+			RegisteredClaims: jwt.RegisteredClaims{
+				Subject:   user.ID.String(),
+				ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour)),
+			},
+		})
+
+		_, err = ts.API.requireAdminCredentials(httptest.NewRecorder(), newRequest(token))
+		require.Error(ts.T(), err)
+		httpErr, ok := err.(*HTTPError)
+		require.True(ts.T(), ok, "expected HTTPError, got %T", err)
+		require.Equal(ts.T(), apierrors.ErrorCodeSessionExpired, httpErr.ErrorCode)
+	})
+
+	ts.Run("sessionless service_role token still passes", func() {
+		token := signClaims(&AccessTokenClaims{
+			Role: "service_role",
+			RegisteredClaims: jwt.RegisteredClaims{
+				ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour)),
+			},
+		})
+
+		_, err := ts.API.requireAdminCredentials(httptest.NewRecorder(), newRequest(token))
+		require.NoError(ts.T(), err)
+	})
+
+	ts.Run("admin token with nil-uuid session_id passes (treated as sessionless)", func() {
+		token := signClaims(&AccessTokenClaims{
+			Role:      "supabase_admin",
+			SessionId: uuid.Nil.String(),
+			RegisteredClaims: jwt.RegisteredClaims{
+				Subject:   user.ID.String(),
+				ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour)),
+			},
+		})
+
+		_, err := ts.API.requireAdminCredentials(httptest.NewRecorder(), newRequest(token))
+		require.NoError(ts.T(), err)
+	})
 }

--- a/internal/api/middleware_test.go
+++ b/internal/api/middleware_test.go
@@ -894,9 +894,12 @@ func (ts *MiddlewareTestSuite) TestRequireAdminCredentialsSessionCheck() {
 		require.NoError(ts.T(), err)
 		require.NoError(ts.T(), ts.API.db.Create(freshSession))
 
-		// Backdate the session past the timebox.
-		freshSession.CreatedAt = time.Now().Add(-48 * time.Hour)
-		require.NoError(ts.T(), ts.API.db.Update(freshSession))
+		// Backdate the session past the timebox — pop manages created_at
+		// automatically on Update, so go through raw SQL.
+		require.NoError(ts.T(), ts.API.db.RawQuery(
+			"UPDATE auth.sessions SET created_at = ? WHERE id = ?",
+			time.Now().Add(-48*time.Hour), freshSession.ID,
+		).Exec())
 
 		timebox := time.Hour
 		original := ts.Config.Sessions.Timebox


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Middleware validates the session token has not expired.

## What is the new behavior?

Validates the token has not expired and that the session has not been revoked.

## Additional context

Middleware checks for admin tokens should validate that the session is still live. JWTs may be revoked but stay valid until the expiry time.
