### PR TITLE
chore: bump Go to 1.25.11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.10-alpine3.23 as build
+FROM golang:1.25.11-alpine3.23 as build
 ENV GO111MODULE=on
 ENV CGO_ENABLED=0
 ENV GOOS=linux

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM golang:1.25.10-alpine3.23
+FROM golang:1.25.11-alpine3.23
 ENV GO111MODULE=on
 ENV CGO_ENABLED=0
 ENV GOOS=linux

--- a/go.mod
+++ b/go.mod
@@ -171,4 +171,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-go 1.25.10
+go 1.25.11

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/supabase/auth/tools
 
-go 1.25.10
+go 1.25.11
 
 tool (
 	github.com/securego/gosec/v2/cmd/gosec


### PR DESCRIPTION
Bump Go version to 1.25.11 to address [recent govulncheck findings](https://github.com/supabase/auth/actions/runs/26885088010/job/79294993111) 