### PR TITLE
fix(passkeys): enforce AAL checks on passkey registration and deletion

### DIFF
--- a/internal/api/passkey_manage.go
+++ b/internal/api/passkey_manage.go
@@ -112,7 +112,12 @@ func (a *API) PasskeyDelete(w http.ResponseWriter, r *http.Request) error {
 	ctx := r.Context()
 	config := a.config
 	user := getUser(ctx)
+	session := getSession(ctx)
 	db := a.db.WithContext(ctx)
+
+	if err := requirePasskeyManagementAAL(user, session); err != nil {
+		return err
+	}
 
 	passkeyID, err := uuid.FromString(chi.URLParam(r, "passkey_id"))
 	if err != nil {

--- a/internal/api/passkey_manage_test.go
+++ b/internal/api/passkey_manage_test.go
@@ -238,6 +238,41 @@ func (ts *PasskeyTestSuite) TestPasskeyDeleteUnauthenticated() {
 	ts.Equal(http.StatusUnauthorized, w.Code)
 }
 
+// TestPasskeyDeleteBlockedAtAAL1WhenMFAEnabled verifies that a user enrolled in a
+// verified MFA factor cannot delete a passkey from an AAL1 session.
+func (ts *PasskeyTestSuite) TestPasskeyDeleteBlockedAtAAL1WhenMFAEnabled() {
+	ts.enrollVerifiedFactor(ts.TestUser)
+	cred := ts.createTestPasskey(ts.TestUser.ID, "Protected")
+
+	token := ts.generateToken(ts.TestUser, &ts.TestSession.ID)
+	w := ts.makeRequest(http.MethodDelete, fmt.Sprintf("http://localhost/passkeys/%s", cred.ID), nil, withBearerToken(token))
+
+	ts.Equal(http.StatusForbidden, w.Code)
+	var errResp map[string]any
+	require.NoError(ts.T(), json.NewDecoder(w.Body).Decode(&errResp))
+	ts.Equal("insufficient_aal", errResp["error_code"])
+
+	// The passkey must still exist.
+	_, err := models.FindWebAuthnCredentialByID(ts.API.db, cred.ID)
+	require.NoError(ts.T(), err)
+}
+
+// TestPasskeyDeleteAllowedAtAAL2WhenMFAEnabled verifies that a user with a verified
+// MFA factor who has stepped up to AAL2 can delete a passkey.
+func (ts *PasskeyTestSuite) TestPasskeyDeleteAllowedAtAAL2WhenMFAEnabled() {
+	f := ts.enrollVerifiedFactor(ts.TestUser)
+	ts.elevateSessionToAAL2(ts.TestSession, f.ID)
+	cred := ts.createTestPasskey(ts.TestUser.ID, "To Delete")
+
+	token := ts.generateToken(ts.TestUser, &ts.TestSession.ID)
+	w := ts.makeRequest(http.MethodDelete, fmt.Sprintf("http://localhost/passkeys/%s", cred.ID), nil, withBearerToken(token))
+
+	ts.Equal(http.StatusNoContent, w.Code)
+
+	_, err := models.FindWebAuthnCredentialByID(ts.API.db, cred.ID)
+	ts.True(models.IsNotFoundError(err))
+}
+
 func (ts *PasskeyTestSuite) TestPasskeyManageDisabled() {
 	ts.Config.Passkey.Enabled = false
 	token := ts.generateToken(ts.TestUser, &ts.TestSession.ID)

--- a/internal/api/passkey_registration.go
+++ b/internal/api/passkey_registration.go
@@ -43,10 +43,15 @@ func (a *API) PasskeyRegistrationOptions(w http.ResponseWriter, r *http.Request)
 	ctx := r.Context()
 	config := a.config
 	user := getUser(ctx)
+	session := getSession(ctx)
 	db := a.db.WithContext(ctx)
 
 	if user.IsSSOUser {
 		return apierrors.NewUnprocessableEntityError(apierrors.ErrorCodeValidationFailed, "SSO users cannot register passkeys")
+	}
+
+	if err := requirePasskeyManagementAAL(user, session); err != nil {
+		return err
 	}
 
 	// Check passkey limit
@@ -78,7 +83,7 @@ func (a *API) PasskeyRegistrationOptions(w http.ResponseWriter, r *http.Request)
 	}
 
 	webAuthnUser := newWebAuthnUser(user, existingCreds)
-	options, session, err := webAuthn.BeginRegistration(webAuthnUser, webauthn.WithExclusions(excludeList))
+	options, webAuthnSessionData, err := webAuthn.BeginRegistration(webAuthnUser, webauthn.WithExclusions(excludeList))
 	if err != nil {
 		return apierrors.NewInternalServerError("Failed to generate WebAuthn registration options").WithInternalError(err)
 	}
@@ -87,7 +92,7 @@ func (a *API) PasskeyRegistrationOptions(w http.ResponseWriter, r *http.Request)
 	challenge := models.NewWebAuthnChallenge(
 		&user.ID,
 		models.WebAuthnChallengeTypeRegistration,
-		&models.WebAuthnSessionData{SessionData: session},
+		&models.WebAuthnSessionData{SessionData: webAuthnSessionData},
 		expiresAt,
 	)
 
@@ -108,10 +113,15 @@ func (a *API) PasskeyRegistrationVerify(w http.ResponseWriter, r *http.Request) 
 	ctx := r.Context()
 	config := a.config
 	user := getUser(ctx)
+	session := getSession(ctx)
 	db := a.db.WithContext(ctx)
 
 	if user.IsSSOUser {
 		return apierrors.NewUnprocessableEntityError(apierrors.ErrorCodeValidationFailed, "SSO users cannot register passkeys")
+	}
+
+	if err := requirePasskeyManagementAAL(user, session); err != nil {
+		return err
 	}
 
 	params := &PasskeyRegistrationVerifyParams{}

--- a/internal/api/passkey_registration_test.go
+++ b/internal/api/passkey_registration_test.go
@@ -364,3 +364,83 @@ func (ts *PasskeyTestSuite) TestRegisterVerifySSOUser() {
 
 	ts.Equal(http.StatusUnprocessableEntity, w.Code)
 }
+
+// TestRegistrationOptionsBlockedAtAAL1WhenMFAEnabled verifies that a user enrolled
+// in a verified MFA factor cannot get registration options from an AAL1 session.
+func (ts *PasskeyTestSuite) TestRegistrationOptionsBlockedAtAAL1WhenMFAEnabled() {
+	ts.enrollVerifiedFactor(ts.TestUser)
+
+	token := ts.generateToken(ts.TestUser, &ts.TestSession.ID)
+	w := ts.makeRequest(http.MethodPost, "http://localhost/passkeys/registration/options", nil, withBearerToken(token))
+
+	ts.Equal(http.StatusForbidden, w.Code)
+	var errResp map[string]any
+	require.NoError(ts.T(), json.NewDecoder(w.Body).Decode(&errResp))
+	ts.Equal("insufficient_aal", errResp["error_code"])
+}
+
+// TestRegistrationVerifyBlockedAtAAL1WhenMFAEnabled verifies that the AAL2 gate on
+// verify runs before the registration challenge is consumed, so a blocked request
+// leaves the challenge intact.
+func (ts *PasskeyTestSuite) TestRegistrationVerifyBlockedAtAAL1WhenMFAEnabled() {
+	ts.enrollVerifiedFactor(ts.TestUser)
+
+	challenge := models.NewWebAuthnChallenge(
+		&ts.TestUser.ID,
+		models.WebAuthnChallengeTypeRegistration,
+		dummySessionData(),
+		time.Now().Add(5*time.Minute),
+	)
+	require.NoError(ts.T(), ts.API.db.Create(challenge))
+
+	token := ts.generateToken(ts.TestUser, &ts.TestSession.ID)
+	w := ts.makeRequest(http.MethodPost, "http://localhost/passkeys/registration/verify", map[string]any{
+		"challenge_id": challenge.ID.String(),
+		"credential":   map[string]any{},
+	}, withBearerToken(token))
+
+	ts.Equal(http.StatusForbidden, w.Code)
+	var errResp map[string]any
+	require.NoError(ts.T(), json.NewDecoder(w.Body).Decode(&errResp))
+	ts.Equal("insufficient_aal", errResp["error_code"])
+
+	// The challenge must not have been consumed by a request that failed the gate.
+	_, err := models.FindWebAuthnChallengeByID(ts.API.db, challenge.ID)
+	require.NoError(ts.T(), err)
+}
+
+// TestRegisterPasskeyAAL2HappyPathWhenMFAEnabled verifies that a user with a
+// verified MFA factor who has stepped up to AAL2 can still register a passkey
+// end-to-end (both the options and verify endpoints pass the gate).
+func (ts *PasskeyTestSuite) TestRegisterPasskeyAAL2HappyPathWhenMFAEnabled() {
+	f := ts.enrollVerifiedFactor(ts.TestUser)
+	ts.elevateSessionToAAL2(ts.TestSession, f.ID)
+
+	token := ts.generateToken(ts.TestUser, &ts.TestSession.ID)
+
+	// Step 1: options succeed at AAL2
+	w := ts.makeRequest(http.MethodPost, "http://localhost/passkeys/registration/options", nil, withBearerToken(token))
+	ts.Require().Equal(http.StatusOK, w.Code)
+
+	var optionsResp PasskeyRegistrationOptionsResponse
+	require.NoError(ts.T(), json.NewDecoder(w.Body).Decode(&optionsResp))
+
+	// Step 2: simulate the authenticator creating a credential
+	authenticator := &virtualAuthenticator{
+		rpID:   ts.Config.WebAuthn.RPID,
+		origin: ts.Config.WebAuthn.RPOrigins[0],
+	}
+	credResp, err := authenticator.createCredential(optionsResp.Options)
+	require.NoError(ts.T(), err)
+
+	// Step 3: verify succeeds at AAL2
+	w = ts.makeRequest(http.MethodPost, "http://localhost/passkeys/registration/verify", map[string]any{
+		"challenge_id": optionsResp.ChallengeID,
+		"credential":   json.RawMessage(credResp.JSON),
+	}, withBearerToken(token))
+	ts.Require().Equal(http.StatusOK, w.Code)
+
+	var passkeyResp PasskeyMetadataResponse
+	require.NoError(ts.T(), json.NewDecoder(w.Body).Decode(&passkeyResp))
+	ts.NotEmpty(passkeyResp.ID)
+}

--- a/internal/api/passkey_test.go
+++ b/internal/api/passkey_test.go
@@ -85,6 +85,22 @@ func (ts *PasskeyTestSuite) generateToken(user *models.User, sessionID *uuid.UUI
 	return token
 }
 
+// enrollVerifiedFactor creates a verified TOTP MFA factor for the user so that
+// user.HasMFAEnabled() returns true, exercising the passkey AAL2 step-up gate.
+func (ts *PasskeyTestSuite) enrollVerifiedFactor(user *models.User) *models.Factor {
+	f := models.NewTOTPFactor(user, fmt.Sprintf("factor-%s", uuid.Must(uuid.NewV4()).String()[:8]))
+	require.NoError(ts.T(), f.SetSecret("secretkey", ts.Config.Security.DBEncryption.Encrypt, ts.Config.Security.DBEncryption.EncryptionKeyID, ts.Config.Security.DBEncryption.EncryptionKey))
+	require.NoError(ts.T(), ts.API.db.Create(f))
+	require.NoError(ts.T(), f.UpdateStatus(ts.API.db, models.FactorStateVerified))
+	return f
+}
+
+// elevateSessionToAAL2 marks the session as AAL2 in the database, simulating a
+// completed MFA verification.
+func (ts *PasskeyTestSuite) elevateSessionToAAL2(session *models.Session, factorID uuid.UUID) {
+	require.NoError(ts.T(), session.UpdateAALAndAssociatedFactor(ts.API.db, models.AAL2, &factorID))
+}
+
 // requestOption configures an HTTP request built by makeRequest.
 type requestOption func(*http.Request)
 

--- a/internal/api/passkey_webauthn.go
+++ b/internal/api/passkey_webauthn.go
@@ -3,8 +3,23 @@ package api
 import (
 	"github.com/go-webauthn/webauthn/protocol"
 	"github.com/go-webauthn/webauthn/webauthn"
+	"github.com/supabase/auth/internal/api/apierrors"
 	"github.com/supabase/auth/internal/models"
 )
+
+// requirePasskeyManagementAAL enforces an AAL2 session for passkey credential
+// management (registration and deletion) when the user has a verified MFA
+// factor.
+//
+// When the user has no verified factor the check is skipped: their maximum
+// assurance level is AAL1, so requiring AAL2 could never be satisfied. The
+// check fails closed, treating a missing session as not meeting AAL2.
+func requirePasskeyManagementAAL(user *models.User, session *models.Session) error {
+	if user.HasMFAEnabled() && (session == nil || !session.IsAAL2()) {
+		return apierrors.NewForbiddenError(apierrors.ErrorCodeInsufficientAAL, "AAL2 session is required to manage passkeys when MFA is enabled")
+	}
+	return nil
+}
 
 // getPasskeyWebAuthn creates a *webauthn.WebAuthn instance from the shared server-side WebAuthn configuration.
 func (a *API) getPasskeyWebAuthn() (*webauthn.WebAuthn, error) {


### PR DESCRIPTION
If a user has a verified MFA factor enrolled, then enforce AAL2 for passkey registration and deletion.

Note: we explicitly do not gate the passkey update operation since it can only be used to update the `friendly_name` of the passkey.