### PR TITLE
fix: update identity last sign-in time on OAuth sign-ins

### DIFF
--- a/internal/api/external.go
+++ b/internal/api/external.go
@@ -367,7 +367,9 @@ func (a *API) createAccountFromExternalIdentity(tx *storage.Connection, r *http.
 		user = decision.User
 		identity = decision.Identities[0]
 
+		now := time.Now()
 		identity.IdentityData = identityData
+		identity.LastSignInAt = &now
 		if terr = tx.UpdateOnly(identity, "identity_data", "last_sign_in_at"); terr != nil {
 			return 0, nil, terr
 		}

--- a/internal/api/external_google_test.go
+++ b/internal/api/external_google_test.go
@@ -6,9 +6,11 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"github.com/supabase/auth/internal/api/provider"
+	"github.com/supabase/auth/internal/models"
 )
 
 const (
@@ -120,6 +122,31 @@ func (ts *ExternalTestSuite) TestSignupExternalGoogleDisableSignupSuccessWithPri
 	u := performAuthorization(ts, "google", code, "")
 
 	assertAuthorizationSuccess(ts, u, tokenCount, userCount, "google@example.com", "Google Test", "googleTestId", "http://example.com/avatar")
+}
+
+func (ts *ExternalTestSuite) TestSignupExternalGoogleUpdatesIdentityLastSignInAt() {
+	ts.Config.DisableSignup = true
+
+	ts.createUserWithIdentity("google", "googleTestId", "google@example.com", "Google Test", "http://example.com/avatar", "")
+	identity, err := models.FindIdentityByIdAndProvider(ts.API.db, "googleTestId", "google")
+	ts.Require().NoError(err)
+
+	previousLastSignInAt := time.Now().Add(-24 * time.Hour)
+	identity.LastSignInAt = &previousLastSignInAt
+	ts.Require().NoError(ts.API.db.UpdateOnly(identity, "last_sign_in_at"))
+
+	tokenCount, userCount := 0, 0
+	code := "authcode"
+	server := GoogleTestSignupSetup(ts, &tokenCount, &userCount, code, googleUser)
+	defer server.Close()
+
+	u := performAuthorization(ts, "google", code, "")
+
+	assertAuthorizationSuccess(ts, u, tokenCount, userCount, "google@example.com", "Google Test", "googleTestId", "http://example.com/avatar")
+	identity, err = models.FindIdentityByIdAndProvider(ts.API.db, "googleTestId", "google")
+	ts.Require().NoError(err)
+	ts.Require().NotNil(identity.LastSignInAt)
+	ts.Require().True(identity.LastSignInAt.After(previousLastSignInAt), "expected identity last_sign_in_at to be updated after sign in")
 }
 
 func (ts *ExternalTestSuite) TestInviteTokenExternalGoogleSuccessWhenMatchingToken() {


### PR DESCRIPTION
## What changed

- Refresh the existing OAuth identity's `last_sign_in_at` timestamp when a known identity signs in again.
- Add a Google OAuth regression test that verifies `auth.identities.last_sign_in_at` moves forward on subsequent sign-ins.

Fixes #2563.

## Testing

- `go test ./internal/api -run 'TestExternal/TestSignupExternalGoogleUpdatesIdentityLastSignInAt' -count=1`
- `go test ./internal/api -run 'TestExternal/TestSignupExternalGoogle(_AuthorizationCode|DisableSignupSuccessWithPrimaryEmail|UpdatesIdentityLastSignInAt)$' -count=1`
- `go test ./internal/api -run TestExternal -count=1`
