### PR TITLE
fix(Dockerfile): ensure forks exists on fs before make deps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ WORKDIR /go/src/github.com/supabase/auth
 
 # Pulling dependencies
 COPY ./Makefile ./go.* ./
+COPY ./internal/forks/godotenv ./internal/forks/godotenv
 RUN make deps
 
 # Building stuff


### PR DESCRIPTION
Release action is [failing](https://github.com/supabase/auth/actions/runs/27016942895/job/79738663274) due to the Dockerfile calling make deps before the source for the replace directive is set.