### PR TITLE
fix(conf): ignore invalid SMTP headers config

### DIFF
--- a/internal/conf/configuration.go
+++ b/internal/conf/configuration.go
@@ -514,17 +514,16 @@ type SMTPConfiguration struct {
 }
 
 func (c *SMTPConfiguration) Validate() error {
-	headers := make(map[string][]string)
+	c.normalizedHeaders = nil
 
 	if c.Headers != "" {
+		headers := make(map[string][]string)
 		err := json.Unmarshal([]byte(c.Headers), &headers)
 		if err != nil {
-			return fmt.Errorf("conf: SMTP headers not a map[string][]string format: %w", err)
+			logrus.WithError(err).Warn("Invalid SMTP headers configuration; ignoring SMTP headers")
+		} else if len(headers) > 0 {
+			c.normalizedHeaders = headers
 		}
-	}
-
-	if len(headers) > 0 {
-		c.normalizedHeaders = headers
 	}
 
 	mail := gomail.NewMessage()

--- a/internal/conf/configuration_test.go
+++ b/internal/conf/configuration_test.go
@@ -19,7 +19,6 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
-
 func TestPasswordRequiredCharactersDecode(t *testing.T) {
 	examples := []struct {
 		Value  string
@@ -321,9 +320,20 @@ func TestValidate(t *testing.T) {
 			},
 		},
 		{
-			val: &SMTPConfiguration{Headers: "invalid"},
-			err: `conf: SMTP headers not a map[string][]string format:` +
-				` invalid character 'i' looking for beginning of value`,
+			val: &SMTPConfiguration{Headers: `{"X-Test":["one","two"]}`},
+			check: func(t *testing.T, v any) {
+				got := (v.(*SMTPConfiguration)).NormalizedHeaders()
+				require.Equal(t, []string{"one", "two"}, got["X-Test"])
+			},
+		},
+		{
+			val: &SMTPConfiguration{
+				Headers:           `{"X-SES-Message-Tags":["ses:feedback-id-b=\$messageType"]}`,
+				normalizedHeaders: map[string][]string{"X-Test": {"stale"}},
+			},
+			check: func(t *testing.T, v any) {
+				require.Nil(t, (v.(*SMTPConfiguration)).NormalizedHeaders())
+			},
 		},
 
 		{
@@ -923,7 +933,6 @@ func TestMethods(t *testing.T) {
 		require.NoError(t, err)
 	}
 }
-
 
 func TestWebAuthnConfigurationValidate(t *testing.T) {
 	// Empty RPID → error

--- a/internal/conf/confload/confload_test.go
+++ b/internal/conf/confload/confload_test.go
@@ -209,6 +209,21 @@ func TestGlobal(t *testing.T) {
 
 }
 
+func TestGlobalIgnoresInvalidSMTPHeaders(t *testing.T) {
+	t.Setenv("GOTRUE_SITE_URL", "http://localhost:8080")
+	t.Setenv("GOTRUE_DB_DRIVER", "postgres")
+	t.Setenv("GOTRUE_DB_DATABASE_URL", "fake")
+	t.Setenv("GOTRUE_OPERATOR_TOKEN", "token")
+	t.Setenv("GOTRUE_JWT_SECRET", "secret")
+	t.Setenv("API_EXTERNAL_URL", "http://localhost:9999")
+	t.Setenv("GOTRUE_SMTP_HEADERS", `{"X-SES-Message-Tags":["ses:feedback-id-b=\$messageType"]}`)
+
+	gc, err := LoadGlobal("")
+	require.NoError(t, err)
+	require.NotNil(t, gc)
+	require.Nil(t, gc.SMTP.NormalizedHeaders())
+}
+
 func TestLoading(t *testing.T) {
 	os.Clearenv()
 


### PR DESCRIPTION
## Summary

- Treat invalid optional `GOTRUE_SMTP_HEADERS` JSON as a warning instead of failing global config validation.
- Clear stale normalized SMTP headers before each validation pass.
- Keep valid SMTP header parsing unchanged and cover invalid env loading with regression tests.

Fixes #2533.

## Tests

- `go test ./internal/conf -run TestValidate -count=1`
- `go test ./internal/conf/confload -run 'TestGlobal|TestGlobalIgnoresInvalidSMTPHeaders' -count=1`
- `go test ./internal/conf/... -count=1`
