### PR TITLE
fix(custom-oidc): strip trailing slashes from issuer

### DIFF
--- a/internal/models/custom_oauth_provider.go
+++ b/internal/models/custom_oauth_provider.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"database/sql/driver"
 	"encoding/json"
+	"strings"
 	"time"
 
 	"github.com/gobuffalo/pop/v6/slices"
@@ -134,7 +135,7 @@ func (p *CustomOAuthProvider) GetDiscoveryURL() string {
 		return *p.DiscoveryURL
 	}
 
-	return *p.Issuer + "/.well-known/openid-configuration"
+	return strings.TrimRight(*p.Issuer, "/") + "/.well-known/openid-configuration"
 }
 
 // SetDiscoveryCache stores a validated OIDC discovery document and records the cache time.

--- a/internal/models/custom_oauth_provider_test.go
+++ b/internal/models/custom_oauth_provider_test.go
@@ -451,6 +451,41 @@ func (ts *CustomOAuthProviderTestSuite) TestClientSecretRoundTripThroughDB() {
 	assert.Equal(ts.T(), secret, decrypted)
 }
 
+func TestGetDiscoveryURLStripsTrailingSlashes(t *testing.T) {
+	tests := []struct {
+		name     string
+		issuer   string
+		expected string
+	}{
+		{
+			name:     "no trailing slash",
+			issuer:   "https://example.com",
+			expected: "https://example.com/.well-known/openid-configuration",
+		},
+		{
+			name:     "single trailing slash",
+			issuer:   "https://example.com/",
+			expected: "https://example.com/.well-known/openid-configuration",
+		},
+		{
+			name:     "multiple trailing slashes",
+			issuer:   "https://example.com///",
+			expected: "https://example.com/.well-known/openid-configuration",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			issuer := tt.issuer
+			provider := &CustomOAuthProvider{
+				ProviderType: ProviderTypeOIDC,
+				Issuer:       &issuer,
+			}
+			assert.Equal(t, tt.expected, provider.GetDiscoveryURL())
+		})
+	}
+}
+
 // Helper functions
 
 func (ts *CustomOAuthProviderTestSuite) createTestProvider(providerType ProviderType, identifier string) *CustomOAuthProvider {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## summary
Fixes `GetDiscoveryURL` constructing a malformed URL (e.g. `https://example.com//.well-known/openid-configuration`) when the configured OIDC issuer has a trailing slash.
