### PR TITLE
chore(conf): do not halt startup for non-essential config fields

### DIFF
--- a/internal/conf/configuration.go
+++ b/internal/conf/configuration.go
@@ -534,6 +534,9 @@ func (c *SMTPConfiguration) buildNormalizedHeaders() cachedValue[map[string][]st
 		logrus.WithError(err).Warn(err)
 		return makeCachedValue(zero, err)
 	}
+	if len(val) == 0 {
+		return makeCachedValue(zero, err)
+	}
 	return makeCachedValue(val, nil)
 }
 
@@ -616,6 +619,9 @@ func (c *MailerConfiguration) buildServiceHeaders() cachedValue[map[string][]str
 		err = fmt.Errorf(
 			"conf: mailer validation headers not a map[string][]string format: %w", err)
 		logrus.WithError(err).Warn(err)
+		return makeCachedValue(zero, err)
+	}
+	if len(val) == 0 {
 		return makeCachedValue(zero, err)
 	}
 	return makeCachedValue(val, nil)

--- a/internal/conf/configuration.go
+++ b/internal/conf/configuration.go
@@ -509,29 +509,32 @@ type SMTPConfiguration struct {
 	Headers        string        `json:"headers"`
 	LoggingEnabled bool          `json:"logging_enabled" split_words:"true" default:"false"`
 
-	fromAddress       string              `json:"-"`
-	normalizedHeaders map[string][]string `json:"-"`
+	fromAddress          string                           `json:"-"`
+	normalizedHeadersVal cachedValue[map[string][]string] `json:"-"`
 }
 
 func (c *SMTPConfiguration) Validate() error {
-	headers := make(map[string][]string)
-
-	if c.Headers != "" {
-		err := json.Unmarshal([]byte(c.Headers), &headers)
-		if err != nil {
-			return fmt.Errorf("conf: SMTP headers not a map[string][]string format: %w", err)
-		}
-	}
-
-	if len(headers) > 0 {
-		c.normalizedHeaders = headers
-	}
-
 	mail := gomail.NewMessage()
-
 	c.fromAddress = mail.FormatAddress(c.AdminEmail, c.SenderName)
-
+	c.normalizedHeadersVal = c.buildNormalizedHeaders()
 	return nil
+}
+
+func (c *SMTPConfiguration) buildNormalizedHeaders() cachedValue[map[string][]string] {
+	var zero map[string][]string
+	if c.Headers == "" {
+		return makeCachedValue(zero, nil)
+	}
+
+	val := make(map[string][]string)
+	err := json.Unmarshal([]byte(c.Headers), &val)
+	if err != nil {
+		err = fmt.Errorf(
+			"conf: SMTP headers not a map[string][]string format: %w", err)
+		logrus.WithError(err).Warn(err)
+		return makeCachedValue(zero, err)
+	}
+	return makeCachedValue(val, nil)
 }
 
 func (c *SMTPConfiguration) FromAddress() string {
@@ -539,7 +542,7 @@ func (c *SMTPConfiguration) FromAddress() string {
 }
 
 func (c *SMTPConfiguration) NormalizedHeaders() map[string][]string {
-	return c.normalizedHeaders
+	return c.normalizedHeadersVal.val
 }
 
 type MailerConfiguration struct {
@@ -583,50 +586,74 @@ type MailerConfiguration struct {
 	// template reload.
 	TemplateReloadingMaxIdle time.Duration `json:"template_reloading_max_idle" split_words:"true" default:"20m"`
 
-	serviceHeaders   map[string][]string `json:"-"`
-	blockedMXRecords map[string]bool     `json:"-"`
+	serviceHeadersVal   cachedValue[map[string][]string] `json:"-"`
+	blockedMXRecordsVal cachedValue[map[string]bool]     `json:"-"`
 }
 
 func (c *MailerConfiguration) Validate() error {
-	headers := make(map[string][]string)
-
-	if c.EmailValidationServiceHeaders != "" {
-		err := json.Unmarshal([]byte(c.EmailValidationServiceHeaders), &headers)
-		if err != nil {
-			return fmt.Errorf("conf: mailer validation headers not a map[string][]string format: %w", err)
-		}
-	}
-
-	if len(headers) > 0 {
-		c.serviceHeaders = headers
-	}
-
-	// EmailValidationBlockedMX is a JSON array in the config string for brevity.
-	var blockedMXRecords map[string]bool
-	if c.EmailValidationBlockedMX != "" {
-		var blockedMXArray []string
-		err := json.Unmarshal([]byte(c.EmailValidationBlockedMX), &blockedMXArray)
-		if err != nil {
-			return fmt.Errorf("conf: email_validation_blocked_mx is not a valid JSON array: %w", err)
-		}
-		blockedMXRecords = make(map[string]bool, len(blockedMXArray)*2)
-		for _, record := range blockedMXArray {
-			blockedMXRecords[record] = true
-			blockedMXRecords[record+"."] = true
-		}
-	}
-
-	c.blockedMXRecords = blockedMXRecords
-
+	c.serviceHeadersVal = c.buildServiceHeaders()
+	c.blockedMXRecordsVal = c.buildBlockedMXRecords()
 	return nil
 }
 
 func (c *MailerConfiguration) GetEmailValidationServiceHeaders() map[string][]string {
-	return c.serviceHeaders
+	return c.serviceHeadersVal.val
 }
 
 func (c *MailerConfiguration) GetEmailValidationBlockedMXRecords() map[string]bool {
-	return c.blockedMXRecords
+	return c.blockedMXRecordsVal.val
+}
+
+func (c *MailerConfiguration) buildServiceHeaders() cachedValue[map[string][]string] {
+	var zero map[string][]string
+	if c.EmailValidationServiceHeaders == "" {
+		return makeCachedValue(zero, nil)
+	}
+
+	val := make(map[string][]string)
+	err := json.Unmarshal([]byte(c.EmailValidationServiceHeaders), &val)
+	if err != nil {
+		err = fmt.Errorf(
+			"conf: mailer validation headers not a map[string][]string format: %w", err)
+		logrus.WithError(err).Warn(err)
+		return makeCachedValue(zero, err)
+	}
+	return makeCachedValue(val, nil)
+}
+
+func (c *MailerConfiguration) buildBlockedMXRecords() cachedValue[map[string]bool] {
+	var zero map[string]bool
+	if c.EmailValidationBlockedMX == "" {
+		return makeCachedValue(zero, nil)
+	}
+
+	var blockedMXArray []string
+	err := json.Unmarshal([]byte(c.EmailValidationBlockedMX), &blockedMXArray)
+	if err != nil {
+		err = fmt.Errorf(
+			"conf: blocked mx records not a valid JSON array: %w", err)
+		logrus.WithError(err).Warn(err)
+		return makeCachedValue(zero, err)
+	}
+
+	val := make(map[string]bool, len(blockedMXArray)*2)
+	for _, record := range blockedMXArray {
+		val[record] = true
+		val[record+"."] = true
+	}
+	return makeCachedValue(val, nil)
+}
+
+type cachedValue[T any] struct {
+	val T
+	err error
+}
+
+func makeCachedValue[T any](val T, err error) cachedValue[T] {
+	return cachedValue[T]{
+		val: val,
+		err: err,
+	}
 }
 
 type PhoneProviderConfiguration struct {

--- a/internal/conf/configuration.go
+++ b/internal/conf/configuration.go
@@ -529,13 +529,12 @@ func (c *SMTPConfiguration) buildNormalizedHeaders() cachedValue[map[string][]st
 	val := make(map[string][]string)
 	err := json.Unmarshal([]byte(c.Headers), &val)
 	if err != nil {
-		err = fmt.Errorf(
-			"conf: SMTP headers not a map[string][]string format: %w", err)
-		logrus.WithError(err).Warn(err)
+		const msg = "conf: SMTP headers configuration is invalid, ignoring"
+		logrus.WithError(err).Warn(msg)
 		return makeCachedValue(zero, err)
 	}
 	if len(val) == 0 {
-		return makeCachedValue(zero, err)
+		return makeCachedValue(zero, nil)
 	}
 	return makeCachedValue(val, nil)
 }
@@ -616,13 +615,12 @@ func (c *MailerConfiguration) buildServiceHeaders() cachedValue[map[string][]str
 	val := make(map[string][]string)
 	err := json.Unmarshal([]byte(c.EmailValidationServiceHeaders), &val)
 	if err != nil {
-		err = fmt.Errorf(
-			"conf: mailer validation headers not a map[string][]string format: %w", err)
-		logrus.WithError(err).Warn(err)
+		const msg = "conf: mailer validation headers configuration is invalid, ignoring"
+		logrus.WithError(err).Warn(msg)
 		return makeCachedValue(zero, err)
 	}
 	if len(val) == 0 {
-		return makeCachedValue(zero, err)
+		return makeCachedValue(zero, nil)
 	}
 	return makeCachedValue(val, nil)
 }
@@ -636,9 +634,8 @@ func (c *MailerConfiguration) buildBlockedMXRecords() cachedValue[map[string]boo
 	var blockedMXArray []string
 	err := json.Unmarshal([]byte(c.EmailValidationBlockedMX), &blockedMXArray)
 	if err != nil {
-		err = fmt.Errorf(
-			"conf: blocked mx records not a valid JSON array: %w", err)
-		logrus.WithError(err).Warn(err)
+		const msg = "conf: blocked mx records configuration is invalid, ignoring"
+		logrus.WithError(err).Warn(msg)
 		return makeCachedValue(zero, err)
 	}
 

--- a/internal/conf/configuration_test.go
+++ b/internal/conf/configuration_test.go
@@ -322,7 +322,7 @@ func TestValidate(t *testing.T) {
 		{
 			val: &SMTPConfiguration{Headers: "invalid"},
 			check: func(t *testing.T, v any) {
-				const exp = `conf: SMTP headers not`
+				const exp = `invalid character`
 
 				mcfg := v.(*SMTPConfiguration)
 				val := mcfg.normalizedHeadersVal.val
@@ -338,7 +338,7 @@ func TestValidate(t *testing.T) {
 		{
 			val: &MailerConfiguration{EmailValidationServiceHeaders: "invalid"},
 			check: func(t *testing.T, v any) {
-				const exp = `conf: mailer validation headers`
+				const exp = `invalid character`
 
 				mcfg := v.(*MailerConfiguration)
 				val := mcfg.serviceHeadersVal.val
@@ -351,7 +351,7 @@ func TestValidate(t *testing.T) {
 		{
 			val: &MailerConfiguration{EmailValidationBlockedMX: "invalid"},
 			check: func(t *testing.T, v any) {
-				const exp = `conf: blocked mx records`
+				const exp = `invalid character`
 				mcfg := v.(*MailerConfiguration)
 				val := mcfg.blockedMXRecordsVal.val
 				err := mcfg.blockedMXRecordsVal.err

--- a/internal/conf/configuration_test.go
+++ b/internal/conf/configuration_test.go
@@ -19,7 +19,6 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
-
 func TestPasswordRequiredCharactersDecode(t *testing.T) {
 	examples := []struct {
 		Value  string
@@ -322,27 +321,53 @@ func TestValidate(t *testing.T) {
 		},
 		{
 			val: &SMTPConfiguration{Headers: "invalid"},
-			err: `conf: SMTP headers not a map[string][]string format:` +
-				` invalid character 'i' looking for beginning of value`,
-		},
+			check: func(t *testing.T, v any) {
+				const exp = `conf: SMTP headers not`
 
+				mcfg := v.(*SMTPConfiguration)
+				val := mcfg.normalizedHeadersVal.val
+				err := mcfg.normalizedHeadersVal.err
+				require.Contains(t, err.Error(), exp)
+				require.Error(t, err)
+				require.Nil(t, val)
+			},
+		},
 		{
 			val: &MailerConfiguration{},
 		},
 		{
 			val: &MailerConfiguration{EmailValidationServiceHeaders: "invalid"},
-			err: `conf: mailer validation headers not a map[string][]string format:` +
-				` invalid character 'i' looking for beginning of value`,
+			check: func(t *testing.T, v any) {
+				const exp = `conf: mailer validation headers`
+
+				mcfg := v.(*MailerConfiguration)
+				val := mcfg.serviceHeadersVal.val
+				err := mcfg.serviceHeadersVal.err
+				require.Contains(t, err.Error(), exp)
+				require.Error(t, err)
+				require.Nil(t, val)
+			},
 		},
 		{
 			val: &MailerConfiguration{EmailValidationBlockedMX: "invalid"},
-			err: `conf: email_validation_blocked_mx`,
+			check: func(t *testing.T, v any) {
+				const exp = `conf: blocked mx records`
+				mcfg := v.(*MailerConfiguration)
+				val := mcfg.blockedMXRecordsVal.val
+				err := mcfg.blockedMXRecordsVal.err
+				require.Error(t, err)
+				require.Contains(t, err.Error(), exp)
+				require.Nil(t, val)
+			},
 		},
 		{
 			val: &MailerConfiguration{EmailValidationBlockedMX: `["foo.com"]`},
 			check: func(t *testing.T, v any) {
-				got := (v.(*MailerConfiguration)).GetEmailValidationBlockedMXRecords()
-				require.True(t, got["foo.com"])
+				mcfg := v.(*MailerConfiguration)
+				val := mcfg.blockedMXRecordsVal.val
+				err := mcfg.blockedMXRecordsVal.err
+				require.NoError(t, err)
+				require.True(t, val["foo.com"])
 			},
 		},
 
@@ -923,7 +948,6 @@ func TestMethods(t *testing.T) {
 		require.NoError(t, err)
 	}
 }
-
 
 func TestWebAuthnConfigurationValidate(t *testing.T) {
 	// Empty RPID → error

--- a/internal/conf/confload/confload_test.go
+++ b/internal/conf/confload/confload_test.go
@@ -26,10 +26,23 @@ func TestGlobal(t *testing.T) {
 	gc, err := LoadGlobal("")
 	require.NoError(t, err)
 	assert.Equal(t, true, gc.SMTP.LoggingEnabled)
-	assert.Equal(t, "project_ref", gc.SMTP.NormalizedHeaders()["X-PM-Metadata-project-ref"][0])
 	require.NotNil(t, gc)
 	assert.Equal(t, "X-Request-ID", gc.API.RequestIDHeader)
 	assert.Equal(t, "pg-functions://postgres/auth/count_failed_attempts", gc.Hook.MFAVerificationAttempt.URI)
+
+	{
+		hdrs := gc.SMTP.NormalizedHeaders()
+		require.NoError(t, err)
+		assert.Equal(t, 1, len(hdrs["X-PM-Metadata-project-ref"]))
+		assert.Equal(t, "project_ref", hdrs["X-PM-Metadata-project-ref"][0])
+	}
+
+	{
+		hdrs := gc.Mailer.GetEmailValidationServiceHeaders()
+		require.NoError(t, err)
+		assert.Equal(t, 1, len(hdrs["apikey"]))
+		assert.Equal(t, "test", hdrs["apikey"][0])
+	}
 
 	{
 		os.Setenv("GOTRUE_RATE_LIMIT_EMAIL_SENT", "0/1h")
@@ -58,12 +71,6 @@ func TestGlobal(t *testing.T) {
 		gc, err = LoadGlobal("")
 		require.NoError(t, err)
 		assert.Equal(t, true, gc.Mailer.EmailBackgroundSending)
-	}
-
-	{
-		hdrs := gc.Mailer.GetEmailValidationServiceHeaders()
-		assert.Equal(t, 1, len(hdrs["apikey"]))
-		assert.Equal(t, "test", hdrs["apikey"][0])
 	}
 
 	{

--- a/internal/mailer/validateclient/validateclient.go
+++ b/internal/mailer/validateclient/validateclient.go
@@ -165,25 +165,6 @@ type emailValidator struct {
 	blockedMXRecords map[string]bool
 }
 
-func (m *emailValidator) MailNew(
-	ctx context.Context,
-	to, subject, body string,
-	headers map[string][]string,
-	typ string,
-) error {
-	return nil
-}
-
-func (m *emailValidator) Mail(
-	ctx context.Context,
-	to, subjectTemplate, templateURL, defaultTemplate string,
-	templateData map[string]any,
-	headers map[string][]string,
-	typ string,
-) error {
-	return nil
-}
-
 func newEmailValidator(mc conf.MailerConfiguration) *emailValidator {
 	return &emailValidator{
 		extended:         mc.EmailValidationExtended,


### PR DESCRIPTION
This wraps some non-essential fields that would previously halt the startup of the auth server when Validate() failed with a cachedValue. This cached value holds the original error for testability but maintains the existing API's around it. When err is non-nil we log a warning.

I also removed some unrelated dead code in internal/mailer I spotted while auditing uses of the newly wrapped config values.