### PR TITLE
feat(custom-oidc): support non-standard discovery URLs

### DIFF
--- a/internal/api/custom_oauth_admin.go
+++ b/internal/api/custom_oauth_admin.go
@@ -2,12 +2,9 @@ package api
 
 import (
 	"context"
-	"encoding/json"
-	"io"
 	"net/http"
 	"slices"
 	"strings"
-	"time"
 
 	"github.com/go-chi/chi/v5"
 	popslices "github.com/gobuffalo/pop/v6/slices"
@@ -666,61 +663,34 @@ func validateAuthorizationParams(params map[string]interface{}) error {
 	return nil
 }
 
-// maxDiscoveryResponseSize is the maximum size of an OIDC discovery response body (1 MB).
-const maxDiscoveryResponseSize = 1 << 20
-
-// discoveryFetchTimeout is the timeout for fetching an OIDC discovery document.
-const discoveryFetchTimeout = 10 * time.Second
-
-// fetchAndValidateDiscovery fetches the OIDC discovery document from the
-// provider's discovery URL and validates that it contains the required fields
-// per the OpenID Connect Discovery 1.0 specification. It also verifies that
-// the issuer in the discovery document matches the expected issuer.
+// fetchAndValidateDiscovery fetches the OIDC discovery document via the shared
+// utility, then applies admin-only validation: required fields per the OpenID
+// Connect Discovery 1.0 spec must be present before we persist the document.
+// Returns *models.OIDCDiscovery so the caller can store it directly.
 func fetchAndValidateDiscovery(ctx context.Context, discoveryURL, expectedIssuer string) (*models.OIDCDiscovery, error) {
-	resp, err := utilities.FetchURLWithTimeout(ctx, discoveryURL, discoveryFetchTimeout)
+	doc, err := utilities.FetchAndValidateOIDCDiscovery(ctx, discoveryURL, expectedIssuer)
 	if err != nil {
 		return nil, apierrors.NewBadRequestError(
 			apierrors.ErrorCodeValidationFailed,
-			"Failed to fetch OIDC discovery document from %q: %v", discoveryURL, err,
-		)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, apierrors.NewBadRequestError(
-			apierrors.ErrorCodeValidationFailed,
-			"OIDC discovery endpoint %q returned HTTP %d, expected 200", discoveryURL, resp.StatusCode,
+			"OIDC discovery from %q failed: %v", discoveryURL, err,
 		)
 	}
 
-	body, err := io.ReadAll(io.LimitReader(resp.Body, maxDiscoveryResponseSize))
-	if err != nil {
-		return nil, apierrors.NewBadRequestError(
-			apierrors.ErrorCodeValidationFailed,
-			"Failed to read OIDC discovery response from %q", discoveryURL,
-		)
-	}
-
-	var discovery models.OIDCDiscovery
-	if err := json.Unmarshal(body, &discovery); err != nil {
-		return nil, apierrors.NewBadRequestError(
-			apierrors.ErrorCodeValidationFailed,
-			"OIDC discovery document from %q is not valid JSON", discoveryURL,
-		)
-	}
-
-	// Validate required fields per OpenID Connect Discovery 1.0 spec
+	// Validate required fields per OpenID Connect Discovery 1.0 spec.
+	// Stricter than the runtime path needs — runtime can tolerate missing
+	// fields and surface a less helpful error at login; admin should reject
+	// the configuration up front.
 	var missing []string
-	if discovery.Issuer == "" {
+	if doc.Issuer == "" {
 		missing = append(missing, "issuer")
 	}
-	if discovery.AuthorizationEndpoint == "" {
+	if doc.AuthorizationEndpoint == "" {
 		missing = append(missing, "authorization_endpoint")
 	}
-	if discovery.TokenEndpoint == "" {
+	if doc.TokenEndpoint == "" {
 		missing = append(missing, "token_endpoint")
 	}
-	if discovery.JwksURI == "" {
+	if doc.JwksURI == "" {
 		missing = append(missing, "jwks_uri")
 	}
 	if len(missing) > 0 {
@@ -730,16 +700,17 @@ func fetchAndValidateDiscovery(ctx context.Context, discoveryURL, expectedIssuer
 		)
 	}
 
-	// The issuer in the discovery document MUST exactly match the expected issuer
-	// per OpenID Connect Discovery 1.0, Section 4.3.
-	if discovery.Issuer != expectedIssuer {
-		return nil, apierrors.NewBadRequestError(
-			apierrors.ErrorCodeValidationFailed,
-			"OIDC discovery issuer mismatch: discovery document reports %q but expected %q", discovery.Issuer, expectedIssuer,
-		)
-	}
-
-	return &discovery, nil
+	return &models.OIDCDiscovery{
+		Issuer:                 doc.Issuer,
+		AuthorizationEndpoint:  doc.AuthorizationEndpoint,
+		TokenEndpoint:          doc.TokenEndpoint,
+		UserinfoEndpoint:       doc.UserinfoEndpoint,
+		JwksURI:                doc.JwksURI,
+		ScopesSupported:        doc.ScopesSupported,
+		ResponseTypesSupported: doc.ResponseTypesSupported,
+		GrantTypesSupported:    doc.GrantTypesSupported,
+		SubjectTypesSupported:  doc.SubjectTypesSupported,
+	}, nil
 }
 
 // validateAttributeMapping ensures no sensitive system fields are targeted

--- a/internal/api/external.go
+++ b/internal/api/external.go
@@ -690,8 +690,7 @@ func (a *API) loadCustomProvider(ctx context.Context, db *storage.Connection, id
 	config := a.config
 	var pConfig conf.OAuthProviderConfiguration
 
-	// Build the redirect URL
-	redirectURL := config.API.ExternalURL + "/callback"
+	redirectURL := strings.TrimRight(config.API.ExternalURL, "/") + "/callback"
 
 	// Parse scopes (space-separated per RFC 6749)
 	var scopeList []string

--- a/internal/api/external.go
+++ b/internal/api/external.go
@@ -765,7 +765,6 @@ func (a *API) loadCustomProvider(ctx context.Context, db *storage.Connection, id
 	}
 
 	// Create custom OIDC provider instance
-	// oidc.NewProvider() will automatically fetch discovery document
 	p, err := provider.NewCustomOIDCProvider(
 		ctx,
 		customProvider.ClientID,
@@ -773,6 +772,7 @@ func (a *API) loadCustomProvider(ctx context.Context, db *storage.Connection, id
 		redirectURL,
 		scopeList,
 		*customProvider.Issuer,
+		customProvider.GetDiscoveryURL(),
 		customProvider.PKCEEnabled,
 		customProvider.AcceptableClientIDs,
 		customProvider.AttributeMapping,

--- a/internal/api/provider/custom_oauth.go
+++ b/internal/api/provider/custom_oauth.go
@@ -110,12 +110,16 @@ type CustomOIDCProvider struct {
 	authorizationParams map[string]interface{}
 }
 
-// NewCustomOIDCProvider creates a new custom OIDC provider
+// NewCustomOIDCProvider creates a new custom OIDC provider.
+// discoveryURL is the URL to fetch the OIDC discovery document from
+// (typically {issuer}/.well-known/openid-configuration, or an admin-configured
+// override).
 func NewCustomOIDCProvider(
 	ctx context.Context,
 	clientID, clientSecret, redirectURL string,
 	scopes []string,
 	issuer string,
+	discoveryURL string,
 	pkceEnabled bool,
 	acceptableClientIDs []string,
 	attributeMapping, authorizationParams map[string]interface{},
@@ -133,8 +137,7 @@ func NewCustomOIDCProvider(
 		scopes = append([]string{"openid"}, scopes...)
 	}
 
-	// Create OIDC provider - uses cache to avoid redundant discovery fetches
-	oidcProvider, err := cache.GetProvider(ctx, issuer)
+	oidcProvider, err := cache.GetProviderFromURL(ctx, issuer, discoveryURL)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create OIDC provider: %w", err)
 	}

--- a/internal/api/provider/custom_oauth_test.go
+++ b/internal/api/provider/custom_oauth_test.go
@@ -280,7 +280,7 @@ func TestNewCustomOIDCProvider(t *testing.T) {
 		[]string{"ios-client", "android-client"},
 		map[string]interface{}{"email": "user_email"},
 		map[string]interface{}{"prompt": "consent"},
-		NewOIDCProviderCache(0),
+		newTestOIDCProviderCache(t, 0),
 	)
 
 	require.NoError(t, err)
@@ -415,7 +415,7 @@ func TestCustomOIDCProvider_AuthCodeURL(t *testing.T) {
 			"ui_locales": "en",
 			"login_hint": "user@example.com",
 		},
-		NewOIDCProviderCache(0),
+		newTestOIDCProviderCache(t, 0),
 	)
 
 	require.NoError(t, err)
@@ -466,7 +466,7 @@ func TestNewCustomOIDCProvider_CustomDiscoveryURL(t *testing.T) {
 		server.URL+"/custom-discovery",
 		false,
 		nil, nil, nil,
-		NewOIDCProviderCache(time.Hour),
+		newTestOIDCProviderCache(t, time.Hour),
 	)
 	require.NoError(t, err)
 	require.NotNil(t, p)
@@ -511,7 +511,7 @@ func TestCustomOIDCProvider_RequiresPKCE(t *testing.T) {
 			nil,
 			nil,
 			nil,
-			NewOIDCProviderCache(0),
+			newTestOIDCProviderCache(t, 0),
 		)
 
 		require.NoError(t, err)
@@ -532,7 +532,7 @@ func TestCustomOIDCProvider_RequiresPKCE(t *testing.T) {
 			nil,
 			nil,
 			nil,
-			NewOIDCProviderCache(0),
+			newTestOIDCProviderCache(t, 0),
 		)
 
 		require.NoError(t, err)

--- a/internal/api/provider/custom_oauth_test.go
+++ b/internal/api/provider/custom_oauth_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -274,6 +275,7 @@ func TestNewCustomOIDCProvider(t *testing.T) {
 		"https://myapp.com/callback",
 		[]string{"profile", "email"}, // Without openid
 		server.URL, // issuer
+		server.URL + "/.well-known/openid-configuration",
 		true, // PKCE enabled
 		[]string{"ios-client", "android-client"},
 		map[string]interface{}{"email": "user_email"},
@@ -403,6 +405,7 @@ func TestCustomOIDCProvider_AuthCodeURL(t *testing.T) {
 		"https://myapp.com/callback",
 		[]string{"openid", "profile"},
 		server.URL, // issuer
+		server.URL + "/.well-known/openid-configuration",
 		false,
 		nil,
 		nil,
@@ -429,6 +432,48 @@ func TestCustomOIDCProvider_AuthCodeURL(t *testing.T) {
 	assert.Contains(t, authURL, "max_age=3600")
 	assert.Contains(t, authURL, "ui_locales=en")
 	assert.Contains(t, authURL, "login_hint=user")
+}
+
+func TestNewCustomOIDCProvider_CustomDiscoveryURL(t *testing.T) {
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/custom-discovery":
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"issuer":                 server.URL,
+				"authorization_endpoint": server.URL + "/custom-authorize",
+				"token_endpoint":         server.URL + "/custom-token",
+				"userinfo_endpoint":      server.URL + "/custom-userinfo",
+				"jwks_uri":               server.URL + "/jwks",
+			})
+		case "/jwks":
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]interface{}{"keys": []interface{}{}})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	p, err := NewCustomOIDCProvider(
+		context.Background(),
+		"test-client-id",
+		"test-secret",
+		"https://myapp.com/callback",
+		[]string{"openid"},
+		server.URL,
+		server.URL+"/custom-discovery",
+		false,
+		nil, nil, nil,
+		NewOIDCProviderCache(time.Hour),
+	)
+	require.NoError(t, err)
+	require.NotNil(t, p)
+
+	assert.Equal(t, server.URL+"/custom-authorize", p.config.Endpoint.AuthURL)
+	assert.Equal(t, server.URL+"/custom-token", p.config.Endpoint.TokenURL)
+	assert.Equal(t, server.URL+"/custom-userinfo", p.userinfoEndpoint)
 }
 
 func TestCustomOIDCProvider_RequiresPKCE(t *testing.T) {
@@ -461,6 +506,7 @@ func TestCustomOIDCProvider_RequiresPKCE(t *testing.T) {
 			"https://myapp.com/callback",
 			[]string{"openid"},
 			server.URL, // issuer
+			server.URL + "/.well-known/openid-configuration",
 			true, // PKCE enabled
 			nil,
 			nil,
@@ -481,6 +527,7 @@ func TestCustomOIDCProvider_RequiresPKCE(t *testing.T) {
 			"https://myapp.com/callback",
 			[]string{"openid"},
 			server.URL, // issuer
+			server.URL + "/.well-known/openid-configuration",
 			false, // PKCE disabled
 			nil,
 			nil,

--- a/internal/api/provider/oidc_cache.go
+++ b/internal/api/provider/oidc_cache.go
@@ -49,6 +49,27 @@ func NewOIDCProviderCache(ttl time.Duration) *OIDCProviderCache {
 	}
 }
 
+// getEntry returns the cached entry for issuer, if any. It holds the read lock
+// only for the map access and releases it via defer, so a panic in a future
+// caller can't leave the mutex held and deadlock the auth server.
+func (c *OIDCProviderCache) getEntry(issuer string) (*oidcCacheEntry, bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	entry, ok := c.cache[issuer]
+	return entry, ok
+}
+
+// putEntry stores provider for issuer, stamped with the current time. The write
+// lock is released via defer for the same panic-safety reason as getEntry.
+func (c *OIDCProviderCache) putEntry(issuer string, provider *oidc.Provider) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.cache[issuer] = &oidcCacheEntry{
+		provider:  provider,
+		fetchedAt: c.now(),
+	}
+}
+
 // GetProvider returns a cached *oidc.Provider for the given issuer, fetching
 // it via oidc.NewProvider if not cached or expired. Concurrent requests for
 // the same issuer are deduplicated via singleflight.
@@ -56,12 +77,9 @@ func (c *OIDCProviderCache) GetProvider(ctx context.Context, issuer string) (*oi
 	now := c.now()
 
 	// Fast path: read-lock check
-	c.mu.RLock()
-	if entry, ok := c.cache[issuer]; ok && now.Sub(entry.fetchedAt) < c.ttl {
-		c.mu.RUnlock()
+	if entry, ok := c.getEntry(issuer); ok && now.Sub(entry.fetchedAt) < c.ttl {
 		return entry.provider, nil
 	}
-	c.mu.RUnlock()
 
 	// Slow path: singleflight fetch
 	val, err, _ := c.sf.Do(issuer, func() (interface{}, error) {
@@ -70,24 +88,15 @@ func (c *OIDCProviderCache) GetProvider(ctx context.Context, issuer string) (*oi
 			return nil, err
 		}
 
-		c.mu.Lock()
-		c.cache[issuer] = &oidcCacheEntry{
-			provider:  p,
-			fetchedAt: c.now(),
-		}
-		c.mu.Unlock()
-
+		c.putEntry(issuer, p)
 		return p, nil
 	})
 	if err != nil {
 		// Serve stale entry if available — keeps auth working during
 		// transient network failures or issuer outages.
-		c.mu.RLock()
-		if entry, ok := c.cache[issuer]; ok {
-			c.mu.RUnlock()
+		if entry, ok := c.getEntry(issuer); ok {
 			return entry.provider, nil
 		}
-		c.mu.RUnlock()
 		return nil, err
 	}
 
@@ -101,13 +110,12 @@ func (c *OIDCProviderCache) GetProvider(ctx context.Context, issuer string) (*oi
 func (c *OIDCProviderCache) GetProviderFromURL(ctx context.Context, issuer, discoveryURL string) (*oidc.Provider, error) {
 	now := c.now()
 
-	c.mu.RLock()
-	if entry, ok := c.cache[issuer]; ok && now.Sub(entry.fetchedAt) < c.ttl {
-		c.mu.RUnlock()
+	// Fast path: read-lock check
+	if entry, ok := c.getEntry(issuer); ok && now.Sub(entry.fetchedAt) < c.ttl {
 		return entry.provider, nil
 	}
-	c.mu.RUnlock()
 
+	// Slow path: singleflight fetch
 	val, err, _ := c.sf.Do(issuer, func() (interface{}, error) {
 		doc, err := utilities.FetchAndValidateOIDCDiscovery(ctx, discoveryURL, issuer)
 		if err != nil {
@@ -130,22 +138,15 @@ func (c *OIDCProviderCache) GetProviderFromURL(ctx context.Context, issuer, disc
 			Algorithms:  algs,
 		}).NewProvider(ctx)
 
-		c.mu.Lock()
-		c.cache[issuer] = &oidcCacheEntry{
-			provider:  p,
-			fetchedAt: c.now(),
-		}
-		c.mu.Unlock()
-
+		c.putEntry(issuer, p)
 		return p, nil
 	})
 	if err != nil {
-		c.mu.RLock()
-		if entry, ok := c.cache[issuer]; ok {
-			c.mu.RUnlock()
+		// Serve stale entry if available — keeps auth working during
+		// transient network failures or issuer outages.
+		if entry, ok := c.getEntry(issuer); ok {
 			return entry.provider, nil
 		}
-		c.mu.RUnlock()
 		return nil, err
 	}
 

--- a/internal/api/provider/oidc_cache.go
+++ b/internal/api/provider/oidc_cache.go
@@ -2,20 +2,13 @@ package provider
 
 import (
 	"context"
-	"encoding/json"
-	"fmt"
-	"net/http"
 	"sync"
 	"time"
 
 	"github.com/coreos/go-oidc/v3/oidc"
+	"github.com/supabase/auth/internal/utilities"
 	"golang.org/x/sync/singleflight"
 )
-
-// oidcDiscoveryHTTPClient bounds the discovery fetch so a slow or hung
-// upstream cannot wedge an auth request indefinitely. JWKS fetches use
-// go-oidc's own client and are unaffected.
-var oidcDiscoveryHTTPClient = &http.Client{Timeout: 10 * time.Second}
 
 // oidcSupportedAlgorithms mirrors the set that go-oidc's discovery path filters
 // against internally. We duplicate it here because the manual ProviderConfig
@@ -27,15 +20,6 @@ var oidcSupportedAlgorithms = map[string]bool{
 	"ES256": true, "ES384": true, "ES512": true,
 	"PS256": true, "PS384": true, "PS512": true,
 	"EdDSA": true,
-}
-
-type oidcDiscoveryDoc struct {
-	Issuer      string   `json:"issuer"`
-	AuthURL     string   `json:"authorization_endpoint"`
-	TokenURL    string   `json:"token_endpoint"`
-	JWKSURL     string   `json:"jwks_uri"`
-	UserInfoURL string   `json:"userinfo_endpoint"`
-	Algorithms  []string `json:"id_token_signing_alg_values_supported"`
 }
 
 type oidcCacheEntry struct {
@@ -125,31 +109,13 @@ func (c *OIDCProviderCache) GetProviderFromURL(ctx context.Context, issuer, disc
 	c.mu.RUnlock()
 
 	val, err, _ := c.sf.Do(issuer, func() (interface{}, error) {
-		req, err := http.NewRequestWithContext(ctx, http.MethodGet, discoveryURL, nil)
+		doc, err := utilities.FetchAndValidateOIDCDiscovery(ctx, discoveryURL, issuer)
 		if err != nil {
-			return nil, fmt.Errorf("oidc: failed to build discovery request: %w", err)
-		}
-		resp, err := oidcDiscoveryHTTPClient.Do(req)
-		if err != nil {
-			return nil, fmt.Errorf("oidc: discovery request to %s failed: %w", discoveryURL, err)
-		}
-		defer resp.Body.Close()
-
-		if resp.StatusCode != http.StatusOK {
-			return nil, fmt.Errorf("oidc: discovery request to %s returned %s", discoveryURL, resp.Status)
-		}
-
-		var doc oidcDiscoveryDoc
-		if err := json.NewDecoder(resp.Body).Decode(&doc); err != nil {
-			return nil, fmt.Errorf("oidc: failed to decode discovery document from %s: %w", discoveryURL, err)
-		}
-
-		if doc.Issuer != issuer {
-			return nil, fmt.Errorf("oidc: issuer mismatch, expected %q got %q", issuer, doc.Issuer)
+			return nil, err
 		}
 
 		var algs []string
-		for _, a := range doc.Algorithms {
+		for _, a := range doc.IDTokenSigningAlgValuesSupported {
 			if oidcSupportedAlgorithms[a] {
 				algs = append(algs, a)
 			}
@@ -157,10 +123,10 @@ func (c *OIDCProviderCache) GetProviderFromURL(ctx context.Context, issuer, disc
 
 		p := (&oidc.ProviderConfig{
 			IssuerURL:   doc.Issuer,
-			AuthURL:     doc.AuthURL,
-			TokenURL:    doc.TokenURL,
-			UserInfoURL: doc.UserInfoURL,
-			JWKSURL:     doc.JWKSURL,
+			AuthURL:     doc.AuthorizationEndpoint,
+			TokenURL:    doc.TokenEndpoint,
+			UserInfoURL: doc.UserinfoEndpoint,
+			JWKSURL:     doc.JwksURI,
 			Algorithms:  algs,
 		}).NewProvider(ctx)
 

--- a/internal/api/provider/oidc_cache.go
+++ b/internal/api/provider/oidc_cache.go
@@ -2,12 +2,41 @@ package provider
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
 	"sync"
 	"time"
 
 	"github.com/coreos/go-oidc/v3/oidc"
 	"golang.org/x/sync/singleflight"
 )
+
+// oidcDiscoveryHTTPClient bounds the discovery fetch so a slow or hung
+// upstream cannot wedge an auth request indefinitely. JWKS fetches use
+// go-oidc's own client and are unaffected.
+var oidcDiscoveryHTTPClient = &http.Client{Timeout: 10 * time.Second}
+
+// oidcSupportedAlgorithms mirrors the set that go-oidc's discovery path filters
+// against internally. We duplicate it here because the manual ProviderConfig
+// path doesn't go through that filter — without it, a misconfigured upstream
+// could push a verifier into accepting algorithms go-oidc doesn't actually
+// support. Keep in sync with go-oidc's supportedAlgorithms.
+var oidcSupportedAlgorithms = map[string]bool{
+	"RS256": true, "RS384": true, "RS512": true,
+	"ES256": true, "ES384": true, "ES512": true,
+	"PS256": true, "PS384": true, "PS512": true,
+	"EdDSA": true,
+}
+
+type oidcDiscoveryDoc struct {
+	Issuer      string   `json:"issuer"`
+	AuthURL     string   `json:"authorization_endpoint"`
+	TokenURL    string   `json:"token_endpoint"`
+	JWKSURL     string   `json:"jwks_uri"`
+	UserInfoURL string   `json:"userinfo_endpoint"`
+	Algorithms  []string `json:"id_token_signing_alg_values_supported"`
+}
 
 type oidcCacheEntry struct {
 	provider  *oidc.Provider
@@ -69,6 +98,82 @@ func (c *OIDCProviderCache) GetProvider(ctx context.Context, issuer string) (*oi
 	if err != nil {
 		// Serve stale entry if available — keeps auth working during
 		// transient network failures or issuer outages.
+		c.mu.RLock()
+		if entry, ok := c.cache[issuer]; ok {
+			c.mu.RUnlock()
+			return entry.provider, nil
+		}
+		c.mu.RUnlock()
+		return nil, err
+	}
+
+	return val.(*oidc.Provider), nil
+}
+
+// GetProviderFromURL returns an *oidc.Provider built from an explicit discovery URL,
+// rather than the standard {issuer}/.well-known/openid-configuration path.
+// The result is cached and deduplicated (singleflight) under the issuer key,
+// so Invalidate(issuer) continues to work unchanged.
+func (c *OIDCProviderCache) GetProviderFromURL(ctx context.Context, issuer, discoveryURL string) (*oidc.Provider, error) {
+	now := c.now()
+
+	c.mu.RLock()
+	if entry, ok := c.cache[issuer]; ok && now.Sub(entry.fetchedAt) < c.ttl {
+		c.mu.RUnlock()
+		return entry.provider, nil
+	}
+	c.mu.RUnlock()
+
+	val, err, _ := c.sf.Do(issuer, func() (interface{}, error) {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, discoveryURL, nil)
+		if err != nil {
+			return nil, fmt.Errorf("oidc: failed to build discovery request: %w", err)
+		}
+		resp, err := oidcDiscoveryHTTPClient.Do(req)
+		if err != nil {
+			return nil, fmt.Errorf("oidc: discovery request to %s failed: %w", discoveryURL, err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			return nil, fmt.Errorf("oidc: discovery request to %s returned %s", discoveryURL, resp.Status)
+		}
+
+		var doc oidcDiscoveryDoc
+		if err := json.NewDecoder(resp.Body).Decode(&doc); err != nil {
+			return nil, fmt.Errorf("oidc: failed to decode discovery document from %s: %w", discoveryURL, err)
+		}
+
+		if doc.Issuer != issuer {
+			return nil, fmt.Errorf("oidc: issuer mismatch, expected %q got %q", issuer, doc.Issuer)
+		}
+
+		var algs []string
+		for _, a := range doc.Algorithms {
+			if oidcSupportedAlgorithms[a] {
+				algs = append(algs, a)
+			}
+		}
+
+		p := (&oidc.ProviderConfig{
+			IssuerURL:   doc.Issuer,
+			AuthURL:     doc.AuthURL,
+			TokenURL:    doc.TokenURL,
+			UserInfoURL: doc.UserInfoURL,
+			JWKSURL:     doc.JWKSURL,
+			Algorithms:  algs,
+		}).NewProvider(ctx)
+
+		c.mu.Lock()
+		c.cache[issuer] = &oidcCacheEntry{
+			provider:  p,
+			fetchedAt: c.now(),
+		}
+		c.mu.Unlock()
+
+		return p, nil
+	})
+	if err != nil {
 		c.mu.RLock()
 		if entry, ok := c.cache[issuer]; ok {
 			c.mu.RUnlock()

--- a/internal/api/provider/oidc_cache_test.go
+++ b/internal/api/provider/oidc_cache_test.go
@@ -12,7 +12,33 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/supabase/auth/internal/utilities"
 )
+
+// installPlainHTTPDiscoveryFetcher swaps the utility's HTTP fetcher to a
+// plain (non-SSRF-validated) one so httptest loopback servers work, and
+// restores the production default when the test ends.
+func installPlainHTTPDiscoveryFetcher(t *testing.T) {
+	t.Helper()
+	client := &http.Client{Timeout: 5 * time.Second}
+	t.Cleanup(utilities.SetOIDCDiscoveryHTTPFetcherForTest(
+		func(ctx context.Context, discoveryURL string) (*http.Response, error) {
+			req, err := http.NewRequestWithContext(ctx, http.MethodGet, discoveryURL, nil)
+			if err != nil {
+				return nil, err
+			}
+			return client.Do(req)
+		},
+	))
+}
+
+// newTestOIDCProviderCache builds a cache and installs the plain HTTP
+// discovery fetcher for the test's lifetime so httptest loopback servers work.
+func newTestOIDCProviderCache(t *testing.T, ttl time.Duration) *OIDCProviderCache {
+	t.Helper()
+	installPlainHTTPDiscoveryFetcher(t)
+	return NewOIDCProviderCache(ttl)
+}
 
 // newTestOIDCServer creates a test OIDC discovery server that counts fetches.
 func newTestOIDCServer(fetchCount *atomic.Int64) *httptest.Server {
@@ -276,7 +302,7 @@ func TestOIDCProviderCache_GetProviderFromURL_CustomPath(t *testing.T) {
 	server := newTestOIDCServerCustomPath(&fetchCount, "/my-discovery")
 	defer server.Close()
 
-	cache := NewOIDCProviderCache(time.Hour)
+	cache := newTestOIDCProviderCache(t, time.Hour)
 
 	p, err := cache.GetProviderFromURL(context.Background(), server.URL, server.URL+"/my-discovery")
 	require.NoError(t, err)
@@ -303,7 +329,7 @@ func TestOIDCProviderCache_GetProviderFromURL_IssuerMismatch(t *testing.T) {
 	}))
 	defer server.Close()
 
-	cache := NewOIDCProviderCache(time.Hour)
+	cache := newTestOIDCProviderCache(t, time.Hour)
 
 	_, err := cache.GetProviderFromURL(context.Background(), server.URL, server.URL+"/discovery")
 	require.Error(t, err)
@@ -315,7 +341,7 @@ func TestOIDCProviderCache_GetProviderFromURL_CacheHit(t *testing.T) {
 	server := newTestOIDCServerCustomPath(&fetchCount, "/custom-discovery")
 	defer server.Close()
 
-	cache := NewOIDCProviderCache(time.Hour)
+	cache := newTestOIDCProviderCache(t, time.Hour)
 
 	p1, err := cache.GetProviderFromURL(context.Background(), server.URL, server.URL+"/custom-discovery")
 	require.NoError(t, err)
@@ -336,7 +362,7 @@ func TestOIDCProviderCache_GetProviderFromURL_StaleOnError(t *testing.T) {
 	server := newTestOIDCServerCustomPath(&fetchCount, "/custom-discovery")
 
 	now := time.Now()
-	cache := NewOIDCProviderCache(time.Hour)
+	cache := newTestOIDCProviderCache(t, time.Hour)
 	cache.now = func() time.Time { return now }
 
 	// Prime the cache
@@ -360,7 +386,7 @@ func TestOIDCProviderCache_GetProviderFromURL_InvalidateWorks(t *testing.T) {
 	server := newTestOIDCServerCustomPath(&fetchCount, "/custom-discovery")
 	defer server.Close()
 
-	cache := NewOIDCProviderCache(time.Hour)
+	cache := newTestOIDCProviderCache(t, time.Hour)
 
 	_, err := cache.GetProviderFromURL(context.Background(), server.URL, server.URL+"/custom-discovery")
 	require.NoError(t, err)

--- a/internal/api/provider/oidc_cache_test.go
+++ b/internal/api/provider/oidc_cache_test.go
@@ -240,3 +240,136 @@ func TestOIDCProviderCache_TTLPassedThrough(t *testing.T) {
 	cache := NewOIDCProviderCache(30 * time.Minute)
 	assert.Equal(t, 30*time.Minute, cache.ttl)
 }
+
+// newTestOIDCServerCustomPath creates a test server that serves discovery at a custom path.
+func newTestOIDCServerCustomPath(fetchCount *atomic.Int64, path string) *httptest.Server {
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case path:
+			if fetchCount != nil {
+				fetchCount.Add(1)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"issuer":                                server.URL,
+				"authorization_endpoint":                server.URL + "/authorize",
+				"token_endpoint":                        server.URL + "/token",
+				"userinfo_endpoint":                     server.URL + "/userinfo",
+				"jwks_uri":                              server.URL + "/jwks",
+				"id_token_signing_alg_values_supported": []string{"RS256", "ES256", "HS256"},
+			})
+		case "/jwks":
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"keys": []interface{}{},
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	return server
+}
+
+func TestOIDCProviderCache_GetProviderFromURL_CustomPath(t *testing.T) {
+	var fetchCount atomic.Int64
+	server := newTestOIDCServerCustomPath(&fetchCount, "/my-discovery")
+	defer server.Close()
+
+	cache := NewOIDCProviderCache(time.Hour)
+
+	p, err := cache.GetProviderFromURL(context.Background(), server.URL, server.URL+"/my-discovery")
+	require.NoError(t, err)
+	require.NotNil(t, p)
+
+	assert.Equal(t, int64(1), fetchCount.Load())
+	assert.Equal(t, server.URL+"/authorize", p.Endpoint().AuthURL)
+	assert.Equal(t, server.URL+"/token", p.Endpoint().TokenURL)
+	assert.Equal(t, server.URL+"/userinfo", p.UserInfoEndpoint())
+}
+
+func TestOIDCProviderCache_GetProviderFromURL_IssuerMismatch(t *testing.T) {
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/discovery" {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"issuer":                 "https://wrong-issuer.example.com",
+				"authorization_endpoint": server.URL + "/authorize",
+				"token_endpoint":         server.URL + "/token",
+				"jwks_uri":               server.URL + "/jwks",
+			})
+		}
+	}))
+	defer server.Close()
+
+	cache := NewOIDCProviderCache(time.Hour)
+
+	_, err := cache.GetProviderFromURL(context.Background(), server.URL, server.URL+"/discovery")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "issuer mismatch")
+}
+
+func TestOIDCProviderCache_GetProviderFromURL_CacheHit(t *testing.T) {
+	var fetchCount atomic.Int64
+	server := newTestOIDCServerCustomPath(&fetchCount, "/custom-discovery")
+	defer server.Close()
+
+	cache := NewOIDCProviderCache(time.Hour)
+
+	p1, err := cache.GetProviderFromURL(context.Background(), server.URL, server.URL+"/custom-discovery")
+	require.NoError(t, err)
+	require.NotNil(t, p1)
+	assert.Equal(t, int64(1), fetchCount.Load())
+
+	// Second call should hit cache — no additional HTTP request
+	p2, err := cache.GetProviderFromURL(context.Background(), server.URL, server.URL+"/custom-discovery")
+	require.NoError(t, err)
+	require.NotNil(t, p2)
+	assert.Equal(t, int64(1), fetchCount.Load())
+
+	assert.Equal(t, p1, p2)
+}
+
+func TestOIDCProviderCache_GetProviderFromURL_StaleOnError(t *testing.T) {
+	var fetchCount atomic.Int64
+	server := newTestOIDCServerCustomPath(&fetchCount, "/custom-discovery")
+
+	now := time.Now()
+	cache := NewOIDCProviderCache(time.Hour)
+	cache.now = func() time.Time { return now }
+
+	// Prime the cache
+	p1, err := cache.GetProviderFromURL(context.Background(), server.URL, server.URL+"/custom-discovery")
+	require.NoError(t, err)
+	require.NotNil(t, p1)
+	assert.Equal(t, int64(1), fetchCount.Load())
+
+	// Advance time past TTL, then close the server
+	now = now.Add(2 * time.Hour)
+	server.Close()
+
+	// Should return stale entry rather than error
+	p2, err := cache.GetProviderFromURL(context.Background(), server.URL, server.URL+"/custom-discovery")
+	require.NoError(t, err)
+	assert.Equal(t, p1, p2)
+}
+
+func TestOIDCProviderCache_GetProviderFromURL_InvalidateWorks(t *testing.T) {
+	var fetchCount atomic.Int64
+	server := newTestOIDCServerCustomPath(&fetchCount, "/custom-discovery")
+	defer server.Close()
+
+	cache := NewOIDCProviderCache(time.Hour)
+
+	_, err := cache.GetProviderFromURL(context.Background(), server.URL, server.URL+"/custom-discovery")
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), fetchCount.Load())
+
+	// Invalidate by issuer (not discoveryURL)
+	cache.Invalidate(server.URL)
+
+	_, err = cache.GetProviderFromURL(context.Background(), server.URL, server.URL+"/custom-discovery")
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), fetchCount.Load())
+}

--- a/internal/utilities/oidc_discovery.go
+++ b/internal/utilities/oidc_discovery.go
@@ -1,0 +1,79 @@
+package utilities
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+// OIDCDiscoveryFetchTimeout bounds the discovery fetch so a slow or hung
+// upstream cannot wedge an auth request indefinitely.
+const OIDCDiscoveryFetchTimeout = 10 * time.Second
+
+// MaxOIDCDiscoveryResponseSize caps how much of the discovery body we'll read.
+// Defends against an attacker (or a buggy upstream) serving an unbounded body.
+const MaxOIDCDiscoveryResponseSize = 1 << 20 // 1 MB
+
+// OIDCDiscoveryDocument is the wire-format representation of an OIDC discovery
+// document. It's the superset of fields needed by both the admin path (which
+// persists to models.OIDCDiscovery) and the runtime path (which builds an
+// *oidc.Provider). Storage and runtime concerns are kept out of this type.
+type OIDCDiscoveryDocument struct {
+	Issuer                           string   `json:"issuer"`
+	AuthorizationEndpoint            string   `json:"authorization_endpoint"`
+	TokenEndpoint                    string   `json:"token_endpoint"`
+	UserinfoEndpoint                 string   `json:"userinfo_endpoint,omitempty"`
+	JwksURI                          string   `json:"jwks_uri"`
+	ScopesSupported                  []string `json:"scopes_supported,omitempty"`
+	ResponseTypesSupported           []string `json:"response_types_supported,omitempty"`
+	GrantTypesSupported              []string `json:"grant_types_supported,omitempty"`
+	SubjectTypesSupported            []string `json:"subject_types_supported,omitempty"`
+	IDTokenSigningAlgValuesSupported []string `json:"id_token_signing_alg_values_supported,omitempty"`
+}
+
+// oidcDiscoveryHTTPFetcher is the underlying fetcher used by
+// FetchAndValidateOIDCDiscovery. Tests swap it via SetOIDCDiscoveryHTTPFetcherForTest
+// to bypass the SSRF-protected default (which refuses httptest loopback URLs).
+var oidcDiscoveryHTTPFetcher = func(ctx context.Context, discoveryURL string) (*http.Response, error) {
+	return FetchURLWithTimeout(ctx, discoveryURL, OIDCDiscoveryFetchTimeout)
+}
+
+// SetOIDCDiscoveryHTTPFetcherForTest replaces the HTTP fetcher used by
+// FetchAndValidateOIDCDiscovery and returns a function that restores the
+// previous fetcher. Test-only — the production default applies SSRF protection
+// (rejects loopback, private IPs, non-HTTPS), which test servers cannot satisfy.
+func SetOIDCDiscoveryHTTPFetcherForTest(fn func(ctx context.Context, discoveryURL string) (*http.Response, error)) (restore func()) {
+	prev := oidcDiscoveryHTTPFetcher
+	oidcDiscoveryHTTPFetcher = fn
+	return func() { oidcDiscoveryHTTPFetcher = prev }
+}
+
+// FetchAndValidateOIDCDiscovery fetches an OIDC discovery document from
+// discoveryURL, decodes it, and verifies its issuer matches expectedIssuer
+// (per OpenID Connect Discovery 1.0, Section 4.3). Errors are returned as
+// plain Go errors; callers wrap them into their own error types.
+func FetchAndValidateOIDCDiscovery(ctx context.Context, discoveryURL, expectedIssuer string) (*OIDCDiscoveryDocument, error) {
+	resp, err := oidcDiscoveryHTTPFetcher(ctx, discoveryURL)
+	if err != nil {
+		return nil, fmt.Errorf("oidc: discovery request to %s failed: %w", discoveryURL, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("oidc: discovery request to %s returned %s", discoveryURL, resp.Status)
+	}
+
+	var doc OIDCDiscoveryDocument
+	if err := json.NewDecoder(io.LimitReader(resp.Body, MaxOIDCDiscoveryResponseSize)).Decode(&doc); err != nil {
+		return nil, fmt.Errorf("oidc: failed to decode discovery document from %s: %w", discoveryURL, err)
+	}
+
+	if doc.Issuer != expectedIssuer {
+		return nil, fmt.Errorf("oidc: issuer mismatch, expected %q got %q", expectedIssuer, doc.Issuer)
+	}
+
+	return &doc, nil
+}

--- a/internal/utilities/oidc_discovery_test.go
+++ b/internal/utilities/oidc_discovery_test.go
@@ -1,0 +1,145 @@
+package utilities
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// withTestFetcher installs a test fetcher for the duration of the test and
+// restores the production default on cleanup.
+func withTestFetcher(t *testing.T, fn func(ctx context.Context, discoveryURL string) (*http.Response, error)) {
+	t.Helper()
+	t.Cleanup(SetOIDCDiscoveryHTTPFetcherForTest(fn))
+}
+
+// plainHTTPFetcher is a fetcher that does a normal GET without SSRF validation,
+// suitable for httptest loopback servers.
+func plainHTTPFetcher() func(ctx context.Context, discoveryURL string) (*http.Response, error) {
+	client := &http.Client{}
+	return func(ctx context.Context, discoveryURL string) (*http.Response, error) {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, discoveryURL, nil)
+		if err != nil {
+			return nil, err
+		}
+		return client.Do(req)
+	}
+}
+
+func TestFetchAndValidateOIDCDiscovery_HappyPath(t *testing.T) {
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"issuer":                                server.URL,
+			"authorization_endpoint":                server.URL + "/authorize",
+			"token_endpoint":                        server.URL + "/token",
+			"userinfo_endpoint":                     server.URL + "/userinfo",
+			"jwks_uri":                              server.URL + "/jwks",
+			"scopes_supported":                      []string{"openid", "email"},
+			"response_types_supported":              []string{"code"},
+			"grant_types_supported":                 []string{"authorization_code"},
+			"subject_types_supported":               []string{"public"},
+			"id_token_signing_alg_values_supported": []string{"RS256", "ES256"},
+		})
+	}))
+	defer server.Close()
+
+	withTestFetcher(t, plainHTTPFetcher())
+
+	doc, err := FetchAndValidateOIDCDiscovery(context.Background(), server.URL+"/.well-known/openid-configuration", server.URL)
+	require.NoError(t, err)
+	require.NotNil(t, doc)
+	assert.Equal(t, server.URL, doc.Issuer)
+	assert.Equal(t, server.URL+"/authorize", doc.AuthorizationEndpoint)
+	assert.Equal(t, server.URL+"/token", doc.TokenEndpoint)
+	assert.Equal(t, server.URL+"/userinfo", doc.UserinfoEndpoint)
+	assert.Equal(t, server.URL+"/jwks", doc.JwksURI)
+	assert.Equal(t, []string{"openid", "email"}, doc.ScopesSupported)
+	assert.Equal(t, []string{"code"}, doc.ResponseTypesSupported)
+	assert.Equal(t, []string{"authorization_code"}, doc.GrantTypesSupported)
+	assert.Equal(t, []string{"public"}, doc.SubjectTypesSupported)
+	assert.Equal(t, []string{"RS256", "ES256"}, doc.IDTokenSigningAlgValuesSupported)
+}
+
+func TestFetchAndValidateOIDCDiscovery_Non200Status(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "nope", http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	withTestFetcher(t, plainHTTPFetcher())
+
+	_, err := FetchAndValidateOIDCDiscovery(context.Background(), server.URL+"/discovery", server.URL)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "500")
+}
+
+func TestFetchAndValidateOIDCDiscovery_BodyExceedsCap(t *testing.T) {
+	// Serve a JSON body larger than MaxOIDCDiscoveryResponseSize so the
+	// LimitReader truncates mid-object and json.Decode fails.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"issuer":"x","filler":"`))
+		w.Write([]byte(strings.Repeat("A", MaxOIDCDiscoveryResponseSize+1024)))
+		w.Write([]byte(`"}`))
+	}))
+	defer server.Close()
+
+	withTestFetcher(t, plainHTTPFetcher())
+
+	_, err := FetchAndValidateOIDCDiscovery(context.Background(), server.URL+"/discovery", "x")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "decode")
+}
+
+func TestFetchAndValidateOIDCDiscovery_InvalidJSON(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`not json at all`))
+	}))
+	defer server.Close()
+
+	withTestFetcher(t, plainHTTPFetcher())
+
+	_, err := FetchAndValidateOIDCDiscovery(context.Background(), server.URL+"/discovery", "anything")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "decode")
+}
+
+func TestFetchAndValidateOIDCDiscovery_IssuerMismatch(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"issuer":                 "https://wrong-issuer.example.com",
+			"authorization_endpoint": "https://x/authorize",
+			"token_endpoint":         "https://x/token",
+			"jwks_uri":               "https://x/jwks",
+		})
+	}))
+	defer server.Close()
+
+	withTestFetcher(t, plainHTTPFetcher())
+
+	_, err := FetchAndValidateOIDCDiscovery(context.Background(), server.URL+"/discovery", "https://expected.example.com")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "issuer mismatch")
+}
+
+func TestFetchAndValidateOIDCDiscovery_FetcherError(t *testing.T) {
+	sentinel := errors.New("boom")
+	withTestFetcher(t, func(ctx context.Context, discoveryURL string) (*http.Response, error) {
+		return nil, sentinel
+	})
+
+	_, err := FetchAndValidateOIDCDiscovery(context.Background(), "https://example.com/discovery", "https://example.com")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, sentinel)
+}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

## What is the current behavior?

`discoveryUrl` is only validated during provider creation (admin endpoint)

## What is the new behavior?

use `discoveryUrl` while making the actual OIDC discovery too

## Summary
- Adds `OIDCProviderCache.GetProviderFromURL` so custom OIDC providers can fetch their discovery document from any URL, not just `{issuer}/.well-known/openid-configuration`.
- Custom OIDC providers now always route through this path; the URL is sourced from `CustomOAuthProvider.GetDiscoveryURL()` (which falls back to the standard path when no override is configured).
- Bounds discovery fetches with a 10s HTTP timeout and verifies the document's `issuer` matches the configured one before constructing the provider.