### PR TITLE
feat(custom-oauth): add per-provider custom_claims_allowlist

### DIFF
--- a/internal/api/custom_oauth_admin.go
+++ b/internal/api/custom_oauth_admin.go
@@ -53,9 +53,11 @@ type AdminCustomOAuthProviderParams struct {
 	Scopes              []string               `json:"scopes"`
 	PKCEEnabled         *bool                  `json:"pkce_enabled,omitempty"`
 	AttributeMapping    map[string]interface{} `json:"attribute_mapping,omitempty"`
-	AuthorizationParams map[string]interface{} `json:"authorization_params,omitempty"`
-	Enabled             *bool                  `json:"enabled,omitempty"`
-	EmailOptional       *bool                  `json:"email_optional,omitempty"`
+	// CustomClaimsAllowlist lists raw IdP claim keys to copy verbatim into custom_claims.
+	CustomClaimsAllowlist []string               `json:"custom_claims_allowlist,omitempty"`
+	AuthorizationParams   map[string]interface{} `json:"authorization_params,omitempty"`
+	Enabled               *bool                  `json:"enabled,omitempty"`
+	EmailOptional         *bool                  `json:"email_optional,omitempty"`
 
 	// OIDC-specific fields
 	Issuer         string  `json:"issuer,omitempty"`
@@ -170,6 +172,11 @@ func (a *API) adminCustomOAuthProviderCreate(w http.ResponseWriter, r *http.Requ
 		return err
 	}
 
+	// Validate custom claims allowlist (non-empty source keys)
+	if err := validateCustomClaimsAllowlist(params.CustomClaimsAllowlist); err != nil {
+		return err
+	}
+
 	// Check quota if configured
 	if config.CustomOAuth.MaxProviders > 0 {
 		totalCount, err := models.CountCustomOAuthProviders(db)
@@ -274,6 +281,13 @@ func (a *API) adminCustomOAuthProviderUpdate(w http.ResponseWriter, r *http.Requ
 	// Validate attribute mapping if provided
 	if params.AttributeMapping != nil {
 		if err := validateAttributeMapping(params.AttributeMapping); err != nil {
+			return err
+		}
+	}
+
+	// Validate custom claims allowlist if provided
+	if params.CustomClaimsAllowlist != nil {
+		if err := validateCustomClaimsAllowlist(params.CustomClaimsAllowlist); err != nil {
 			return err
 		}
 	}
@@ -477,18 +491,19 @@ func buildProviderFromParams(params *AdminCustomOAuthProviderParams, providerTyp
 	// Generate ID upfront so it's available for client secret encryption (used as AAD)
 	id, _ := uuid.NewV4()
 	provider := &models.CustomOAuthProvider{
-		ID:                  id,
-		ProviderType:        providerType,
-		Identifier:          params.Identifier,
-		Name:                params.Name,
-		ClientID:            params.ClientID,
-		AcceptableClientIDs: popslices.String(params.AcceptableClientIDs),
-		Scopes:              popslices.String(params.Scopes),
-		PKCEEnabled:         getBoolOrDefault(params.PKCEEnabled, true),
-		AttributeMapping:    popslices.Map(params.AttributeMapping),
-		AuthorizationParams: popslices.Map(params.AuthorizationParams),
-		Enabled:             getBoolOrDefault(params.Enabled, true),
-		EmailOptional:       getBoolOrDefault(params.EmailOptional, false),
+		ID:                    id,
+		ProviderType:          providerType,
+		Identifier:            params.Identifier,
+		Name:                  params.Name,
+		ClientID:              params.ClientID,
+		AcceptableClientIDs:   popslices.String(params.AcceptableClientIDs),
+		Scopes:                popslices.String(params.Scopes),
+		PKCEEnabled:           getBoolOrDefault(params.PKCEEnabled, true),
+		AttributeMapping:      popslices.Map(params.AttributeMapping),
+		CustomClaimsAllowlist: popslices.String(params.CustomClaimsAllowlist),
+		AuthorizationParams:   popslices.Map(params.AuthorizationParams),
+		Enabled:               getBoolOrDefault(params.Enabled, true),
+		EmailOptional:         getBoolOrDefault(params.EmailOptional, false),
 	}
 
 	// Set type-specific fields
@@ -559,6 +574,9 @@ func updateProviderFromParams(provider *models.CustomOAuthProvider, params *Admi
 	}
 	if params.AttributeMapping != nil {
 		provider.AttributeMapping = popslices.Map(params.AttributeMapping)
+	}
+	if params.CustomClaimsAllowlist != nil {
+		provider.CustomClaimsAllowlist = popslices.String(params.CustomClaimsAllowlist)
 	}
 	if params.AuthorizationParams != nil {
 		provider.AuthorizationParams = popslices.Map(params.AuthorizationParams)
@@ -749,3 +767,18 @@ func validateAttributeMapping(mapping map[string]interface{}) error {
 	return nil
 }
 
+// validateCustomClaimsAllowlist ensures every allowlist entry is a non-empty
+// source claim key. Unlike attribute_mapping, these are opaque source keys
+// copied into custom_claims (not typed targets)
+func validateCustomClaimsAllowlist(allowlist []string) error {
+	for _, key := range allowlist {
+		if strings.TrimSpace(key) == "" {
+			return apierrors.NewBadRequestError(
+				apierrors.ErrorCodeValidationFailed,
+				"custom_claims_allowlist entries must be non-empty strings",
+			)
+		}
+	}
+
+	return nil
+}

--- a/internal/api/custom_oauth_admin_test.go
+++ b/internal/api/custom_oauth_admin_test.go
@@ -10,8 +10,8 @@ import (
 	"testing"
 
 	popslices "github.com/gobuffalo/pop/v6/slices"
-	jwt "github.com/golang-jwt/jwt/v5"
 	"github.com/gofrs/uuid"
+	jwt "github.com/golang-jwt/jwt/v5"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -594,6 +594,56 @@ func (ts *CustomOAuthAdminTestSuite) TestUpdateProvider() {
 	assert.Equal(ts.T(), "new-client-id", updated.ClientID)
 	assert.False(ts.T(), updated.Enabled)
 	assert.Equal(ts.T(), popslices.String{"openid", "profile", "email"}, updated.Scopes)
+}
+
+func (ts *CustomOAuthAdminTestSuite) TestCustomClaimsAllowlistCreateUpdateGet() {
+	payload := ts.createTestOAuth2Payload("allowlist-provider")
+	payload["custom_claims_allowlist"] = []string{"groups", "org_id"}
+
+	w := ts.createProvider(payload, http.StatusCreated)
+
+	var created models.CustomOAuthProvider
+	require.NoError(ts.T(), json.NewDecoder(w.Body).Decode(&created))
+	assert.Equal(ts.T(), popslices.String{"groups", "org_id"}, created.CustomClaimsAllowlist)
+
+	// PUT replaces the allowlist.
+	updatePayload := map[string]interface{}{
+		"custom_claims_allowlist": []string{"mail", "sn", "nlEduPersonProfileId"},
+	}
+	var body bytes.Buffer
+	require.NoError(ts.T(), json.NewEncoder(&body).Encode(updatePayload))
+
+	req := httptest.NewRequest(http.MethodPut, fmt.Sprintf("/admin/custom-providers/%s", created.Identifier), &body)
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", ts.token))
+	w = httptest.NewRecorder()
+	ts.API.handler.ServeHTTP(w, req)
+	require.Equal(ts.T(), http.StatusOK, w.Code)
+
+	var updated models.CustomOAuthProvider
+	require.NoError(ts.T(), json.NewDecoder(w.Body).Decode(&updated))
+	assert.Equal(ts.T(), popslices.String{"mail", "sn", "nlEduPersonProfileId"}, updated.CustomClaimsAllowlist)
+
+	// GET returns the persisted allowlist.
+	req = httptest.NewRequest(http.MethodGet, fmt.Sprintf("/admin/custom-providers/%s", created.Identifier), nil)
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", ts.token))
+	w = httptest.NewRecorder()
+	ts.API.handler.ServeHTTP(w, req)
+	require.Equal(ts.T(), http.StatusOK, w.Code)
+
+	var fetched models.CustomOAuthProvider
+	require.NoError(ts.T(), json.NewDecoder(w.Body).Decode(&fetched))
+	assert.Equal(ts.T(), popslices.String{"mail", "sn", "nlEduPersonProfileId"}, fetched.CustomClaimsAllowlist)
+}
+
+func (ts *CustomOAuthAdminTestSuite) TestCustomClaimsAllowlistRejectsEmptyEntries() {
+	payload := ts.createTestOAuth2Payload("allowlist-bad")
+	payload["custom_claims_allowlist"] = []string{"groups", ""}
+
+	w := ts.createProvider(payload, http.StatusBadRequest)
+
+	var apiErr apierrors.HTTPError
+	require.NoError(ts.T(), json.NewDecoder(w.Body).Decode(&apiErr))
+	assert.Equal(ts.T(), apierrors.ErrorCodeValidationFailed, apiErr.ErrorCode)
 }
 
 // Test DELETE /admin/custom-providers/:id (Delete)

--- a/internal/api/external.go
+++ b/internal/api/external.go
@@ -743,6 +743,7 @@ func (a *API) loadCustomProvider(ctx context.Context, db *storage.Connection, id
 			customProvider.AcceptableClientIDs,
 			customProvider.AttributeMapping,
 			customProvider.AuthorizationParams,
+			customProvider.CustomClaimsAllowlist,
 		)
 
 		// Build provider configuration
@@ -776,6 +777,7 @@ func (a *API) loadCustomProvider(ctx context.Context, db *storage.Connection, id
 		customProvider.AcceptableClientIDs,
 		customProvider.AttributeMapping,
 		customProvider.AuthorizationParams,
+		customProvider.CustomClaimsAllowlist,
 		a.oidcCache,
 	)
 	if err != nil {

--- a/internal/api/provider/custom_oauth.go
+++ b/internal/api/provider/custom_oauth.go
@@ -12,12 +12,13 @@ import (
 
 // CustomOAuthProvider implements OAuthProvider for custom OAuth2 providers
 type CustomOAuthProvider struct {
-	config              *oauth2.Config
-	userinfoURL         string
-	pkceEnabled         bool
-	acceptableClientIDs []string
-	attributeMapping    map[string]interface{}
-	authorizationParams map[string]interface{}
+	config                *oauth2.Config
+	userinfoURL           string
+	pkceEnabled           bool
+	acceptableClientIDs   []string
+	attributeMapping      map[string]interface{}
+	authorizationParams   map[string]interface{}
+	customClaimsAllowlist []string
 }
 
 // NewCustomOAuthProvider creates a new custom OAuth provider
@@ -27,6 +28,7 @@ func NewCustomOAuthProvider(
 	pkceEnabled bool,
 	acceptableClientIDs []string,
 	attributeMapping, authorizationParams map[string]interface{},
+	customClaimsAllowlist []string,
 ) *CustomOAuthProvider {
 	config := &oauth2.Config{
 		ClientID:     clientID,
@@ -40,12 +42,13 @@ func NewCustomOAuthProvider(
 	}
 
 	return &CustomOAuthProvider{
-		config:              config,
-		userinfoURL:         userinfoURL,
-		pkceEnabled:         pkceEnabled,
-		acceptableClientIDs: acceptableClientIDs,
-		attributeMapping:    attributeMapping,
-		authorizationParams: authorizationParams,
+		config:                config,
+		userinfoURL:           userinfoURL,
+		pkceEnabled:           pkceEnabled,
+		acceptableClientIDs:   acceptableClientIDs,
+		attributeMapping:      attributeMapping,
+		authorizationParams:   authorizationParams,
+		customClaimsAllowlist: customClaimsAllowlist,
 	}
 }
 
@@ -68,10 +71,13 @@ func (p *CustomOAuthProvider) GetOAuthToken(ctx context.Context, code string, op
 
 // GetUserData fetches user data from the provider's userinfo endpoint
 func (p *CustomOAuthProvider) GetUserData(ctx context.Context, tok *oauth2.Token) (*UserProvidedData, error) {
-	var claims Claims
-	if err := makeRequest(ctx, tok, p.config, p.userinfoURL, &claims); err != nil {
+	claims, raw, err := fetchUserinfoClaims(ctx, tok, p.config, p.userinfoURL)
+	if err != nil {
 		return nil, err
 	}
+
+	// Capture allowlisted custom claims before attribute mapping
+	captureAllowedClaims(raw, p.customClaimsAllowlist, &claims)
 
 	// Apply attribute mapping if configured
 	if len(p.attributeMapping) > 0 {
@@ -101,13 +107,14 @@ func (p *CustomOAuthProvider) RequiresPKCE() bool {
 
 // CustomOIDCProvider implements OAuthProvider for custom OIDC providers
 type CustomOIDCProvider struct {
-	config              *oauth2.Config
-	oidcProvider        *oidc.Provider
-	userinfoEndpoint    string
-	pkceEnabled         bool
-	acceptableClientIDs []string
-	attributeMapping    map[string]interface{}
-	authorizationParams map[string]interface{}
+	config                *oauth2.Config
+	oidcProvider          *oidc.Provider
+	userinfoEndpoint      string
+	pkceEnabled           bool
+	acceptableClientIDs   []string
+	attributeMapping      map[string]interface{}
+	authorizationParams   map[string]interface{}
+	customClaimsAllowlist []string
 }
 
 // NewCustomOIDCProvider creates a new custom OIDC provider.
@@ -123,6 +130,7 @@ func NewCustomOIDCProvider(
 	pkceEnabled bool,
 	acceptableClientIDs []string,
 	attributeMapping, authorizationParams map[string]interface{},
+	customClaimsAllowlist []string,
 	cache *OIDCProviderCache,
 ) (*CustomOIDCProvider, error) {
 	// Ensure 'openid' scope is always present for OIDC
@@ -155,13 +163,14 @@ func NewCustomOIDCProvider(
 	}
 
 	return &CustomOIDCProvider{
-		config:              config,
-		oidcProvider:        oidcProvider,
-		userinfoEndpoint:    userinfoEndpoint,
-		pkceEnabled:         pkceEnabled,
-		acceptableClientIDs: acceptableClientIDs,
-		attributeMapping:    attributeMapping,
-		authorizationParams: authorizationParams,
+		config:                config,
+		oidcProvider:          oidcProvider,
+		userinfoEndpoint:      userinfoEndpoint,
+		pkceEnabled:           pkceEnabled,
+		acceptableClientIDs:   acceptableClientIDs,
+		attributeMapping:      attributeMapping,
+		authorizationParams:   authorizationParams,
+		customClaimsAllowlist: customClaimsAllowlist,
 	}, nil
 }
 
@@ -201,6 +210,17 @@ func (p *CustomOIDCProvider) GetUserData(ctx context.Context, tok *oauth2.Token)
 			return nil, err
 		}
 
+		// Capture allowlisted custom claims from the raw ID token before
+		// attribute mapping. Because we only copy explicitly listed keys, there
+		// is no risk of re-adding keys a parser intentionally stripped (e.g. Azure).
+		if len(p.customClaimsAllowlist) > 0 && userData.Metadata != nil {
+			var raw map[string]interface{}
+			if err := idTokenObj.Claims(&raw); err != nil {
+				return nil, fmt.Errorf("failed to read ID token claims: %w", err)
+			}
+			captureAllowedClaims(raw, p.customClaimsAllowlist, userData.Metadata)
+		}
+
 		// Apply attribute mapping to the metadata from ID token
 		if len(p.attributeMapping) > 0 && userData.Metadata != nil {
 			*userData.Metadata = applyAttributeMapping(*userData.Metadata, p.attributeMapping)
@@ -211,10 +231,13 @@ func (p *CustomOIDCProvider) GetUserData(ctx context.Context, tok *oauth2.Token)
 
 	// No ID token, use userinfo endpoint
 	if p.userinfoEndpoint != "" {
-		var claims Claims
-		if err := makeRequest(ctx, tok, p.config, p.userinfoEndpoint, &claims); err != nil {
+		claims, raw, err := fetchUserinfoClaims(ctx, tok, p.config, p.userinfoEndpoint)
+		if err != nil {
 			return nil, err
 		}
+
+		// Capture allowlisted custom claims before attribute mapping
+		captureAllowedClaims(raw, p.customClaimsAllowlist, &claims)
 
 		// Apply attribute mapping
 		if len(p.attributeMapping) > 0 {
@@ -266,6 +289,44 @@ func (p *CustomOIDCProvider) validateAudience(audiences []string) error {
 
 	// No valid audience found
 	return fmt.Errorf("token audience %v does not match any acceptable client ID", audiences)
+}
+
+// fetchUserinfoClaims fetches the userinfo response once and returns both the
+// typed Claims and the raw claim map. The raw map is needed so that arbitrary
+// allowlisted keys (which have no typed field) can be copied verbatim.
+func fetchUserinfoClaims(ctx context.Context, tok *oauth2.Token, config *oauth2.Config, url string) (Claims, map[string]interface{}, error) {
+	var raw map[string]interface{}
+	if err := makeRequest(ctx, tok, config, url, &raw); err != nil {
+		return Claims{}, nil, err
+	}
+
+	var claims Claims
+	b, err := json.Marshal(raw)
+	if err != nil {
+		return Claims{}, nil, err
+	}
+	if err := json.Unmarshal(b, &claims); err != nil {
+		return Claims{}, nil, err
+	}
+
+	return claims, raw, nil
+}
+
+// captureAllowedClaims copies each allowlisted key present in raw into
+// c.CustomClaims verbatim. An empty allowlist captures nothing (D1), and keys
+// absent from raw are silently skipped (no nil entry is created). Because only
+// explicitly listed keys are copied, protocol/registered claims never leak.
+func captureAllowedClaims(raw map[string]interface{}, allowlist []string, c *Claims) {
+	for _, key := range allowlist {
+		value, ok := raw[key]
+		if !ok {
+			continue
+		}
+		if c.CustomClaims == nil {
+			c.CustomClaims = make(map[string]interface{})
+		}
+		c.CustomClaims[key] = value
+	}
 }
 
 // applyAttributeMapping applies custom attribute mapping to claims

--- a/internal/api/provider/custom_oauth_claims_test.go
+++ b/internal/api/provider/custom_oauth_claims_test.go
@@ -1,0 +1,290 @@
+package provider
+
+import (
+	"context"
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/coreos/go-oidc/v3/oidc"
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/oauth2"
+)
+
+// captureAllowedClaims is the single helper shared by all three capture paths.
+func TestCaptureAllowedClaims(t *testing.T) {
+	// A representative raw claim map: standard claims, custom claims, and
+	// protocol/registered claims that must never leak unless explicitly listed.
+	raw := map[string]interface{}{
+		"sub":       "user-123",
+		"email":     "test@example.com",
+		"groups":    []interface{}{"admins", "devs"},
+		"org_id":    "org-42",
+		"tenant_id": "tenant-7",
+		"nbf":       float64(1700000000),
+		"nonce":     "abc",
+		"c_hash":    "xyz",
+		"at_hash":   "qrs",
+		"sid":       "session-1",
+	}
+
+	t.Run("captures only allowlisted keys", func(t *testing.T) {
+		c := &Claims{}
+		captureAllowedClaims(raw, []string{"groups", "org_id"}, c)
+
+		require.NotNil(t, c.CustomClaims)
+		assert.Len(t, c.CustomClaims, 2)
+		assert.Equal(t, []interface{}{"admins", "devs"}, c.CustomClaims["groups"])
+		assert.Equal(t, "org-42", c.CustomClaims["org_id"])
+		// Not listed → absent.
+		assert.NotContains(t, c.CustomClaims, "tenant_id")
+	})
+
+	t.Run("protocol/registered claims never leak when not listed", func(t *testing.T) {
+		c := &Claims{}
+		captureAllowedClaims(raw, []string{"groups"}, c)
+
+		for _, protocolKey := range []string{"nbf", "nonce", "c_hash", "at_hash", "sid"} {
+			assert.NotContains(t, c.CustomClaims, protocolKey)
+		}
+	})
+
+	t.Run("empty allowlist captures nothing", func(t *testing.T) {
+		c := &Claims{}
+		captureAllowedClaims(raw, nil, c)
+		assert.Nil(t, c.CustomClaims)
+
+		captureAllowedClaims(raw, []string{}, c)
+		assert.Nil(t, c.CustomClaims)
+	})
+
+	t.Run("allowlisted key absent from response is skipped", func(t *testing.T) {
+		c := &Claims{}
+		captureAllowedClaims(raw, []string{"groups", "not_present"}, c)
+
+		assert.Contains(t, c.CustomClaims, "groups")
+		// No nil entry created for the missing key.
+		assert.NotContains(t, c.CustomClaims, "not_present")
+		assert.Len(t, c.CustomClaims, 1)
+	})
+
+	t.Run("azure-style stripped keys are not re-added", func(t *testing.T) {
+		// Simulates the Azure path where the parser intentionally strips some
+		// keys: an allowlist that omits them must not bring them back.
+		azureRaw := map[string]interface{}{
+			"sub":      "azure-user",
+			"email":    "user@example.com",
+			"groups":   []interface{}{"team-a"},
+			"aio":      "stripped-azure-internal",
+			"xms_edov": "1",
+			"nonce":    "n-1",
+		}
+		c := &Claims{}
+		captureAllowedClaims(azureRaw, []string{"groups"}, c)
+
+		assert.Equal(t, []interface{}{"team-a"}, c.CustomClaims["groups"])
+		assert.NotContains(t, c.CustomClaims, "aio")
+		assert.NotContains(t, c.CustomClaims, "xms_edov")
+		assert.NotContains(t, c.CustomClaims, "nonce")
+	})
+}
+
+func TestCustomOAuthProvider_GetUserData_CustomClaimsAllowlist(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"sub":            "user-123",
+			"email":          "test@example.com",
+			"email_verified": true,
+			"groups":         []interface{}{"admins"},
+			"org_id":         "org-42",
+			"tenant_id":      "tenant-7", // not allowlisted
+			"nonce":          "should-not-leak",
+		})
+	}))
+	defer server.Close()
+
+	provider := NewCustomOAuthProvider(
+		"client-id", "client-secret",
+		"https://example.com/authorize", "https://example.com/token",
+		server.URL, "https://myapp.com/callback",
+		[]string{"openid"}, false,
+		nil, nil, nil,
+		[]string{"groups", "org_id"},
+	)
+
+	userData, err := provider.GetUserData(context.Background(), &oauth2.Token{AccessToken: "t", TokenType: "Bearer"})
+	require.NoError(t, err)
+	require.NotNil(t, userData.Metadata)
+
+	require.NotNil(t, userData.Metadata.CustomClaims)
+	assert.Equal(t, []interface{}{"admins"}, userData.Metadata.CustomClaims["groups"])
+	assert.Equal(t, "org-42", userData.Metadata.CustomClaims["org_id"])
+	assert.NotContains(t, userData.Metadata.CustomClaims, "tenant_id")
+	assert.NotContains(t, userData.Metadata.CustomClaims, "nonce")
+	// Standard claims still parsed.
+	assert.Equal(t, "test@example.com", userData.Metadata.Email)
+}
+
+func TestCustomOAuthProvider_GetUserData_EmptyAllowlist(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"sub":    "user-123",
+			"email":  "test@example.com",
+			"groups": []interface{}{"admins"},
+		})
+	}))
+	defer server.Close()
+
+	provider := NewCustomOAuthProvider(
+		"client-id", "client-secret",
+		"https://example.com/authorize", "https://example.com/token",
+		server.URL, "https://myapp.com/callback",
+		[]string{"openid"}, false,
+		nil, nil, nil,
+		nil, // empty allowlist
+	)
+
+	userData, err := provider.GetUserData(context.Background(), &oauth2.Token{AccessToken: "t", TokenType: "Bearer"})
+	require.NoError(t, err)
+	require.NotNil(t, userData.Metadata)
+	assert.Nil(t, userData.Metadata.CustomClaims)
+}
+
+func TestCustomOIDCProvider_GetUserData_UserinfoAllowlist(t *testing.T) {
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/.well-known/openid-configuration":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"issuer":                 server.URL,
+				"authorization_endpoint": server.URL + "/authorize",
+				"token_endpoint":         server.URL + "/token",
+				"userinfo_endpoint":      server.URL + "/userinfo",
+				"jwks_uri":               server.URL + "/jwks",
+			})
+		case "/jwks":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"keys": []interface{}{}})
+		case "/userinfo":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"sub":       "user-123",
+				"email":     "test@example.com",
+				"mail":      "alt@example.com",
+				"sn":        "Doe",
+				"tenant_id": "tenant-7", // not allowlisted
+			})
+		}
+	}))
+	defer server.Close()
+
+	provider, err := NewCustomOIDCProvider(
+		context.Background(),
+		"client-id", "client-secret", "https://myapp.com/callback",
+		[]string{"openid"}, server.URL, false,
+		nil, nil, nil,
+		[]string{"mail", "sn"},
+		NewOIDCProviderCache(0),
+	)
+	require.NoError(t, err)
+
+	// Token with no id_token → falls through to userinfo endpoint.
+	userData, err := provider.GetUserData(context.Background(), &oauth2.Token{AccessToken: "t", TokenType: "Bearer"})
+	require.NoError(t, err)
+	require.NotNil(t, userData.Metadata)
+
+	require.NotNil(t, userData.Metadata.CustomClaims)
+	assert.Equal(t, "alt@example.com", userData.Metadata.CustomClaims["mail"])
+	assert.Equal(t, "Doe", userData.Metadata.CustomClaims["sn"])
+	assert.NotContains(t, userData.Metadata.CustomClaims, "tenant_id")
+}
+
+func TestCustomOIDCProvider_GetUserData_IDTokenAllowlist(t *testing.T) {
+	defer func() {
+		OverrideVerifiers = make(map[string]func(context.Context, *oidc.Config) *oidc.IDTokenVerifier)
+		OverrideClock = nil
+	}()
+
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/.well-known/openid-configuration":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"issuer":                 server.URL,
+				"authorization_endpoint": server.URL + "/authorize",
+				"token_endpoint":         server.URL + "/token",
+				"jwks_uri":               server.URL + "/jwks",
+			})
+		case "/jwks":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"keys": []interface{}{}})
+		}
+	}))
+	defer server.Close()
+
+	issuedAt := time.Unix(1700000000, 0)
+	claims := jwt.MapClaims{
+		"iss":       server.URL,
+		"aud":       "client-id",
+		"sub":       "user-123",
+		"email":     "test@example.com",
+		"groups":    []string{"admins", "devs"},
+		"org_id":    "org-42",
+		"iat":       issuedAt.Unix(),
+		"exp":       issuedAt.Add(time.Hour).Unix(),
+		"nbf":       issuedAt.Unix(),   // protocol claim, not allowlisted
+		"nonce":     "should-not-leak", // protocol claim, not allowlisted
+		"c_hash":    "should-not-leak", // protocol claim, not allowlisted
+		"tenant_id": "tenant-7",        // not allowlisted
+	}
+	tokenString, err := jwt.NewWithClaims(jwt.SigningMethodRS256, claims).SignedString(key)
+	require.NoError(t, err)
+
+	provider, err := NewCustomOIDCProvider(
+		context.Background(),
+		"client-id", "client-secret", "https://myapp.com/callback",
+		[]string{"openid"}, server.URL, false,
+		nil, nil, nil,
+		[]string{"groups", "org_id"},
+		NewOIDCProviderCache(0),
+	)
+	require.NoError(t, err)
+
+	// Override the verifier to trust our in-test signing key, and freeze the clock.
+	OverrideVerifiers[server.URL+"/authorize"] = func(ctx context.Context, config *oidc.Config) *oidc.IDTokenVerifier {
+		return oidc.NewVerifier(server.URL, &oidc.StaticKeySet{
+			PublicKeys: []crypto.PublicKey{&key.PublicKey},
+		}, config)
+	}
+	OverrideClock = func() time.Time { return issuedAt.Add(time.Second) }
+
+	tok := (&oauth2.Token{AccessToken: "t", TokenType: "Bearer"}).WithExtra(map[string]interface{}{
+		"id_token": tokenString,
+	})
+
+	userData, err := provider.GetUserData(context.Background(), tok)
+	require.NoError(t, err)
+	require.NotNil(t, userData.Metadata)
+
+	require.NotNil(t, userData.Metadata.CustomClaims)
+	assert.ElementsMatch(t, []interface{}{"admins", "devs"}, userData.Metadata.CustomClaims["groups"])
+	assert.Equal(t, "org-42", userData.Metadata.CustomClaims["org_id"])
+	// Protocol claims and non-listed keys must not be re-added.
+	for _, k := range []string{"nbf", "nonce", "c_hash", "tenant_id"} {
+		assert.NotContains(t, userData.Metadata.CustomClaims, k)
+	}
+}

--- a/internal/api/provider/custom_oauth_claims_test.go
+++ b/internal/api/provider/custom_oauth_claims_test.go
@@ -191,10 +191,10 @@ func TestCustomOIDCProvider_GetUserData_UserinfoAllowlist(t *testing.T) {
 	provider, err := NewCustomOIDCProvider(
 		context.Background(),
 		"client-id", "client-secret", "https://myapp.com/callback",
-		[]string{"openid"}, server.URL, false,
+		[]string{"openid"}, server.URL, server.URL + "/.well-known/openid-configuration", false,
 		nil, nil, nil,
 		[]string{"mail", "sn"},
-		NewOIDCProviderCache(0),
+		newTestOIDCProviderCache(t, 0),
 	)
 	require.NoError(t, err)
 
@@ -257,10 +257,10 @@ func TestCustomOIDCProvider_GetUserData_IDTokenAllowlist(t *testing.T) {
 	provider, err := NewCustomOIDCProvider(
 		context.Background(),
 		"client-id", "client-secret", "https://myapp.com/callback",
-		[]string{"openid"}, server.URL, false,
+		[]string{"openid"}, server.URL, server.URL + "/.well-known/openid-configuration", false,
 		nil, nil, nil,
 		[]string{"groups", "org_id"},
-		NewOIDCProviderCache(0),
+		newTestOIDCProviderCache(t, 0),
 	)
 	require.NoError(t, err)
 

--- a/internal/api/provider/custom_oauth_test.go
+++ b/internal/api/provider/custom_oauth_test.go
@@ -30,6 +30,7 @@ func TestNewCustomOAuthProvider(t *testing.T) {
 		map[string]interface{}{
 			"prompt": "consent",
 		},
+		nil,
 	)
 
 	assert.NotNil(t, provider)
@@ -64,6 +65,7 @@ func TestCustomOAuthProvider_AuthCodeURL(t *testing.T) {
 				"access_type":  "offline",
 				"custom_param": "custom_value",
 			},
+			nil,
 		)
 
 		authURL := provider.AuthCodeURL("test-state")
@@ -111,6 +113,7 @@ func TestCustomOAuthProvider_GetUserData(t *testing.T) {
 		nil,
 		nil,
 		nil,
+		nil,
 	)
 
 	token := &oauth2.Token{
@@ -155,6 +158,7 @@ func TestCustomOAuthProvider_GetUserDataWithAttributeMapping(t *testing.T) {
 			"name":           "full_name", // Map full_name field to name
 		},
 		nil,
+		nil,
 	)
 
 	token := &oauth2.Token{
@@ -185,7 +189,7 @@ func TestApplyAttributeMapping(t *testing.T) {
 				Email:   "test@example.com",
 			},
 			mapping: map[string]interface{}{
-				"email_verified": true, // Literal boolean value
+				"email_verified": true,                // Literal boolean value
 				"iat":            float64(1234567890), // Literal number value
 			},
 			expected: Claims{
@@ -204,15 +208,15 @@ func TestApplyAttributeMapping(t *testing.T) {
 				AvatarURL: "https://example.com/avatar.jpg",
 			},
 			mapping: map[string]interface{}{
-				"name":    "full_name",    // Map full_name -> name
-				"picture": "avatar_url",   // Map avatar_url -> picture
+				"name":    "full_name",  // Map full_name -> name
+				"picture": "avatar_url", // Map avatar_url -> picture
 			},
 			expected: Claims{
-				Subject:  "user-123",
-				Email:    "test@example.com",
-				Name:     "John Doe",
-				Picture:  "https://example.com/avatar.jpg",
-				FullName: "John Doe",  // Original field still exists
+				Subject:   "user-123",
+				Email:     "test@example.com",
+				Name:      "John Doe",
+				Picture:   "https://example.com/avatar.jpg",
+				FullName:  "John Doe", // Original field still exists
 				AvatarURL: "https://example.com/avatar.jpg",
 			},
 		},
@@ -274,12 +278,13 @@ func TestNewCustomOIDCProvider(t *testing.T) {
 		"test-client-secret",
 		"https://myapp.com/callback",
 		[]string{"profile", "email"}, // Without openid
-		server.URL, // issuer
-		server.URL + "/.well-known/openid-configuration",
+		server.URL,                   // issuer
+		server.URL+"/.well-known/openid-configuration",
 		true, // PKCE enabled
 		[]string{"ios-client", "android-client"},
 		map[string]interface{}{"email": "user_email"},
 		map[string]interface{}{"prompt": "consent"},
+		nil,
 		newTestOIDCProviderCache(t, 0),
 	)
 
@@ -405,7 +410,7 @@ func TestCustomOIDCProvider_AuthCodeURL(t *testing.T) {
 		"https://myapp.com/callback",
 		[]string{"openid", "profile"},
 		server.URL, // issuer
-		server.URL + "/.well-known/openid-configuration",
+		server.URL+"/.well-known/openid-configuration",
 		false,
 		nil,
 		nil,
@@ -415,6 +420,7 @@ func TestCustomOIDCProvider_AuthCodeURL(t *testing.T) {
 			"ui_locales": "en",
 			"login_hint": "user@example.com",
 		},
+		nil,
 		newTestOIDCProviderCache(t, 0),
 	)
 
@@ -506,8 +512,9 @@ func TestCustomOIDCProvider_RequiresPKCE(t *testing.T) {
 			"https://myapp.com/callback",
 			[]string{"openid"},
 			server.URL, // issuer
-			server.URL + "/.well-known/openid-configuration",
+			server.URL+"/.well-known/openid-configuration",
 			true, // PKCE enabled
+			nil,
 			nil,
 			nil,
 			nil,
@@ -527,8 +534,9 @@ func TestCustomOIDCProvider_RequiresPKCE(t *testing.T) {
 			"https://myapp.com/callback",
 			[]string{"openid"},
 			server.URL, // issuer
-			server.URL + "/.well-known/openid-configuration",
+			server.URL+"/.well-known/openid-configuration",
 			false, // PKCE disabled
+			nil,
 			nil,
 			nil,
 			nil,

--- a/internal/api/provider/custom_oauth_test.go
+++ b/internal/api/provider/custom_oauth_test.go
@@ -472,6 +472,7 @@ func TestNewCustomOIDCProvider_CustomDiscoveryURL(t *testing.T) {
 		server.URL+"/custom-discovery",
 		false,
 		nil, nil, nil,
+		nil,
 		newTestOIDCProviderCache(t, time.Hour),
 	)
 	require.NoError(t, err)

--- a/internal/models/custom_oauth_provider.go
+++ b/internal/models/custom_oauth_provider.go
@@ -37,9 +37,12 @@ type CustomOAuthProvider struct {
 	Scopes              slices.String `db:"scopes" json:"scopes"`
 	PKCEEnabled         bool          `db:"pkce_enabled" json:"pkce_enabled"`
 	AttributeMapping    slices.Map    `db:"attribute_mapping" json:"attribute_mapping"`
-	AuthorizationParams slices.Map    `db:"authorization_params" json:"authorization_params"`
-	Enabled             bool          `db:"enabled" json:"enabled"`
-	EmailOptional       bool          `db:"email_optional" json:"email_optional"`
+	// CustomClaimsAllowlist is a flat list of raw IdP claim keys copied verbatim
+	// into custom_claims. Empty means no custom claims are captured.
+	CustomClaimsAllowlist slices.String `db:"custom_claims_allowlist" json:"custom_claims_allowlist"`
+	AuthorizationParams   slices.Map    `db:"authorization_params" json:"authorization_params"`
+	Enabled               bool          `db:"enabled" json:"enabled"`
+	EmailOptional         bool          `db:"email_optional" json:"email_optional"`
 
 	// OIDC-specific fields (null for OAuth2 providers)
 	Issuer            *string        `db:"issuer" json:"issuer,omitempty"`
@@ -281,6 +284,9 @@ func CreateCustomOAuthProvider(tx *storage.Connection, provider *CustomOAuthProv
 	}
 	if provider.AcceptableClientIDs == nil {
 		provider.AcceptableClientIDs = slices.String{}
+	}
+	if provider.CustomClaimsAllowlist == nil {
+		provider.CustomClaimsAllowlist = slices.String{}
 	}
 
 	if err := tx.Create(provider); err != nil {

--- a/internal/models/custom_oauth_provider_test.go
+++ b/internal/models/custom_oauth_provider_test.go
@@ -199,6 +199,46 @@ func (ts *CustomOAuthProviderTestSuite) TestStringSliceSerialization() {
 	assert.Empty(ts.T(), found.Scopes)
 }
 
+func (ts *CustomOAuthProviderTestSuite) TestCustomClaimsAllowlistSerialization() {
+	provider := &CustomOAuthProvider{
+		ProviderType:          ProviderTypeOAuth2,
+		Identifier:            "custom:allowlist-test",
+		Name:                  "Allowlist Test",
+		ClientID:              "client-id",
+		AuthorizationURL:      stringPtr("https://example.com/authorize"),
+		TokenURL:              stringPtr("https://example.com/token"),
+		UserinfoURL:           stringPtr("https://example.com/userinfo"),
+		CustomClaimsAllowlist: slices.String{"groups", "org_id", "mail", "sn"},
+		PKCEEnabled:           true,
+		Enabled:               true,
+	}
+
+	err := CreateCustomOAuthProvider(ts.db, provider)
+	require.NoError(ts.T(), err)
+
+	// Retrieve and verify the non-empty allowlist round-trips.
+	found, err := FindCustomOAuthProviderByID(ts.db, provider.ID)
+	require.NoError(ts.T(), err)
+	assert.Equal(ts.T(), slices.String{"groups", "org_id", "mail", "sn"}, found.CustomClaimsAllowlist)
+
+	// Replacing with an empty allowlist round-trips to an empty slice.
+	provider.CustomClaimsAllowlist = slices.String{}
+	err = UpdateCustomOAuthProvider(ts.db, provider)
+	require.NoError(ts.T(), err)
+
+	found, err = FindCustomOAuthProviderByID(ts.db, provider.ID)
+	require.NoError(ts.T(), err)
+	assert.Empty(ts.T(), found.CustomClaimsAllowlist)
+}
+
+func (ts *CustomOAuthProviderTestSuite) TestCustomClaimsAllowlistDefaultsEmpty() {
+	provider := ts.createTestProvider(ProviderTypeOAuth2, "custom:allowlist-default")
+
+	found, err := FindCustomOAuthProviderByID(ts.db, provider.ID)
+	require.NoError(ts.T(), err)
+	assert.Empty(ts.T(), found.CustomClaimsAllowlist)
+}
+
 func (ts *CustomOAuthProviderTestSuite) TestAttributeMappingSerialization() {
 	mapping := slices.Map{
 		"email":      "user_email",

--- a/migrations/20260611000000_add_custom_claims_allowlist.up.sql
+++ b/migrations/20260611000000_add_custom_claims_allowlist.up.sql
@@ -1,0 +1,6 @@
+-- Add custom_claims_allowlist column to custom_oauth_providers table
+-- Holds a flat list of raw IdP claim keys to copy verbatim into custom_claims.
+-- Empty (the default) means no custom claims are captured.
+/* auth_migration: 20260611000000 */
+alter table {{ index .Options "Namespace" }}.custom_oauth_providers
+    add column if not exists custom_claims_allowlist text[] not null default '{}';

--- a/migrations/20260625000000_add_custom_claims_allowlist.up.sql
+++ b/migrations/20260625000000_add_custom_claims_allowlist.up.sql
@@ -1,6 +1,6 @@
 -- Add custom_claims_allowlist column to custom_oauth_providers table
 -- Holds a flat list of raw IdP claim keys to copy verbatim into custom_claims.
 -- Empty (the default) means no custom claims are captured.
-/* auth_migration: 20260611000000 */
+/* auth_migration: 20260625000000 */
 alter table {{ index .Options "Namespace" }}.custom_oauth_providers
     add column if not exists custom_claims_allowlist text[] not null default '{}';

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2339,6 +2339,12 @@ paths:
                   example:
                     email: "user_email"
                     name: "full_name"
+                custom_claims_allowlist:
+                  type: array
+                  items:
+                    type: string
+                  description: Raw IdP claim keys to copy verbatim into the user's custom_claims (e.g. groups, org_id). For OIDC providers these are read from the ID token claims (falling back to the userinfo response when no ID token is returned); for OAuth2 providers they are read from the userinfo response. Empty preserves no non-standard claims.
+                  example: ["groups", "org_id"]
                 authorization_params:
                   type: object
                   description: Additional authorization request parameters as string key-value pairs (cannot override reserved OAuth parameters)
@@ -2565,6 +2571,11 @@ paths:
                   type: object
                   description: Map provider claims to user attributes
                   additionalProperties: true
+                custom_claims_allowlist:
+                  type: array
+                  items:
+                    type: string
+                  description: Raw IdP claim keys to copy verbatim into the user's custom_claims (e.g. groups, org_id). For OIDC providers these are read from the ID token claims (falling back to the userinfo response when no ID token is returned); for OAuth2 providers they are read from the userinfo response. Empty preserves no non-standard claims.
                 authorization_params:
                   type: object
                   description: Additional authorization request parameters as string key-value pairs
@@ -3777,6 +3788,12 @@ components:
           example:
             email: "user_email"
             name: "full_name"
+        custom_claims_allowlist:
+          type: array
+          items:
+            type: string
+          description: Raw IdP claim keys copied verbatim into the user's custom_claims (e.g. groups, org_id). For OIDC providers these are read from the ID token claims (falling back to the userinfo response when no ID token is returned); for OAuth2 providers they are read from the userinfo response. Empty preserves no non-standard claims.
+          example: ["groups", "org_id"]
         authorization_params:
           type: object
           description: Additional parameters to include in authorization requests as string key-value pairs (cannot override reserved OAuth parameters)


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

 ## What

Adds a per-provider `custom_claims_allowlist` to custom OAuth/OIDC providers: a flat list of raw IdP claim keys that get copied verbatim into `custom_claims` on the user's `identity_data` / `raw_user_meta_data`.

  ```
  PATCH /admin/custom-providers/custom:acme
  { "custom_claims_allowlist": ["groups", "org_id", "mail", "sn"] }

Result, queryable in a before insert on auth.users trigger (and stored in the auth.identities table as well for future queries):
  "custom_claims": { "groups": [...], "org_id": "...", "mail": "...", "sn": "..." }
```

## Why

Admins integrating non-standard IdPs need to read provider-specific claims (e.g. groups, mail, nlEduPersonProfileId) that don't map to standard fields. This is the allowlist design rather than a denylist (previous implementation: https://github.com/supabase/auth/pull/2520):

- No Azure "re-add stripped claims" risk: we only copy keys explicitly named, so a parser that strips a claim stays authoritative.
- No reflection, no exhaustive exclusion set to maintain, no ordering hazard with ParseIDToken.

Design decisions
- Default = empty -> capture nothing. Opt-in only.
- text[] column (slices.String), matching `scopes` / `acceptable_client_ids`.
- Distinct from attribute_mapping: the allowlist copies raw source keys into the opaque custom_claims bucket; attribute_mapping remaps typed fields. No privilege-escalation surface, so no blocked-target guard (only a non-empty-entry check).
- Capture runs before applyAttributeMapping at all sources (OAuth userinfo, OIDC userinfo) via one captureAllowedClaims helper.