### PR TITLE
fix(sms): render literal \n in SMS/MFA OTP templates as newlines

### DIFF
--- a/internal/conf/configuration.go
+++ b/internal/conf/configuration.go
@@ -971,6 +971,7 @@ func (config *GlobalConfiguration) PopulateGlobal() error {
 		if SMSTemplate == "" {
 			SMSTemplate = "Your code is {{ .Code }}"
 		}
+		SMSTemplate = strings.ReplaceAll(SMSTemplate, `\n`, "\n")
 		template, err := template.New("").Parse(SMSTemplate)
 		if err != nil {
 			return err
@@ -983,6 +984,7 @@ func (config *GlobalConfiguration) PopulateGlobal() error {
 		if smsTemplate == "" {
 			smsTemplate = "Your code is {{ .Code }}"
 		}
+		smsTemplate = strings.ReplaceAll(smsTemplate, `\n`, "\n")
 		template, err := template.New("").Parse(smsTemplate)
 		if err != nil {
 			return err

--- a/internal/conf/configuration_test.go
+++ b/internal/conf/configuration_test.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 	"strings"
 	"testing"
+	"text/template"
 	"time"
 
 	"github.com/lestrrat-go/jwx/v2/jwa"
@@ -986,4 +987,37 @@ func TestWebAuthnConfigurationValidate(t *testing.T) {
 
 func toPtr[T any](v T) *T {
 	return &(&([1]T{T(v)}))[0]
+}
+
+func TestSMSTemplateNewlines(t *testing.T) {
+	// Literal "\n" escape sequences in the SMS/MFA OTP templates should be
+	// rendered as real newlines so multi-line messages can be sent (e.g. as
+	// required by the WebOTP API).
+	// See https://github.com/supabase/supabase/issues/6435
+	cfg := &GlobalConfiguration{
+		JWT: JWTConfiguration{Secret: "a"},
+		Sms: SmsProviderConfiguration{
+			Provider: "twilio",
+			Template: `Your code is {{ .Code }}\n@example.com #{{ .Code }}`,
+		},
+	}
+	cfg.MFA.Phone.EnrollEnabled = true
+	cfg.MFA.Phone.Template = `MFA code {{ .Code }}\nfrom example`
+
+	require.NoError(t, cfg.PopulateGlobal())
+
+	render := func(tmpl *template.Template) string {
+		var b strings.Builder
+		require.NoError(t, tmpl.Execute(&b, struct{ Code string }{Code: "123456"}))
+		return b.String()
+	}
+
+	smsMsg := render(cfg.Sms.SMSTemplate)
+	require.Equal(t, "Your code is 123456\n@example.com #123456", smsMsg)
+	require.Contains(t, smsMsg, "\n")
+	require.NotContains(t, smsMsg, `\n`)
+
+	mfaMsg := render(cfg.MFA.Phone.SMSTemplate)
+	require.Equal(t, "MFA code 123456\nfrom example", mfaMsg)
+	require.NotContains(t, mfaMsg, `\n`)
 }


### PR DESCRIPTION
The description box auto-loaded Supabase's PR template (those ## What kind of change..., ## What is the current behavior? prompts). You
  

  Fixes supabase/supabase#6435

  ## What kind of change does this PR introduce?
  Bug fix — allows newlines in the SMS / MFA phone OTP templates.

  ## What is the current behavior?
  Go's `text/template` treats template text literally, so a literal `\n` in
  `GOTRUE_SMS_TEMPLATE` (or the MFA phone template) is emitted as the two
  characters `\` + `n` instead of a real newline. This is why `"\n"` and
  `"\\n"` don't work today, and it blocks multi-line OTP messages required by
  the WebOTP API.
  
  ## What is the new behavior?
  Literal `\n` sequences in the SMS and MFA phone templates are unescaped into
  real newlines before the templates are parsed. Added a test covering both
  templates. No default values or test config were changed.