### PR TITLE
fix: return email_address_not_provided for external provider with no email

### DIFF
--- a/internal/api/external.go
+++ b/internal/api/external.go
@@ -173,7 +173,7 @@ func (a *API) internalExternalProviderCallback(w http.ResponseWriter, r *http.Re
 	userData := data.userData
 
 	if len(userData.Emails) == 0 && !emailOptional {
-		return apierrors.NewInternalServerError("Error getting user email from external provider")
+		return apierrors.NewUnprocessableEntityError(apierrors.ErrorCodeEmailAddressNotProvided, "Error getting user email from external provider")
 	}
 
 	userData.Metadata.EmailVerified = false

--- a/internal/api/external_google_test.go
+++ b/internal/api/external_google_test.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 
 	"github.com/stretchr/testify/require"
+	"github.com/supabase/auth/internal/api/apierrors"
 	"github.com/supabase/auth/internal/api/provider"
 )
 
@@ -105,6 +106,10 @@ func (ts *ExternalTestSuite) TestSignupExternalGoogleDisableSignupErrorWhenEmpty
 	u := performAuthorization(ts, "google", code, "")
 
 	assertAuthorizationFailure(ts, u, "Error getting user email from external provider", "server_error", "google@example.com")
+
+	q, err := url.ParseQuery(u.RawQuery)
+	ts.Require().NoError(err)
+	ts.Require().Equal(apierrors.ErrorCodeEmailAddressNotProvided, q.Get("error_code"))
 }
 
 func (ts *ExternalTestSuite) TestSignupExternalGoogleDisableSignupSuccessWithPrimaryEmail() {


### PR DESCRIPTION
## What

When an external OAuth provider returns no email (and the provider is not email-optional), the callback rejected the sign-in with a generic `NewInternalServerError` — HTTP 500, `error_code = unexpected_failure`:

```go
if len(userData.Emails) == 0 && !emailOptional {
    return apierrors.NewInternalServerError("Error getting user email from external provider")
}
```

This wires in the already-defined but **unused** `ErrorCodeEmailAddressNotProvided` and returns a 422 instead:

```go
return apierrors.NewUnprocessableEntityError(apierrors.ErrorCodeEmailAddressNotProvided, "Error getting user email from external provider")
```

Closes #2583.

## Why

- A provider not returning an email is not a server fault — 500 mis-classifies it.
- Clients currently have to substring-match the `error_description` to detect this case. A dedicated `error_code` lets them branch reliably. This came up with Sign in with Apple (email scope withheld), where downstream SDKs can only show a generic error today.
- `email_address_not_provided` is already defined in `errorcode.go` but referenced nowhere; this is its natural use.

## Compatibility

For the OAuth redirect flow, `error` and `error_description` are **unchanged**: 422 is not in `oauthErrorMap`, so `getErrorQueryString` still falls back to `error=server_error`, and `error_description` is the same string. Only `error_code` changes (`unexpected_failure` → `email_address_not_provided`). Existing clients reading `error`/`error_description` are unaffected; new clients gain a stable code. Logging for this case also drops from error-level (with stack trace) to info-level, matching its 4xx nature.

## Testing

- `go build ./...`, `go vet ./internal/api/`, `gofmt` — clean.
- The full `TestExternal` suite passes against a local Postgres (all providers' `...ErrorWhenEmptyEmail` cases still reject as expected).
- Added an assertion to `TestSignupExternalGoogleDisableSignupErrorWhenEmptyEmail` locking in `error_code = email_address_not_provided`.

> Note: I did not run the entire `make docker-test` suite locally (only the `internal/api` external tests); CI will cover the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)