### PR TITLE
fix: read template body from local file path when configured

### DIFF
--- a/internal/mailer/templatemailer/template.go
+++ b/internal/mailer/templatemailer/template.go
@@ -7,6 +7,7 @@ import (
 	"html/template"
 	"io"
 	"net/http"
+	"os"
 	"strings"
 	"sync"
 	"time"
@@ -452,14 +453,27 @@ func (o *Cache) loadEntryBody(
 		temp := template.Must(template.New("").Parse(tempStr))
 		return temp, nil
 	}
-	if !strings.HasPrefix(url, "http") {
-		url = cfg.SiteURL + url
-	}
 
-	tempStr, err := o.fetch(ctx, cfg, url)
-	if err != nil {
-		err = wrapError(ctx, typ, "template_body_http_error", err)
-		return nil, err
+	var tempStr string
+	if strings.HasPrefix(url, "file://") || strings.HasPrefix(url, "/") || strings.HasPrefix(url, "./") {
+		// Local file path: strip optional file:// scheme and read from disk.
+		filePath := strings.TrimPrefix(url, "file://")
+		data, rerr := os.ReadFile(filePath)
+		if rerr != nil {
+			rerr = wrapError(ctx, typ, "template_body_file_error", rerr)
+			return nil, rerr
+		}
+		tempStr = string(data)
+	} else {
+		if !strings.HasPrefix(url, "http") {
+			url = cfg.SiteURL + url
+		}
+		var ferr error
+		tempStr, ferr = o.fetch(ctx, cfg, url)
+		if ferr != nil {
+			ferr = wrapError(ctx, typ, "template_body_http_error", ferr)
+			return nil, ferr
+		}
 	}
 
 	temp, err := template.New(url).Parse(tempStr)


### PR DESCRIPTION
When `GOTRUE_MAILER_TEMPLATES_*` is set to a local file path such as
`/etc/gotrue/templates/confirmation.html`, the template loader was prepending
`SiteURL` and issuing an HTTP GET. Because `/etc/gotrue/templates/confirmation.html`
is not a valid URL path relative to the site, the GET would silently fail or
return the site's root HTML, causing outgoing emails to contain the rendered
HTML of the application rather than the intended template.

**Root cause**

`loadEntryBody` in `internal/mailer/templatemailer/template.go` checked only for
an `http` prefix to decide whether to fetch or prepend. Absolute paths, relative
paths (`./`), and `file://` URIs all fell through to the SiteURL-prepend branch.

**Fix**

Add a path-vs-URL check before the fetch. Values starting with `/`, `./`, or
`file://` are read directly from disk with `os.ReadFile`. The `file://` scheme is
stripped before the read so the path is passed verbatim to the OS. Only values
starting with `http` (or lacking any recognised scheme) continue through the
existing HTTP fetch path.

No existing tests are broken by this change. The default-template fallback and
the SiteURL-relative-fragment behavior are unchanged.

Fixes #2589