### PR TITLE
fix(otp): improve error messages when phone provider is not configured

### DIFF
--- a/internal/api/otp.go
+++ b/internal/api/otp.go
@@ -91,7 +91,12 @@ func (a *API) Otp(w http.ResponseWriter, r *http.Request) error {
 		return a.SmsOtp(w, r)
 	}
 
-	return apierrors.NewBadRequestError(apierrors.ErrorCodeValidationFailed, "One of email or phone must be set")
+	return apierrors.NewBadRequestError(
+    apierrors.ErrorCodeValidationFailed,
+    "One of 'email' or 'phone' must be provided in the request body. "+
+        "If you are using email OTP, ensure the 'email' field is set. "+
+        "If you are using SMS OTP, ensure the 'phone' field is set in E.164 format (e.g. +19998887777).",
+)
 }
 
 type SmsOtpResponse struct {
@@ -105,8 +110,13 @@ func (a *API) SmsOtp(w http.ResponseWriter, r *http.Request) error {
 	config := a.config
 
 	if !config.External.Phone.Enabled {
-		return apierrors.NewBadRequestError(apierrors.ErrorCodePhoneProviderDisabled, "Unsupported phone provider")
-	}
+    return apierrors.NewBadRequestError(
+        apierrors.ErrorCodePhoneProviderDisabled,
+        "SMS/phone authentication is not enabled for this project. "+
+            "To fix this, go to your Supabase Dashboard → Authentication → Providers → Phone, "+
+            "enable Phone Auth, and configure a provider such as Twilio or Vonage.",
+    )
+}
 	var err error
 
 	params := &SmsParams{}


### PR DESCRIPTION
## Problem
Closes supabase/supabase#46570

When users request an OTP verification code and don't receive it, 
developers currently get this unhelpful error:

This tells them nothing about what is wrong or how to fix it. 
Developers then have to search through docs and GitHub issues to 
find out they need to configure Twilio/Vonage in the dashboard.

## Changes

**`internal/api/otp.go`**

1. Improved error message when phone provider is not enabled — 
   now points developer directly to Dashboard → Authentication → 
   Providers → Phone
   
2. Improved error message when neither email nor phone is provided — 
   now explains E.164 phone format requirement

## Before

```json
{
  "error": "phone_provider_disabled",
  "message": "Unsupported phone provider"
}
```

## After

```json
{
  "error": "phone_provider_disabled", 
  "message": "SMS/phone authentication is not enabled for this project. To fix this, go to your Supabase Dashboard → Authentication → Providers → Phone, enable Phone Auth, and configure a provider such as Twilio or Vonage."
}
```

## Testing
- No logic changes, only error message strings updated
- All existing tests continue to pass