### PR TITLE
fix(vulncheck): ignore GO-2026-5004 (pgx/v4, not reachable)

### DIFF
--- a/hack/vulncheck-filter/main.go
+++ b/hack/vulncheck-filter/main.go
@@ -9,6 +9,7 @@ import (
 // Vulnerabilities with no upstream fix — remove entries once fixed.
 var ignore = map[string]string{
 	"GO-2026-4518": "pgproto3/v2 DoS, no fix available (EOL). Transitive via pgconn v1 + pop/v6.",
+	"GO-2026-5004": "pgx/v4 SQL injection via dollar-quoted placeholder confusion, no fix available. Transitive via pop/v6.",
 }
 
 func main() {


### PR DESCRIPTION
## What

  Adds `GO-2026-5004` to the `vulncheck-filter` ignore map so `make vulncheck` passes again.

## Why it's safe to ignore

  `GO-2026-5004` is a SQL injection in pgx's `sanitize.SanitizeSQL`, reaching us transitively: `pop/v6 → pgx/v4/stdlib →
  pgx/v4`.

It only triggers when **all** of these hold:
  1. the **simple query protocol** is used (not pgx's default, the extended protocol sends placeholder values as
  separate bind parameters, so nothing is string-interpolated client-side),
  2. the query contains dollar-quoted string literals,
  3. a value inside that literal looks like a placeholder, and
  4. an attacker controls that value.

We're not impacted:
- **We never use the simple protocol.** No `PreferSimpleProtocol` / `SimpleProtocol` / `QueryExecMode` anywhere in the tree: all DB access goes through `database/sql` → pgx/v4 `stdlib` → pop/v6 on the default extended protocol, so `SanitizeSQL` is never exercised.
- The advisory itself calls it "unlikely to occur outside of a contrived scenario."

  ## Why not fix instead

  There is **no upstream fix for pgx/v4** (only v5 ≥ 5.9.2 is patched), and pgx/v4 is transitive via `pop/v6`, so it
  can't be bumped on its own. Same situation as the existing `GO-2026-4518` entry. If we ever opt into the simple
  protocol, this should be revisited.