### PR TITLE
feat(linking): add experimental provider linking-domain groups

### DIFF
--- a/cmd/admin_cmd.go
+++ b/cmd/admin_cmd.go
@@ -66,7 +66,7 @@ func adminCreateUser(config *conf.GlobalConfiguration, args []string) {
 	defer db.Close()
 
 	aud := getAudience(config)
-	if user, err := models.IsDuplicatedEmail(db, args[0], aud, nil, config.Experimental.ProvidersWithOwnLinkingDomain); user != nil {
+	if user, err := models.IsDuplicatedEmail(db, args[0], aud, nil, config.Experimental.ProviderLinkingDomains); user != nil {
 		logrus.Fatalf("Error creating new user: user already exists")
 	} else if err != nil {
 		logrus.Fatalf("Error checking user email: %+v", err)

--- a/internal/api/admin.go
+++ b/internal/api/admin.go
@@ -348,7 +348,7 @@ func (a *API) adminUserCreate(w http.ResponseWriter, r *http.Request) error {
 		if err != nil {
 			return err
 		}
-		if user, err := models.IsDuplicatedEmail(db, params.Email, aud, nil, config.Experimental.ProvidersWithOwnLinkingDomain); err != nil {
+		if user, err := models.IsDuplicatedEmail(db, params.Email, aud, nil, config.Experimental.ProviderLinkingDomains); err != nil {
 			return apierrors.NewInternalServerError("Database error checking email").WithInternalError(err)
 		} else if user != nil {
 			return apierrors.NewUnprocessableEntityError(apierrors.ErrorCodeEmailExists, DuplicateEmailMsg)

--- a/internal/api/external.go
+++ b/internal/api/external.go
@@ -343,7 +343,7 @@ func (a *API) createAccountFromExternalIdentity(tx *storage.Connection, r *http.
 		// surface change. It therefore set to true for other linking
 		// domains, not just SSO ones. This enables different linking
 		// domains to co-exist, such as when using
-		// GOTRUE_EXPERIMENTAL_PROVIDERS_WITH_OWN_LINKING_DOMAIN="provider_a,provider_b".
+		// GOTRUE_EXPERIMENTAL_PROVIDER_LINKING_DOMAINS="provider_a=social,provider_b=social".
 		isSSOUser := decision.LinkingDomain != "default"
 
 		// because params above sets no password, this method is not

--- a/internal/api/mail.go
+++ b/internal/api/mail.go
@@ -246,7 +246,7 @@ func (a *API) adminGenerateLink(w http.ResponseWriter, r *http.Request) error {
 			if terr != nil {
 				return terr
 			}
-			if duplicateUser, terr := models.IsDuplicatedEmail(tx, params.NewEmail, user.Aud, user, config.Experimental.ProvidersWithOwnLinkingDomain); terr != nil {
+			if duplicateUser, terr := models.IsDuplicatedEmail(tx, params.NewEmail, user.Aud, user, config.Experimental.ProviderLinkingDomains); terr != nil {
 				return apierrors.NewInternalServerError("Database error checking email").WithInternalError(terr)
 			} else if duplicateUser != nil {
 				return apierrors.NewUnprocessableEntityError(apierrors.ErrorCodeEmailExists, DuplicateEmailMsg)

--- a/internal/api/signup.go
+++ b/internal/api/signup.go
@@ -146,7 +146,7 @@ func (a *API) Signup(w http.ResponseWriter, r *http.Request) error {
 		if err != nil {
 			return err
 		}
-		user, err = models.IsDuplicatedEmail(db, params.Email, params.Aud, nil, config.Experimental.ProvidersWithOwnLinkingDomain)
+		user, err = models.IsDuplicatedEmail(db, params.Email, params.Aud, nil, config.Experimental.ProviderLinkingDomains)
 	case "phone":
 		if !config.External.Phone.Enabled {
 			return apierrors.NewBadRequestError(apierrors.ErrorCodePhoneProviderDisabled, "Phone signups are disabled")

--- a/internal/api/user.go
+++ b/internal/api/user.go
@@ -132,7 +132,7 @@ func (a *API) UserUpdate(w http.ResponseWriter, r *http.Request) error {
 	}
 
 	if params.Email != "" && user.GetEmail() != params.Email {
-		if duplicateUser, err := models.IsDuplicatedEmail(db, params.Email, aud, user, config.Experimental.ProvidersWithOwnLinkingDomain); err != nil {
+		if duplicateUser, err := models.IsDuplicatedEmail(db, params.Email, aud, user, config.Experimental.ProviderLinkingDomains); err != nil {
 			return apierrors.NewInternalServerError("Database error checking email").WithInternalError(err)
 		} else if duplicateUser != nil {
 			return apierrors.NewUnprocessableEntityError(apierrors.ErrorCodeEmailExists, DuplicateEmailMsg)

--- a/internal/conf/configuration.go
+++ b/internal/conf/configuration.go
@@ -307,11 +307,52 @@ type AuditLogConfiguration struct {
 	DisablePostgres bool `split_words:"true" default:"false"`
 }
 
+// ProviderLinkingDomains maps a provider name to the account-linking domain it
+// belongs to. Providers mapped to the same domain link to one another (a
+// matching email lands on the same account) but stay isolated from the
+// "default" (email-linked) pool and from SSO.
+//
+// Provider names can themselves contain a colon (custom OAuth providers are
+// named "custom:<identifier>", e.g. "custom:github"), so the env format uses
+// "=" — not ":" — to separate the provider from its domain. Pairs are
+// comma-separated:
+//
+//	GOTRUE_EXPERIMENTAL_PROVIDER_LINKING_DOMAINS="custom:github=social,custom:google=social"
+type ProviderLinkingDomains map[string]string
+
+func (d *ProviderLinkingDomains) Decode(value string) error {
+	result := ProviderLinkingDomains{}
+	if value = strings.TrimSpace(value); value != "" {
+		for _, pair := range strings.Split(value, ",") {
+			kv := strings.SplitN(pair, "=", 2)
+			if len(kv) != 2 {
+				return fmt.Errorf("conf: invalid provider linking domain %q, expected format \"provider=domain\"", pair)
+			}
+			provider, domain := strings.TrimSpace(kv[0]), strings.TrimSpace(kv[1])
+			if provider == "" || domain == "" {
+				return fmt.Errorf("conf: invalid provider linking domain %q, provider and domain must be non-empty", pair)
+			}
+			result[provider] = domain
+		}
+	}
+	*d = result
+	return nil
+}
+
 type ExperimentalConfiguration struct {
+	// DEPRECATED: use ProviderLinkingDomains instead. Kept for backward
+	// compatibility; auto-migrated in ApplyDefaults into ProviderLinkingDomains as
+	// {provider: provider}.
+	//
 	// Names of providers (e.g. "google") which have their own identity
 	// linking domain, meaning that the ones listed here _will not
 	// participate_ in email similarity linking with other accounts.
 	ProvidersWithOwnLinkingDomain []string `split_words:"true"`
+
+	// ProviderLinkingDomains maps a provider name to the account-linking domain
+	// it belongs to. See the ProviderLinkingDomains type for the env format.
+	// Env: GOTRUE_EXPERIMENTAL_PROVIDER_LINKING_DOMAINS="custom:github=social,custom:google=social"
+	ProviderLinkingDomains ProviderLinkingDomains `split_words:"true"`
 }
 
 // ReloadingConfiguration holds the configuration values for runtime
@@ -1064,6 +1105,19 @@ func (config *GlobalConfiguration) ApplyDefaults() error {
 			config.JWT.ValidMethods = append(config.JWT.ValidMethods, key.PublicKey.Algorithm().String())
 		}
 
+	}
+
+	// Backfill the deprecated ProvidersWithOwnLinkingDomain list into the
+	// ProviderLinkingDomains map. A provider that owned its linking domain maps
+	// to a domain named after itself (own domain == own name). Explicit
+	// ProviderLinkingDomains entries win over the legacy backfill.
+	if config.Experimental.ProviderLinkingDomains == nil {
+		config.Experimental.ProviderLinkingDomains = map[string]string{}
+	}
+	for _, p := range config.Experimental.ProvidersWithOwnLinkingDomain {
+		if _, ok := config.Experimental.ProviderLinkingDomains[p]; !ok {
+			config.Experimental.ProviderLinkingDomains[p] = p
+		}
 	}
 
 	if config.Mailer.Autoconfirm && config.Mailer.AllowUnverifiedEmailSignIns {

--- a/internal/conf/configuration_test.go
+++ b/internal/conf/configuration_test.go
@@ -1011,3 +1011,85 @@ func TestWebAuthnConfigurationValidate(t *testing.T) {
 func toPtr[T any](v T) *T {
 	return &(&([1]T{T(v)}))[0]
 }
+
+func TestExperimentalProviderLinkingDomainsBackfill(t *testing.T) {
+	baseConfig := func() *GlobalConfiguration {
+		c := &GlobalConfiguration{}
+		c.JWT.Secret = "secret"
+		return c
+	}
+
+	// legacy-only: own-domain list backfills into the map as {p: p}, including
+	// provider names that contain a colon
+	{
+		c := baseConfig()
+		c.Experimental.ProvidersWithOwnLinkingDomain = []string{"custom:github"}
+		require.NoError(t, c.ApplyDefaults())
+		require.Equal(t, "custom:github", c.Experimental.ProviderLinkingDomains["custom:github"])
+	}
+
+	// new-only: explicit linking domains are preserved untouched
+	{
+		c := baseConfig()
+		c.Experimental.ProviderLinkingDomains = ProviderLinkingDomains{
+			"custom:github": "social",
+			"custom:google": "social",
+		}
+		require.NoError(t, c.ApplyDefaults())
+		require.Equal(t, ProviderLinkingDomains{
+			"custom:github": "social",
+			"custom:google": "social",
+		}, c.Experimental.ProviderLinkingDomains)
+	}
+
+	// both-set: explicit entry wins over the legacy backfill
+	{
+		c := baseConfig()
+		c.Experimental.ProvidersWithOwnLinkingDomain = []string{"custom:github"}
+		c.Experimental.ProviderLinkingDomains = ProviderLinkingDomains{"custom:github": "social"}
+		require.NoError(t, c.ApplyDefaults())
+		require.Equal(t, "social", c.Experimental.ProviderLinkingDomains["custom:github"])
+	}
+}
+
+func TestProviderLinkingDomainsDecode(t *testing.T) {
+	// "=" separates provider from domain so colon-bearing custom names survive
+	// as keys, alongside builtin names that share the same domain
+	{
+		var d ProviderLinkingDomains
+		require.NoError(t, d.Decode("github=social,custom:google=social"))
+		require.Equal(t, ProviderLinkingDomains{
+			"github":        "social",
+			"custom:google": "social",
+		}, d)
+	}
+
+	// surrounding whitespace is trimmed
+	{
+		var d ProviderLinkingDomains
+		require.NoError(t, d.Decode(" custom:github = social , google = social "))
+		require.Equal(t, ProviderLinkingDomains{
+			"custom:github": "social",
+			"google":        "social",
+		}, d)
+	}
+
+	// empty value yields an empty (non-nil) map
+	{
+		var d ProviderLinkingDomains
+		require.NoError(t, d.Decode(""))
+		require.Equal(t, ProviderLinkingDomains{}, d)
+	}
+
+	// a ":"-only pair is rejected
+	{
+		var d ProviderLinkingDomains
+		require.Error(t, d.Decode("custom:github:social"))
+	}
+
+	// missing domain is rejected
+	{
+		var d ProviderLinkingDomains
+		require.Error(t, d.Decode("custom:github="))
+	}
+}

--- a/internal/conf/confload/confload_test.go
+++ b/internal/conf/confload/confload_test.go
@@ -216,6 +216,25 @@ func TestGlobal(t *testing.T) {
 
 }
 
+func TestExperimentalProviderLinkingDomains(t *testing.T) {
+	os.Clearenv()
+	os.Setenv("GOTRUE_SITE_URL", "http://localhost:8080")
+	os.Setenv("GOTRUE_DB_DRIVER", "postgres")
+	os.Setenv("GOTRUE_DB_DATABASE_URL", "fake")
+	os.Setenv("GOTRUE_OPERATOR_TOKEN", "token")
+	os.Setenv("GOTRUE_JWT_SECRET", "secret")
+	os.Setenv("API_EXTERNAL_URL", "http://localhost:9999")
+	os.Setenv("GOTRUE_EXPERIMENTAL_PROVIDER_LINKING_DOMAINS", "github=social,custom:google=social")
+
+	cfg, err := LoadGlobalFromEnv()
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+	assert.Equal(t, conf.ProviderLinkingDomains{
+		"github":        "social",
+		"custom:google": "social",
+	}, cfg.Experimental.ProviderLinkingDomains)
+}
+
 func TestLoading(t *testing.T) {
 	os.Clearenv()
 

--- a/internal/models/linking.go
+++ b/internal/models/linking.go
@@ -1,7 +1,6 @@
 package models
 
 import (
-	"slices"
 	"strings"
 
 	"github.com/supabase/auth/internal/api/provider"
@@ -14,12 +13,22 @@ import (
 // _should_ generally fall under the same User entity. It's just a runtime
 // string, and is not typically persisted in the database. This value can vary
 // across time.
-func GetAccountLinkingDomain(provider string, ownLinkingDomains []string) string {
-	if strings.HasPrefix(provider, "sso:") || slices.Contains(ownLinkingDomains, provider) {
+//
+// The linkingDomains map assigns providers to a shared linking domain:
+// providers mapped to the same domain link to one another but stay isolated
+// from the "default" email-linked pool and from SSO.
+func GetAccountLinkingDomain(provider string, linkingDomains map[string]string) string {
+	if strings.HasPrefix(provider, "sso:") {
 		// when the provider ID is a SSO provider, then the linking
 		// domain is the provider itself i.e. there can only be one
 		// user + identity per identity provider
 		return provider
+	}
+
+	if domain, ok := linkingDomains[provider]; ok {
+		// providers mapped to the same domain share a linking domain, so
+		// they link to one another but not to default/SSO
+		return domain
 	}
 
 	// otherwise, the linking domain is the default linking domain that
@@ -65,7 +74,7 @@ func DetermineAccountLinking(tx *storage.Connection, config *conf.GlobalConfigur
 	}
 
 	// this is the linking domain for the new identity
-	candidateLinkingDomain := GetAccountLinkingDomain(providerName, config.Experimental.ProvidersWithOwnLinkingDomain)
+	candidateLinkingDomain := GetAccountLinkingDomain(providerName, config.Experimental.ProviderLinkingDomains)
 
 	if identity, terr := FindIdentityByIdAndProvider(tx, sub, providerName); terr == nil {
 		// account exists
@@ -93,7 +102,7 @@ func DetermineAccountLinking(tx *storage.Connection, config *conf.GlobalConfigur
 	// or link to an existing one
 	if len(verifiedEmails) == 0 {
 		// if there are no verified emails, we always decide to create a new account
-		user, terr := IsDuplicatedEmail(tx, candidateEmail.Email, aud, nil, config.Experimental.ProvidersWithOwnLinkingDomain)
+		user, terr := IsDuplicatedEmail(tx, candidateEmail.Email, aud, nil, config.Experimental.ProviderLinkingDomains)
 		if terr != nil {
 			return AccountLinkingResult{}, terr
 		}
@@ -131,7 +140,7 @@ func DetermineAccountLinking(tx *storage.Connection, config *conf.GlobalConfigur
 	// now let's see if there are any existing and similar identities in
 	// the same linking domain
 	for _, identity := range similarIdentities {
-		if GetAccountLinkingDomain(identity.Provider, config.Experimental.ProvidersWithOwnLinkingDomain) == candidateLinkingDomain {
+		if GetAccountLinkingDomain(identity.Provider, config.Experimental.ProviderLinkingDomains) == candidateLinkingDomain {
 			linkingIdentities = append(linkingIdentities, identity)
 		}
 	}

--- a/internal/models/linking_test.go
+++ b/internal/models/linking_test.go
@@ -12,6 +12,30 @@ import (
 	"github.com/supabase/auth/internal/storage/test"
 )
 
+func TestGetAccountLinkingDomain(t *testing.T) {
+	// provider names are matched exactly. A builtin provider (github) and a
+	// custom provider (custom:google) can share the same domain; the "custom:"
+	// prefix is part of the key.
+	linkingDomains := map[string]string{
+		"github":        "social",
+		"custom:google": "social",
+	}
+
+	// SSO providers always get their own isolated domain (the provider id).
+	require.Equal(t, "sso:abc", GetAccountLinkingDomain("sso:abc", linkingDomains))
+
+	// Providers sharing a linking domain resolve to that shared domain.
+	require.Equal(t, "social", GetAccountLinkingDomain("github", linkingDomains))
+	require.Equal(t, "social", GetAccountLinkingDomain("custom:google", linkingDomains))
+
+	// A bare name is not the same key as its "custom:"-prefixed form.
+	require.Equal(t, "default", GetAccountLinkingDomain("custom:github", linkingDomains))
+
+	// Providers without a linking domain fall back to the default email-linked pool.
+	require.Equal(t, "default", GetAccountLinkingDomain("apple", linkingDomains))
+	require.Equal(t, "default", GetAccountLinkingDomain("github", nil))
+}
+
 type AccountLinkingTestSuite struct {
 	suite.Suite
 
@@ -276,6 +300,155 @@ func (ts *AccountLinkingTestSuite) TestLinkingScenarios() {
 		})
 	}
 
+}
+
+func (ts *AccountLinkingTestSuite) TestSharedLinkingDomainLinking() {
+	// a builtin provider (github) and a custom provider (custom:google) share the
+	// "social" linking domain: they link to one another but stay isolated from
+	// the default email-linked pool and from SSO. Mixing the two forms shows that
+	// both a bare name and a colon-bearing "custom:" name are matched exactly.
+	prevLinkingDomains := ts.config.Experimental.ProviderLinkingDomains
+	ts.config.Experimental.ProviderLinkingDomains = map[string]string{
+		"github":        "social",
+		"custom:google": "social",
+	}
+	defer func() { ts.config.Experimental.ProviderLinkingDomains = prevLinkingDomains }()
+
+	const sharedEmail = "shared@example.com"
+
+	ts.Run("custom:google login links into existing github account in the same domain", func() {
+		TruncateAll(ts.db)
+
+		githubUser, err := NewUser("", sharedEmail, "", "authenticated", nil)
+		require.NoError(ts.T(), err)
+		require.NoError(ts.T(), ts.db.Create(githubUser))
+		githubIdentity, err := NewIdentity(githubUser, "github", map[string]interface{}{
+			"sub":   githubUser.ID.String(),
+			"email": sharedEmail,
+		})
+		require.NoError(ts.T(), err)
+		require.NoError(ts.T(), ts.db.Create(githubIdentity))
+
+		decision, err := DetermineAccountLinking(ts.db, ts.config, []provider.Email{
+			{Email: sharedEmail, Verified: true, Primary: true},
+		}, ts.config.JWT.Aud, "custom:google", "google-sub")
+		require.NoError(ts.T(), err)
+
+		require.Equal(ts.T(), LinkAccount, decision.Decision)
+		require.Equal(ts.T(), githubUser.ID, decision.User.ID)
+		require.Equal(ts.T(), "social", decision.LinkingDomain)
+	})
+
+	ts.Run("google login does not link into a default email-only account", func() {
+		TruncateAll(ts.db)
+
+		emailUser, err := NewUser("", sharedEmail, "", "authenticated", nil)
+		require.NoError(ts.T(), err)
+		require.NoError(ts.T(), ts.db.Create(emailUser))
+		emailIdentity, err := NewIdentity(emailUser, "email", map[string]interface{}{
+			"sub":   emailUser.ID.String(),
+			"email": sharedEmail,
+		})
+		require.NoError(ts.T(), err)
+		require.NoError(ts.T(), ts.db.Create(emailIdentity))
+
+		decision, err := DetermineAccountLinking(ts.db, ts.config, []provider.Email{
+			{Email: sharedEmail, Verified: true, Primary: true},
+		}, ts.config.JWT.Aud, "custom:google", "google-sub")
+		require.NoError(ts.T(), err)
+
+		// must create a brand new account in the "social" linking domain, never
+		// link to the default email-linked user
+		require.Equal(ts.T(), CreateAccount, decision.Decision)
+		require.Equal(ts.T(), "social", decision.LinkingDomain)
+	})
+
+	ts.Run("google login does not link into an SSO account", func() {
+		TruncateAll(ts.db)
+
+		ssoProvider := "sso:f06f9e3d-ff92-4c47-a179-7acf1fda6387"
+		ssoUser, err := NewUser("", sharedEmail, "", "authenticated", nil)
+		require.NoError(ts.T(), err)
+		require.NoError(ts.T(), ts.db.Create(ssoUser))
+		ssoIdentity, err := NewIdentity(ssoUser, ssoProvider, map[string]interface{}{
+			"sub":   ssoUser.ID.String(),
+			"email": sharedEmail,
+		})
+		require.NoError(ts.T(), err)
+		require.NoError(ts.T(), ts.db.Create(ssoIdentity))
+
+		decision, err := DetermineAccountLinking(ts.db, ts.config, []provider.Email{
+			{Email: sharedEmail, Verified: true, Primary: true},
+		}, ts.config.JWT.Aud, "custom:google", "google-sub")
+		require.NoError(ts.T(), err)
+
+		require.Equal(ts.T(), CreateAccount, decision.Decision)
+		require.Equal(ts.T(), "social", decision.LinkingDomain)
+	})
+}
+
+func (ts *AccountLinkingTestSuite) TestOwnLinkingDomainLegacyBackfillUnchanged() {
+	// Regression: a legacy deployment configured with
+	// GOTRUE_EXPERIMENTAL_PROVIDERS_WITH_OWN_LINKING_DOMAIN="github" must behave
+	// identically after the migration. ApplyDefaults backfills the deprecated
+	// list into ProviderLinkingDomains as {github: github}.
+	prevLinkingDomains := ts.config.Experimental.ProviderLinkingDomains
+	prevLegacy := ts.config.Experimental.ProvidersWithOwnLinkingDomain
+	ts.config.Experimental.ProviderLinkingDomains = nil
+	ts.config.Experimental.ProvidersWithOwnLinkingDomain = []string{"github"}
+	require.NoError(ts.T(), ts.config.ApplyDefaults())
+	require.Equal(ts.T(), "github", ts.config.Experimental.ProviderLinkingDomains["github"])
+	defer func() {
+		ts.config.Experimental.ProviderLinkingDomains = prevLinkingDomains
+		ts.config.Experimental.ProvidersWithOwnLinkingDomain = prevLegacy
+	}()
+
+	const githubEmail = "githubonly@example.com"
+
+	ts.Run("github stays isolated from a default email-only account", func() {
+		TruncateAll(ts.db)
+
+		emailUser, err := NewUser("", githubEmail, "", "authenticated", nil)
+		require.NoError(ts.T(), err)
+		require.NoError(ts.T(), ts.db.Create(emailUser))
+		emailIdentity, err := NewIdentity(emailUser, "email", map[string]interface{}{
+			"sub":   emailUser.ID.String(),
+			"email": githubEmail,
+		})
+		require.NoError(ts.T(), err)
+		require.NoError(ts.T(), ts.db.Create(emailIdentity))
+
+		decision, err := DetermineAccountLinking(ts.db, ts.config, []provider.Email{
+			{Email: githubEmail, Verified: true, Primary: true},
+		}, ts.config.JWT.Aud, "github", "github-sub")
+		require.NoError(ts.T(), err)
+
+		require.Equal(ts.T(), CreateAccount, decision.Decision)
+		require.Equal(ts.T(), "github", decision.LinkingDomain)
+	})
+
+	ts.Run("github links into existing github account with the same email", func() {
+		TruncateAll(ts.db)
+
+		githubUser, err := NewUser("", githubEmail, "", "authenticated", nil)
+		require.NoError(ts.T(), err)
+		require.NoError(ts.T(), ts.db.Create(githubUser))
+		githubIdentity, err := NewIdentity(githubUser, "github", map[string]interface{}{
+			"sub":   githubUser.ID.String(),
+			"email": githubEmail,
+		})
+		require.NoError(ts.T(), err)
+		require.NoError(ts.T(), ts.db.Create(githubIdentity))
+
+		decision, err := DetermineAccountLinking(ts.db, ts.config, []provider.Email{
+			{Email: githubEmail, Verified: true, Primary: true},
+		}, ts.config.JWT.Aud, "github", "another-github-sub")
+		require.NoError(ts.T(), err)
+
+		require.Equal(ts.T(), LinkAccount, decision.Decision)
+		require.Equal(ts.T(), githubUser.ID, decision.User.ID)
+		require.Equal(ts.T(), "github", decision.LinkingDomain)
+	})
 }
 
 func (ts *AccountLinkingTestSuite) TestMultipleAccounts() {

--- a/internal/models/user.go
+++ b/internal/models/user.go
@@ -779,7 +779,7 @@ func FindUsersInAudience(tx *storage.Connection, aud string, pageParams *Paginat
 // audience importantly in the *default* identity linking domain (meaning SSO
 // accounts and similar are not considered).
 // If a currentUser is provided, we will need to filter out any identities that belong to the current user.
-func IsDuplicatedEmail(tx *storage.Connection, email, aud string, currentUser *User, ownDomainProviders []string) (*User, error) {
+func IsDuplicatedEmail(tx *storage.Connection, email, aud string, currentUser *User, linkingDomains map[string]string) (*User, error) {
 	var identities []Identity
 
 	if err := tx.Eager().Q().Where("email = ?", strings.ToLower(email)).All(&identities); err != nil {
@@ -793,7 +793,7 @@ func IsDuplicatedEmail(tx *storage.Connection, email, aud string, currentUser *U
 	userIDs := make(map[string]uuid.UUID)
 	for _, identity := range identities {
 		if _, ok := userIDs[identity.UserID.String()]; !ok {
-			if GetAccountLinkingDomain(identity.Provider, ownDomainProviders) == "default" {
+			if GetAccountLinkingDomain(identity.Provider, linkingDomains) == "default" {
 				userIDs[identity.UserID.String()] = identity.UserID
 			}
 		}

--- a/internal/models/user_test.go
+++ b/internal/models/user_test.go
@@ -185,6 +185,34 @@ func (ts *UserTestSuite) TestIsDuplicatedEmail() {
 	require.Nil(ts.T(), e, "expected same email to not be duplicated")
 }
 
+func (ts *UserTestSuite) TestIsDuplicatedEmailWithLinkingDomains() {
+	linkingDomains := map[string]string{"github": "social", "google": "social"}
+
+	// A grouped-provider user (its own "social" linking domain, is_sso_user=true)
+	// must NOT be treated as a default-pool duplicate: a default email signup with
+	// the same address is allowed to coexist with it.
+	githubUser, err := NewUser("", "grouped@example.com", "", "test", nil)
+	require.NoError(ts.T(), err)
+	githubUser.IsSSOUser = true
+	require.NoError(ts.T(), ts.db.Create(githubUser))
+	githubIdentity, err := NewIdentity(githubUser, "github", map[string]interface{}{
+		"sub":   githubUser.ID.String(),
+		"email": "grouped@example.com",
+	})
+	require.NoError(ts.T(), err)
+	require.NoError(ts.T(), ts.db.Create(githubIdentity))
+
+	e, err := IsDuplicatedEmail(ts.db, "grouped@example.com", "test", nil, linkingDomains)
+	require.NoError(ts.T(), err)
+	require.Nil(ts.T(), e, "grouped-provider email must not count as a default-pool duplicate")
+
+	// A default-pool email user with the same address IS still a duplicate.
+	_ = ts.createUserWithEmail("default@example.com")
+	e, err = IsDuplicatedEmail(ts.db, "default@example.com", "test", nil, linkingDomains)
+	require.NoError(ts.T(), err)
+	require.NotNil(ts.T(), e, "default email must still count as a duplicate")
+}
+
 func (ts *UserTestSuite) createUser() *User {
 	return ts.createUserWithEmail("david@netlify.com")
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

## What

Adds an experimental provider **linking-domain** map so independent providers can be grouped to share account linking. Providers in the same domain link to one another (matching verified email → same account) but stay isolated from the default email-linked pool and from SSO.

```
GOTRUE_EXPERIMENTAL_PROVIDER_LINKING_DOMAINS="provider_a=social,provider_b=social"
```
## Why
The previous `GOTRUE_EXPERIMENTAL_PROVIDERS_WITH_OWN_LINKING_DOMAIN` only let a provider own an isolated domain named after itself, two distinct providers couldn't share one. This generalizes it to an explicit provider→domain map.

## Notes
- Backward compatible: the old list is deprecated and auto-migrated in `ApplyDefaults` to `{provider: provider}`; explicit map entries win. No behavior change for existing deployments. (old list handling will be removed in a later pr)
- SSO and `"default"` resolution are unchanged.
