### PR TITLE
fix: downgrade session AAL after admin deletion of factor

### DIFF
--- a/internal/api/admin.go
+++ b/internal/api/admin.go
@@ -592,6 +592,9 @@ func (a *API) adminUserDeleteFactor(w http.ResponseWriter, r *http.Request) erro
 		if terr := tx.Destroy(factor); terr != nil {
 			return apierrors.NewInternalServerError("Database error deleting factor").WithInternalError(terr)
 		}
+		if terr := factor.DowngradeSessionsToAAL1(tx); terr != nil {
+			return apierrors.NewInternalServerError("Database error downgrading sessions").WithInternalError(terr)
+		}
 		return nil
 	})
 	if err != nil {

--- a/internal/api/admin_test.go
+++ b/internal/api/admin_test.go
@@ -790,6 +790,14 @@ func (ts *AdminTestSuite) TestAdminUserDeleteFactor() {
 	require.NoError(ts.T(), f.SetSecret("secretkey", ts.Config.Security.DBEncryption.Encrypt, ts.Config.Security.DBEncryption.EncryptionKeyID, ts.Config.Security.DBEncryption.EncryptionKey))
 	require.NoError(ts.T(), ts.API.db.Create(f), "Error saving new test factor")
 
+	// An AAL2 session backed by the factor should be downgraded to AAL1 when the
+	// factor is deleted by an admin (mirrors the self-service unenroll behaviour).
+	s, err := models.NewSession(u.ID, &f.ID)
+	require.NoError(ts.T(), err)
+	require.NoError(ts.T(), ts.API.db.Create(s))
+	require.NoError(ts.T(), models.AddClaimToSession(ts.API.db, s.ID, models.TOTPSignIn))
+	require.NoError(ts.T(), s.UpdateAALAndAssociatedFactor(ts.API.db, models.AAL2, &f.ID))
+
 	// Setup request
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodDelete, fmt.Sprintf("/admin/users/%s/factors/%s/", u.ID, f.ID), nil)
@@ -802,6 +810,14 @@ func (ts *AdminTestSuite) TestAdminUserDeleteFactor() {
 	_, err = models.FindFactorByFactorID(ts.API.db, f.ID)
 	require.EqualError(ts.T(), err, models.FactorNotFoundError{}.Error())
 
+	// The factor's session must be downgraded and its AMR claim stripped.
+	downgraded, err := models.FindSessionByID(ts.API.db, s.ID, false)
+	require.NoError(ts.T(), err)
+	require.Equal(ts.T(), models.AAL1.String(), downgraded.GetAAL())
+	require.Nil(ts.T(), downgraded.FactorID)
+	aal, _, err := downgraded.CalculateAALAndAMR(u)
+	require.NoError(ts.T(), err)
+	require.Equal(ts.T(), models.AAL1, aal)
 }
 
 // TestAdminUserGetFactor tests API /admin/user/<user_id>/factors/


### PR DESCRIPTION
When a factor is deleted via the admin endpoints, downgrade the session's AAL accordingly.