### PR TITLE
feat(token): add RFC 8693 token-exchange grant for provider access tokens

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -186,7 +186,7 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-go 1.25.11
+go 1.25.12
 
 replace (
 	github.com/joho/godotenv => ./internal/forks/godotenv

--- a/internal/api/helpers.go
+++ b/internal/api/helpers.go
@@ -51,6 +51,7 @@ type RequestParams interface {
 		CreateSSOProviderParams |
 		EnrollFactorParams |
 		GenerateLinkParams |
+		TokenExchangeGrantParams |
 		IdTokenGrantParams |
 		InviteParams |
 		OtpParams |

--- a/internal/api/provider/facebook.go
+++ b/internal/api/provider/facebook.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"slices"
 	"strings"
 
 	"github.com/supabase/auth/internal/conf"
@@ -24,6 +25,7 @@ const (
 
 type facebookProvider struct {
 	*oauth2.Config
+	ClientIDs     []string
 	ProfileURL    string
 	DebugTokenURL string
 }
@@ -85,6 +87,7 @@ func NewFacebookProvider(ext conf.OAuthProviderConfiguration, scopes string) (OA
 			},
 			Scopes: oauthScopes,
 		},
+		ClientIDs:     ext.ClientID,
 		ProfileURL:    profileURL,
 		DebugTokenURL: debugTokenURL,
 	}, nil
@@ -120,7 +123,7 @@ func (p facebookProvider) VerifyAccessToken(ctx context.Context, accessToken str
 		return "", fmt.Errorf("facebook: access token is not valid: %s", debugToken.Data.Error.Message)
 	}
 
-	if debugToken.Data.AppID != p.Config.ClientID {
+	if !slices.Contains(p.ClientIDs, debugToken.Data.AppID) {
 		return "", fmt.Errorf("facebook: access token was not issued for this app")
 	}
 

--- a/internal/api/provider/facebook.go
+++ b/internal/api/provider/facebook.go
@@ -5,6 +5,9 @@ import (
 	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
+	"fmt"
+	"net/url"
 	"strings"
 
 	"github.com/supabase/auth/internal/conf"
@@ -21,7 +24,21 @@ const (
 
 type facebookProvider struct {
 	*oauth2.Config
-	ProfileURL string
+	ProfileURL    string
+	DebugTokenURL string
+}
+
+type facebookDebugToken struct {
+	Data struct {
+		AppID   string `json:"app_id"`
+		Type    string `json:"type"`
+		IsValid bool   `json:"is_valid"`
+		UserID  string `json:"user_id"`
+		Error   struct {
+			Code    int    `json:"code"`
+			Message string `json:"message"`
+		} `json:"error"`
+	} `json:"data"`
 }
 
 type facebookUser struct {
@@ -45,7 +62,9 @@ func NewFacebookProvider(ext conf.OAuthProviderConfiguration, scopes string) (OA
 
 	authHost := chooseHost(ext.URL, defaultFacebookAuthBase)
 	tokenHost := chooseHost(ext.URL, defaultFacebookTokenBase)
-	profileURL := chooseHost(ext.URL, defaultFacebookAPIBase) + "/me?fields=email,first_name,last_name,name,picture"
+	apiHost := chooseHost(ext.URL, defaultFacebookAPIBase)
+	profileURL := apiHost + "/me?fields=email,first_name,last_name,name,picture"
+	debugTokenURL := apiHost + "/debug_token"
 
 	oauthScopes := []string{
 		"email",
@@ -66,8 +85,54 @@ func NewFacebookProvider(ext conf.OAuthProviderConfiguration, scopes string) (OA
 			},
 			Scopes: oauthScopes,
 		},
-		ProfileURL: profileURL,
+		ProfileURL:    profileURL,
+		DebugTokenURL: debugTokenURL,
 	}, nil
+}
+
+// VerifyAccessToken confirms that the given access token was issued for this
+// Facebook app and is still valid. This is required when signing in with an
+// access token obtained on the client (for example a native Android login),
+// to mitigate access token substitution where a token minted for another app
+// could otherwise be replayed against this one.
+func (p facebookProvider) VerifyAccessToken(ctx context.Context, accessToken string) (string, error) {
+	// The app access token authenticates the /debug_token call. It is sent as a
+	// bearer token rather than a query parameter so the client secret is not
+	// captured by URL loggers.
+	appAccessToken := p.Config.ClientID + "|" + p.Config.ClientSecret
+
+	query := url.Values{}
+	query.Set("input_token", accessToken)
+	requestURL := p.DebugTokenURL + "?" + query.Encode()
+
+	var debugToken facebookDebugToken
+	if err := makeRequest(ctx, &oauth2.Token{AccessToken: appAccessToken}, p.Config, requestURL, &debugToken); err != nil {
+		// /debug_token requires input_token in the query string, so strip the URL
+		// from transport errors to avoid leaking the access token into logs.
+		var urlErr *url.Error
+		if errors.As(err, &urlErr) {
+			return "", fmt.Errorf("facebook: could not reach the token debug endpoint: %w", urlErr.Err)
+		}
+		return "", err
+	}
+
+	if !debugToken.Data.IsValid {
+		return "", fmt.Errorf("facebook: access token is not valid: %s", debugToken.Data.Error.Message)
+	}
+
+	if debugToken.Data.AppID != p.Config.ClientID {
+		return "", fmt.Errorf("facebook: access token was not issued for this app")
+	}
+
+	if debugToken.Data.Type != "USER" {
+		return "", fmt.Errorf("facebook: access token is not a user token (type=%q)", debugToken.Data.Type)
+	}
+
+	if debugToken.Data.UserID == "" {
+		return "", fmt.Errorf("facebook: access token does not contain a user id")
+	}
+
+	return debugToken.Data.UserID, nil
 }
 
 func (p facebookProvider) GetOAuthToken(ctx context.Context, code string, opts ...oauth2.AuthCodeOption) (*oauth2.Token, error) {

--- a/internal/api/provider/provider.go
+++ b/internal/api/provider/provider.go
@@ -148,6 +148,14 @@ type OAuthProvider interface {
 	RequiresPKCE() bool
 }
 
+// AccessTokenVerifier is implemented by OAuth providers that can verify a
+// client-provided access token was issued for this app before it is exchanged
+// for a session through the token-exchange grant. It returns the provider's
+// subject identifier (the user id) encoded in the token.
+type AccessTokenVerifier interface {
+	VerifyAccessToken(ctx context.Context, accessToken string) (subject string, err error)
+}
+
 func chooseHost(base, defaultHost string) string {
 	if base == "" {
 		return "https://" + defaultHost

--- a/internal/api/token.go
+++ b/internal/api/token.go
@@ -51,6 +51,8 @@ func (a *API) Token(w http.ResponseWriter, r *http.Request) error {
 		handler = a.RefreshTokenGrant
 	case "id_token":
 		handler = a.IdTokenGrant
+	case TokenExchangeGrantType:
+		handler = a.TokenExchangeGrant
 	case "pkce":
 		handler = a.PKCE
 	case "web3":

--- a/internal/api/token_exchange.go
+++ b/internal/api/token_exchange.go
@@ -1,0 +1,147 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/supabase/auth/internal/api/apierrors"
+	"github.com/supabase/auth/internal/api/provider"
+	"github.com/supabase/auth/internal/metering"
+	"github.com/supabase/auth/internal/models"
+	"github.com/supabase/auth/internal/storage"
+)
+
+// TokenExchangeGrantType is the RFC 8693 OAuth 2.0 Token Exchange grant type.
+const TokenExchangeGrantType = "urn:ietf:params:oauth:grant-type:token-exchange" //#nosec G101 -- Not a credential, an RFC 8693 grant-type URI.
+
+// FacebookAccessTokenType is the subject_token_type URI identifying a Facebook
+// access token for the token-exchange grant.
+const FacebookAccessTokenType = "https://supabase.com/auth/token-type/facebook-access-token" //#nosec G101 -- Not a credential, a token-type URI.
+
+// subjectTokenTypeProviders maps each supported subject_token_type to the
+// provider whose access token it carries. The provider is inferred from the
+// token type rather than passed separately, so a new provider opts in by
+// registering its own token type here.
+var subjectTokenTypeProviders = map[string]string{
+	FacebookAccessTokenType: "facebook",
+}
+
+// TokenExchangeGrantParams are the parameters the TokenExchangeGrant method accepts.
+type TokenExchangeGrantParams struct {
+	SubjectToken     string `json:"subject_token"`
+	SubjectTokenType string `json:"subject_token_type"`
+}
+
+// TokenExchangeGrant implements the RFC 8693 token-exchange grant. It lets a
+// client sign in with a provider-issued access token instead of an OIDC id
+// token.
+//
+// It exists for native Facebook logins on Android: Facebook only mints an OIDC
+// id token (with the email claims) on the first authorization, so signup keeps
+// going through the id_token grant. On every subsequent login Facebook returns
+// only a classic access token, which carries no profile claims. This grant
+// verifies that token belongs to this app, reads the provider subject from it,
+// and signs in the existing identity, so it does not create accounts.
+func (a *API) TokenExchangeGrant(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
+	db := a.db.WithContext(ctx)
+
+	params := &TokenExchangeGrantParams{}
+	if err := retrieveRequestParams(r, params); err != nil {
+		return err
+	}
+
+	if params.SubjectToken == "" {
+		return apierrors.NewOAuthError("invalid_request", "subject_token required")
+	}
+
+	// The provider is inferred from the subject_token_type, so the client never
+	// sends it separately. The mapped value is already the lower-cased provider
+	// name stored on the identity, so no normalization is needed.
+	providerType, ok := subjectTokenTypeProviders[params.SubjectTokenType]
+	if !ok {
+		return apierrors.NewOAuthError("invalid_request", fmt.Sprintf("unsupported subject_token_type %q", params.SubjectTokenType))
+	}
+
+	oauthProvider, pConfig, err := a.OAuthProvider(ctx, providerType)
+	if err != nil {
+		return apierrors.NewBadRequestError(apierrors.ErrorCodeOAuthProviderNotSupported, "Unsupported provider: %q", providerType).WithInternalError(err)
+	}
+
+	if !pConfig.Enabled {
+		return apierrors.NewBadRequestError(apierrors.ErrorCodeProviderDisabled, "Provider (%q) is not enabled", providerType)
+	}
+
+	// Verifying that the access token was issued for this app is provider
+	// specific, so the grant is only available to providers that opt in.
+	verifier, ok := oauthProvider.(provider.AccessTokenVerifier)
+	if !ok {
+		return apierrors.NewBadRequestError(apierrors.ErrorCodeValidationFailed, "token-exchange grant is not supported for the %q provider", providerType)
+	}
+
+	subject, err := verifier.VerifyAccessToken(ctx, params.SubjectToken)
+	if err != nil {
+		return apierrors.NewOAuthError("invalid_request", "Invalid subject_token").WithInternalError(err)
+	}
+
+	// The provider access token carries no profile claims, so this grant only
+	// signs in an identity that already exists (created on the first login via
+	// the id_token grant). A missing identity means the user must sign up first,
+	// but the error stays generic to avoid leaking whether an account exists.
+	identity, err := models.FindIdentityByIdAndProvider(db, subject, providerType)
+	if err != nil {
+		if models.IsNotFoundError(err) {
+			return apierrors.NewOAuthError("invalid_request", "Invalid subject_token").WithInternalError(err)
+		}
+		return apierrors.NewInternalServerError("Database error finding identity").WithInternalError(err)
+	}
+
+	user, err := models.FindUserByID(db, identity.UserID)
+	if err != nil {
+		if models.IsNotFoundError(err) {
+			return apierrors.NewOAuthError("invalid_request", "No user found for this identity")
+		}
+		return apierrors.NewInternalServerError("Database error finding user").WithInternalError(err)
+	}
+
+	if user.IsBanned() {
+		return apierrors.NewOAuthError("invalid_request", "Invalid subject_token")
+	}
+
+	// Don't hand out a session to an unconfirmed user unless the instance allows
+	// unverified email sign-ins, matching the other sign-in paths. The error
+	// stays generic to avoid leaking account state.
+	if !user.IsConfirmed() && !a.config.Mailer.AllowUnverifiedEmailSignIns {
+		return apierrors.NewOAuthError("invalid_request", "Invalid subject_token")
+	}
+
+	var grantParams models.GrantParams
+	grantParams.FillGrantParams(r)
+
+	var token *AccessTokenResponse
+	if err := db.Transaction(func(tx *storage.Connection) error {
+		if terr := models.NewAuditLogEntry(a.config.AuditLog, r, tx, user, models.LoginAction, "", map[string]interface{}{
+			"provider": providerType,
+		}); terr != nil {
+			return terr
+		}
+		var terr error
+		token, terr = a.issueRefreshToken(r, w.Header(), tx, user, models.OAuth, grantParams)
+		return terr
+	}); err != nil {
+		switch err.(type) {
+		case *storage.CommitWithError:
+			return err
+		case *HTTPError:
+			return err
+		default:
+			return apierrors.NewOAuthError("server_error", "Internal Server Error").WithInternalError(err)
+		}
+	}
+
+	metering.RecordLogin(metering.LoginTypeTokenExchange, token.User.ID, &metering.LoginData{
+		Provider: providerType,
+	})
+
+	return sendJSON(w, http.StatusOK, token)
+}

--- a/internal/api/token_exchange_test.go
+++ b/internal/api/token_exchange_test.go
@@ -162,6 +162,24 @@ func (ts *ExternalTestSuite) TestTokenExchangeRejectsTokenFromAnotherApp() {
 	ts.Require().Equal(http.StatusBadRequest, w.Code)
 }
 
+func (ts *ExternalTestSuite) TestTokenExchangeAcceptsSecondaryClientID() {
+	primary := ts.Config.External.Facebook.ClientID[0]
+	ts.Config.External.Facebook.ClientID = []string{primary, "second_app_id"}
+	defer func() { ts.Config.External.Facebook.ClientID = []string{primary} }()
+
+	user := ts.createFacebookIdentity("facebookTestId", "facebook@example.com")
+
+	server := FacebookAccessTokenSetup(ts, "second_app_id", true, "USER", "facebookTestId")
+	defer server.Close()
+
+	w := ts.tokenExchange("token_for_second_app")
+	ts.Require().Equal(http.StatusOK, w.Code, w.Body.String())
+
+	var response AccessTokenResponse
+	ts.Require().NoError(json.NewDecoder(w.Body).Decode(&response))
+	ts.Equal(user.ID, response.User.ID)
+}
+
 func (ts *ExternalTestSuite) TestTokenExchangeRejectsInvalidToken() {
 	ts.createFacebookIdentity("facebookTestId", "facebook@example.com")
 

--- a/internal/api/token_exchange_test.go
+++ b/internal/api/token_exchange_test.go
@@ -1,0 +1,206 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"time"
+
+	"github.com/supabase/auth/internal/models"
+)
+
+// FacebookAccessTokenSetup spins up a mock Graph API that answers the
+// /debug_token call used by the token-exchange grant. appID controls the
+// app_id returned by /debug_token, isValid controls whether the token is
+// reported as valid, tokenType controls the token type (USER, PAGE, APP), and
+// userID is the facebook user id returned as the token subject.
+func FacebookAccessTokenSetup(ts *ExternalTestSuite, appID string, isValid bool, tokenType, userID string) *httptest.Server {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/debug_token":
+			expectedAppToken := ts.Config.External.Facebook.ClientID[0] + "|" + ts.Config.External.Facebook.Secret
+			ts.Equal("Bearer "+expectedAppToken, r.Header.Get("Authorization"))
+			ts.NotEmpty(r.URL.Query().Get("input_token"))
+
+			w.Header().Add("Content-Type", "application/json")
+			fmt.Fprintf(w, `{"data":{"app_id":"%s","type":"%s","is_valid":%t,"user_id":"%s"}}`, appID, tokenType, isValid, userID)
+		default:
+			w.WriteHeader(http.StatusInternalServerError)
+			ts.Fail("unknown facebook graph call %s", r.URL.Path)
+		}
+	}))
+
+	ts.Config.External.Facebook.URL = server.URL
+
+	return server
+}
+
+// createFacebookIdentity creates a confirmed user with a facebook identity
+// whose provider_id is the given facebook user id, so the token-exchange grant
+// can sign them in. Facebook accounts arrive verified, so the user is confirmed.
+func (ts *ExternalTestSuite) createFacebookIdentity(facebookUserID, email string) *models.User {
+	u := ts.createUnconfirmedFacebookIdentity(facebookUserID, email)
+	now := time.Now()
+	u.EmailConfirmedAt = &now
+	ts.Require().NoError(ts.API.db.UpdateOnly(u, "email_confirmed_at"))
+	return u
+}
+
+func (ts *ExternalTestSuite) createUnconfirmedFacebookIdentity(facebookUserID, email string) *models.User {
+	u, err := models.NewUser("", email, "test", ts.Config.JWT.Aud, nil)
+	ts.Require().NoError(err)
+	ts.Require().NoError(ts.API.db.Create(u))
+
+	i, err := models.NewIdentity(u, "facebook", map[string]interface{}{
+		"sub":   facebookUserID,
+		"email": email,
+	})
+	ts.Require().NoError(err)
+	ts.Require().NoError(ts.API.db.Create(i))
+
+	return u
+}
+
+func (ts *ExternalTestSuite) tokenExchange(subjectToken string) *httptest.ResponseRecorder {
+	return ts.tokenExchangeWithType(subjectToken, FacebookAccessTokenType)
+}
+
+func (ts *ExternalTestSuite) tokenExchangeWithType(subjectToken, subjectTokenType string) *httptest.ResponseRecorder {
+	var buffer bytes.Buffer
+	ts.Require().NoError(json.NewEncoder(&buffer).Encode(map[string]interface{}{
+		"subject_token":      subjectToken,
+		"subject_token_type": subjectTokenType,
+	}))
+
+	req := httptest.NewRequest(http.MethodPost, "http://localhost/token?grant_type="+TokenExchangeGrantType, &buffer)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	ts.API.handler.ServeHTTP(w, req)
+	return w
+}
+
+func (ts *ExternalTestSuite) TestTokenExchangeSignsInExistingIdentity() {
+	user := ts.createFacebookIdentity("facebookTestId", "facebook@example.com")
+
+	server := FacebookAccessTokenSetup(ts, ts.Config.External.Facebook.ClientID[0], true, "USER", "facebookTestId")
+	defer server.Close()
+
+	w := ts.tokenExchange("valid_access_token")
+	ts.Require().Equal(http.StatusOK, w.Code, w.Body.String())
+
+	var response AccessTokenResponse
+	ts.Require().NoError(json.NewDecoder(w.Body).Decode(&response))
+	ts.Require().NotEmpty(response.Token)
+	ts.Require().NotEmpty(response.RefreshToken)
+	ts.Require().NotNil(response.User)
+	ts.Equal(user.ID, response.User.ID)
+
+	// The sign-in is recorded in the audit log, like the other grant flows.
+	logs, err := models.FindAuditLogEntries(ts.API.db, []string{"action"}, string(models.LoginAction), nil)
+	ts.Require().NoError(err)
+	ts.Require().NotEmpty(logs)
+	ts.Equal(string(models.LoginAction), logs[0].Payload["action"])
+}
+
+func (ts *ExternalTestSuite) TestTokenExchangeNoIdentityIsRejected() {
+	// No identity is created, so there is nobody to sign in.
+	server := FacebookAccessTokenSetup(ts, ts.Config.External.Facebook.ClientID[0], true, "USER", "facebookTestId")
+	defer server.Close()
+
+	w := ts.tokenExchange("valid_access_token")
+	ts.Require().Equal(http.StatusBadRequest, w.Code)
+}
+
+func (ts *ExternalTestSuite) TestTokenExchangeRejectsBannedUser() {
+	user := ts.createFacebookIdentity("facebookTestId", "facebook@example.com")
+	t := time.Now().Add(24 * time.Hour)
+	user.BannedUntil = &t
+	ts.Require().NoError(ts.API.db.UpdateOnly(user, "banned_until"))
+
+	server := FacebookAccessTokenSetup(ts, ts.Config.External.Facebook.ClientID[0], true, "USER", "facebookTestId")
+	defer server.Close()
+
+	w := ts.tokenExchange("valid_access_token")
+	ts.Require().Equal(http.StatusBadRequest, w.Code)
+}
+
+func (ts *ExternalTestSuite) TestTokenExchangeRejectsUnconfirmedUser() {
+	ts.createUnconfirmedFacebookIdentity("facebookTestId", "facebook@example.com")
+
+	server := FacebookAccessTokenSetup(ts, ts.Config.External.Facebook.ClientID[0], true, "USER", "facebookTestId")
+	defer server.Close()
+
+	w := ts.tokenExchange("valid_access_token")
+	ts.Require().Equal(http.StatusBadRequest, w.Code)
+}
+
+func (ts *ExternalTestSuite) TestTokenExchangeAllowsUnconfirmedWhenConfigured() {
+	ts.Config.Mailer.AllowUnverifiedEmailSignIns = true
+	defer func() { ts.Config.Mailer.AllowUnverifiedEmailSignIns = false }()
+	user := ts.createUnconfirmedFacebookIdentity("facebookTestId", "facebook@example.com")
+
+	server := FacebookAccessTokenSetup(ts, ts.Config.External.Facebook.ClientID[0], true, "USER", "facebookTestId")
+	defer server.Close()
+
+	w := ts.tokenExchange("valid_access_token")
+	ts.Require().Equal(http.StatusOK, w.Code, w.Body.String())
+
+	var response AccessTokenResponse
+	ts.Require().NoError(json.NewDecoder(w.Body).Decode(&response))
+	ts.Equal(user.ID, response.User.ID)
+}
+
+func (ts *ExternalTestSuite) TestTokenExchangeRejectsTokenFromAnotherApp() {
+	ts.createFacebookIdentity("facebookTestId", "facebook@example.com")
+
+	server := FacebookAccessTokenSetup(ts, "some_other_app_id", true, "USER", "facebookTestId")
+	defer server.Close()
+
+	w := ts.tokenExchange("token_for_another_app")
+	ts.Require().Equal(http.StatusBadRequest, w.Code)
+}
+
+func (ts *ExternalTestSuite) TestTokenExchangeRejectsInvalidToken() {
+	ts.createFacebookIdentity("facebookTestId", "facebook@example.com")
+
+	server := FacebookAccessTokenSetup(ts, ts.Config.External.Facebook.ClientID[0], false, "USER", "facebookTestId")
+	defer server.Close()
+
+	w := ts.tokenExchange("invalid_token")
+	ts.Require().Equal(http.StatusBadRequest, w.Code)
+}
+
+func (ts *ExternalTestSuite) TestTokenExchangeRejectsNonUserToken() {
+	ts.createFacebookIdentity("facebookTestId", "facebook@example.com")
+
+	server := FacebookAccessTokenSetup(ts, ts.Config.External.Facebook.ClientID[0], true, "PAGE", "facebookTestId")
+	defer server.Close()
+
+	w := ts.tokenExchange("page_token")
+	ts.Require().Equal(http.StatusBadRequest, w.Code)
+}
+
+func (ts *ExternalTestSuite) TestTokenExchangeMissingSubjectToken() {
+	w := ts.tokenExchange("")
+	ts.Require().Equal(http.StatusBadRequest, w.Code)
+}
+
+func (ts *ExternalTestSuite) TestTokenExchangeMissingSubjectTokenType() {
+	w := ts.tokenExchangeWithType("some_token", "")
+	ts.Require().Equal(http.StatusBadRequest, w.Code)
+}
+
+func (ts *ExternalTestSuite) TestTokenExchangeUnsupportedSubjectTokenType() {
+	w := ts.tokenExchangeWithType("some_token", "urn:ietf:params:oauth:token-type:id_token")
+	ts.Require().Equal(http.StatusBadRequest, w.Code)
+}
+
+func (ts *ExternalTestSuite) TestTokenExchangeProviderDisabled() {
+	ts.Config.External.Facebook.Enabled = false
+	defer func() { ts.Config.External.Facebook.Enabled = true }()
+
+	w := ts.tokenExchange("some_token")
+	ts.Require().Equal(http.StatusBadRequest, w.Code)
+}

--- a/internal/metering/record.go
+++ b/internal/metering/record.go
@@ -22,6 +22,10 @@ const (
 	LoginTypeToken     LoginType = "token" // for refresh token flows, to be backward-compatible with existing data
 	LoginTypeMFA       LoginType = "mfa"   // for MFA verifications
 	LoginTypePasskey   LoginType = "passkey"
+
+	// LoginTypeTokenExchange is the token-exchange grant, where sign-in relies
+	// on a provider-issued access token rather than an OAuth authorization flow.
+	LoginTypeTokenExchange LoginType = "token_exchange"
 )
 
 // Provider constants for consistent login analytics


### PR DESCRIPTION
## What

Adds an RFC 8693 **token-exchange** grant to `POST /token` so a client can sign in with a provider-issued **access token** instead of an OIDC id token:

```
POST /token?grant_type=urn:ietf:params:oauth:grant-type:token-exchange
{
  "subject_token": "<facebook access token>",
  "subject_token_type": "https://supabase.com/auth/token-type/facebook-access-token"
}
```

The provider is inferred from `subject_token_type`, so the request carries no separate `provider` field.

**RFC:** [Token-exchange grant for provider access tokens](https://linear.app/supabase/project/rfc-token-exchange-grant-for-provider-access-tokens-f27171267cb9)

## Why

Native Facebook login on Android (supabase/supabase-flutter#1287) only mints an OIDC id token (which carries `email`/`email_verified`) on the **first** authorization. Every subsequent login returns a classic access token with **no profile claims** and no id token, so the `id_token` grant is unusable for the common repeat-login case. This is a Facebook platform limitation (Limited Login is iOS-only). See facebook/facebook-android-sdk#1132.

The split, matching how Firebase and Auth0 handle Facebook:
- **Signup / first login** → OIDC id token via the existing `id_token` grant (has the email claims). This is where the account is created, including on Android.
- **Repeat logins** → this token-exchange grant.

## How

- `grant_type` is the standard RFC 8693 URN. The provider is inferred from `subject_token_type`: a Facebook access token uses `https://supabase.com/auth/token-type/facebook-access-token`. New providers opt in by registering their own token type, so no new grant is needed and the request carries no separate `provider` field.
- Verification is provider-specific via a new `provider.AccessTokenVerifier` interface. Facebook's implementation calls [`/debug_token`](https://developers.facebook.com/docs/graph-api/reference/debug_token/) (app token sent as a Bearer header, not in the URL; transport errors have the URL stripped so the token can't leak), and requires `is_valid`, an `app_id` matching one of this project's configured Facebook client ids, and a `USER` token type. It returns the token's `user_id` as the subject.
- **Sign-in-existing only:** `debug_token` returns no profile claims, so the grant looks up the existing `auth.identities` row (`provider`, `provider_id=user_id`) and issues a session. It does **not** create accounts (a brand-new user signs up via the id-token first-login path), and rejects banned users and unconfirmed users (unless `AllowUnverifiedEmailSignIns` is set), matching the other sign-in paths. A missing identity returns a generic `Invalid subject_token` to avoid account enumeration; the client fallback for that edge case is `signInWithOAuth` (web).
- Successful sign-ins write a `login` audit log entry (with the provider trait) and are metered under a dedicated `token_exchange` login type, since no OAuth authorization flow is involved.

## Tests

`internal/api/token_exchange_test.go`: sign-in of an existing identity (asserting the audit log entry), no-identity rejected, banned user rejected, unconfirmed user rejected, unconfirmed allowed when `AllowUnverifiedEmailSignIns` is set, token from another app rejected, token issued for a secondary configured client id accepted, invalid token, non-user token, missing subject_token, missing subject_token_type, unsupported subject_token_type, disabled provider. All pass against Postgres.

## Notes / follow-ups

- **Multiple client ids:** `VerifyAccessToken` verifies `debug_token`'s `app_id` against all configured Facebook client ids, matching the `id_token` grant, which already accepts any configured client id as an acceptable audience. The `/debug_token` call itself is authenticated with the primary client id.
- **Session-info tokens:** Facebook's attenuated, no-user-data token can be added later as another `subject_token_type` for defense in depth once the client can produce one; the server flow is identical.
