### PR TITLE
fix(Dockerfile.dev): copy internal/forks/godotenv to WORKDIR

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -10,6 +10,8 @@ WORKDIR /go/src/github.com/supabase/auth
 # Pulling dependencies
 COPY ./Makefile ./go.* ./
 
+COPY internal/forks/godotenv ./internal/forks/godotenv
+
 # Production dependencies
 RUN make deps
 


### PR DESCRIPTION
## What kind of change does this PR introduce?
Bug fix: Earlier Dockerfile.dev was not copying internal/forks/godotenv to WORKDIR which led to a no such file or directory error in RUN make deps. This change copies the missing dir to fix above error

## What is the current behavior?
#2606
<img width="3448" height="1752" alt="image" src="https://github.com/user-attachments/assets/0b6e2269-77cd-423f-a086-155fc186fc67" />

## What is the new behavior?
<img width="3456" height="1686" alt="image" src="https://github.com/user-attachments/assets/ea542ea9-9bfe-475f-86cc-c867531e81bb" />
