### PR TITLE
fix(oauth): prevent authorization-code replay race at /oauth/token

### DIFF
--- a/internal/api/oauthserver/handlers.go
+++ b/internal/api/oauthserver/handlers.go
@@ -394,6 +394,13 @@ func (s *Server) handleAuthorizationCodeGrant(ctx context.Context, w http.Respon
 	grantParams.Scopes = &scopes
 
 	err = db.Transaction(func(tx *storage.Connection) error {
+		if _, terr := models.FindOAuthServerAuthorizationByIDForUpdate(tx, authorization.AuthorizationID); terr != nil {
+			if models.IsNotFoundError(terr) {
+				return apierrors.NewOAuthError("invalid_grant", "Invalid authorization code")
+			}
+			return apierrors.NewInternalServerError("Error locking authorization code").WithInternalError(terr)
+		}
+
 		authMethod := models.OAuthProviderAuthorizationCode
 
 		// Create audit log entry for OAuth token exchange
@@ -423,6 +430,9 @@ func (s *Server) handleAuthorizationCodeGrant(ctx context.Context, w http.Respon
 	if err != nil {
 		if httpErr, ok := err.(*apierrors.HTTPError); ok {
 			return httpErr
+		}
+		if oauthErr, ok := err.(*apierrors.OAuthError); ok {
+			return oauthErr
 		}
 		return apierrors.NewInternalServerError("Error exchanging authorization code").WithInternalError(err)
 	}

--- a/internal/api/oauthserver/handlers_replay_test.go
+++ b/internal/api/oauthserver/handlers_replay_test.go
@@ -1,0 +1,65 @@
+package oauthserver
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/gofrs/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/supabase/auth/internal/api/shared"
+	"github.com/supabase/auth/internal/models"
+)
+
+func (ts *OAuthClientTestSuite) mintApprovedCode(clientID, userID uuid.UUID) string {
+	auth := models.NewOAuthServerAuthorization(models.NewOAuthServerAuthorizationParams{
+		ClientID:    clientID,
+		RedirectURI: "https://example.com/callback",
+		Scope:       "profile",
+		TTL:         time.Hour,
+	})
+	require.NoError(ts.T(), models.CreateOAuthServerAuthorization(ts.DB, auth))
+	require.NoError(ts.T(), auth.SetUser(ts.DB, userID))
+	require.NoError(ts.T(), auth.Approve(ts.DB))
+	return *auth.AuthorizationCode
+}
+
+func (ts *OAuthClientTestSuite) TestAuthCodeReplayRace() {
+	client, _ := ts.createTestOAuthClient()
+	user := ts.createTestUser("replay-race@example.com")
+	code := ts.mintApprovedCode(client.ID, user.ID)
+
+	const n = 10
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	var success int32
+
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			req := httptest.NewRequest(http.MethodPost, "/oauth/token", nil)
+			ctx := shared.WithOAuthServerClient(req.Context(), client)
+			req = req.WithContext(ctx)
+			w := httptest.NewRecorder()
+			params := &OAuthTokenParams{GrantType: GrantTypeAuthorizationCode, Code: code}
+
+			<-start
+			if err := ts.Server.handleAuthorizationCodeGrant(ctx, w, req, params); err == nil {
+				atomic.AddInt32(&success, 1)
+			}
+		}()
+	}
+
+	close(start)
+	wg.Wait()
+
+	assert.Equal(ts.T(), int32(1), success, "authorization code must be single-use: expected exactly one successful redemption, got %d", success)
+
+	_, err := models.FindOAuthServerAuthorizationByCode(ts.DB, code)
+	assert.True(ts.T(), models.IsNotFoundError(err), "authorization code should be consumed after redemption")
+}


### PR DESCRIPTION
# fix(oauth): prevent authorization-code replay race at `/oauth/token`

## What

Fixes an authorization-code replay race (TOCTOU) in the `authorization_code` grant at `POST /oauth/token`.

## Why

`handleAuthorizationCodeGrant` read the code (`FindOAuthServerAuthorizationByCode`) and validated expiry/client/redirect_uri/PKCE **with no transaction or row lock**, opening a transaction only later to issue tokens and `Destroy` the code. Two requests with the same code can both clear validation before either commits; `tx.Destroy`'s `DELETE` matching 0 rows still commits under READ COMMITTED — so **both mint a full token set for one single-use code**, violating RFC 6749 §4.1.2 / PKCE.

The authorize/consent path was hardened in #2512; token-exchange never got the equivalent locked read-modify-write.

## Change

- Reuse `FindOAuthServerAuthorizationByIDForUpdate` (#2512's `FOR UPDATE SKIP LOCKED` helper) to lock the row at the top of the issuing transaction. Concurrent redemptions serialize — the loser skips the locked row and gets `invalid_grant`. No new model code.
- Propagate `*apierrors.OAuthError` out of the transaction so `invalid_grant` reaches the client instead of a 500.

## Impact

No schema/API changes. Behavior differs only under concurrent redemption of the same code.

## Testing

`go build ./...` and `go vet` pass. Reproduction: N concurrent exchanges of one fresh code behind a start barrier — before, ≥2 responses carried `access_token`; after, exactly one succeeds and the rest return `400 invalid_grant` (`success <= 1`).