### PR TITLE
feat(token): support link_identity in the token-exchange grant

### DIFF
--- a/internal/api/token_exchange.go
+++ b/internal/api/token_exchange.go
@@ -31,6 +31,7 @@ var subjectTokenTypeProviders = map[string]string{
 type TokenExchangeGrantParams struct {
 	SubjectToken     string `json:"subject_token"`
 	SubjectTokenType string `json:"subject_token_type"`
+	LinkIdentity     bool   `json:"link_identity"`
 }
 
 // TokenExchangeGrant implements the RFC 8693 token-exchange grant. It lets a
@@ -43,6 +44,10 @@ type TokenExchangeGrantParams struct {
 // only a classic access token, which carries no profile claims. This grant
 // verifies that token belongs to this app, reads the provider subject from it,
 // and signs in the existing identity, so it does not create accounts.
+//
+// When link_identity is set and a valid user access token is provided in the
+// Authorization header, the provider identity is linked to that user instead of
+// signing in an existing identity.
 func (a *API) TokenExchangeGrant(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
 	db := a.db.WithContext(ctx)
 
@@ -61,6 +66,33 @@ func (a *API) TokenExchangeGrant(ctx context.Context, w http.ResponseWriter, r *
 	providerType, ok := subjectTokenTypeProviders[params.SubjectTokenType]
 	if !ok {
 		return apierrors.NewOAuthError("invalid_request", fmt.Sprintf("unsupported subject_token_type %q", params.SubjectTokenType))
+	}
+
+	// When linking, the caller must present a valid user access token; the
+	// verified provider identity is attached to that user instead of signing in
+	// an existing identity.
+	var targetUser *models.User
+	if params.LinkIdentity {
+		if r.Header.Get("Authorization") == "" {
+			return apierrors.NewOAuthError("invalid_request", "Linking requires a valid user access token in Authorization")
+		}
+
+		requireAuthCtx, err := a.requireAuthentication(w, r)
+		if err != nil {
+			return err
+		}
+
+		targetUser = getUser(requireAuthCtx)
+		if targetUser == nil {
+			return apierrors.NewOAuthError("invalid_request", "Linking requires a valid user authentication")
+		}
+
+		if targetUser.IsBanned() {
+			return apierrors.NewOAuthError("invalid_grant", "User is banned")
+		}
+
+		// set it so linkIdentityToUser works below
+		ctx = withTargetUser(ctx, targetUser)
 	}
 
 	oauthProvider, pConfig, err := a.OAuthProvider(ctx, providerType)
@@ -88,44 +120,57 @@ func (a *API) TokenExchangeGrant(ctx context.Context, w http.ResponseWriter, r *
 	// signs in an identity that already exists (created on the first login via
 	// the id_token grant). A missing identity means the user must sign up first,
 	// but the error stays generic to avoid leaking whether an account exists.
-	identity, err := models.FindIdentityByIdAndProvider(db, subject, providerType)
-	if err != nil {
-		if models.IsNotFoundError(err) {
-			return apierrors.NewOAuthError("invalid_request", "Invalid subject_token").WithInternalError(err)
+	var user *models.User
+	if !params.LinkIdentity {
+		identity, err := models.FindIdentityByIdAndProvider(db, subject, providerType)
+		if err != nil {
+			if models.IsNotFoundError(err) {
+				return apierrors.NewOAuthError("invalid_request", "Invalid subject_token").WithInternalError(err)
+			}
+			return apierrors.NewInternalServerError("Database error finding identity").WithInternalError(err)
 		}
-		return apierrors.NewInternalServerError("Database error finding identity").WithInternalError(err)
-	}
 
-	user, err := models.FindUserByID(db, identity.UserID)
-	if err != nil {
-		if models.IsNotFoundError(err) {
-			return apierrors.NewOAuthError("invalid_request", "No user found for this identity")
+		user, err = models.FindUserByID(db, identity.UserID)
+		if err != nil {
+			if models.IsNotFoundError(err) {
+				return apierrors.NewOAuthError("invalid_request", "No user found for this identity")
+			}
+			return apierrors.NewInternalServerError("Database error finding user").WithInternalError(err)
 		}
-		return apierrors.NewInternalServerError("Database error finding user").WithInternalError(err)
-	}
 
-	if user.IsBanned() {
-		return apierrors.NewOAuthError("invalid_request", "Invalid subject_token")
-	}
+		if user.IsBanned() {
+			return apierrors.NewOAuthError("invalid_request", "Invalid subject_token")
+		}
 
-	// Don't hand out a session to an unconfirmed user unless the instance allows
-	// unverified email sign-ins, matching the other sign-in paths. The error
-	// stays generic to avoid leaking account state.
-	if !user.IsConfirmed() && !a.config.Mailer.AllowUnverifiedEmailSignIns {
-		return apierrors.NewOAuthError("invalid_request", "Invalid subject_token")
+		// Don't hand out a session to an unconfirmed user unless the instance
+		// allows unverified email sign-ins, matching the other sign-in paths.
+		// The error stays generic to avoid leaking account state.
+		if !user.IsConfirmed() && !a.config.Mailer.AllowUnverifiedEmailSignIns {
+			return apierrors.NewOAuthError("invalid_request", "Invalid subject_token")
+		}
 	}
 
 	var grantParams models.GrantParams
 	grantParams.FillGrantParams(r)
 
+	// userData for the link path carries only the provider subject; the access
+	// token exposes no profile claims.
+	userData := &provider.UserProvidedData{Metadata: &provider.Claims{Subject: subject}}
+
 	var token *AccessTokenResponse
 	if err := db.Transaction(func(tx *storage.Connection) error {
+		var terr error
+		if params.LinkIdentity {
+			user, terr = a.linkIdentityToUser(r, ctx, tx, userData, providerType)
+			if terr != nil {
+				return terr
+			}
+		}
 		if terr := models.NewAuditLogEntry(a.config.AuditLog, r, tx, user, models.LoginAction, "", map[string]interface{}{
 			"provider": providerType,
 		}); terr != nil {
 			return terr
 		}
-		var terr error
 		token, terr = a.issueRefreshToken(r, w.Header(), tx, user, models.OAuth, grantParams)
 		return terr
 	}); err != nil {

--- a/internal/api/token_exchange_test.go
+++ b/internal/api/token_exchange_test.go
@@ -204,3 +204,81 @@ func (ts *ExternalTestSuite) TestTokenExchangeProviderDisabled() {
 	w := ts.tokenExchange("some_token")
 	ts.Require().Equal(http.StatusBadRequest, w.Code)
 }
+
+func (ts *ExternalTestSuite) generateAccessTokenAndSession(u *models.User) string {
+	s, err := models.NewSession(u.ID, nil)
+	ts.Require().NoError(err)
+	ts.Require().NoError(ts.API.db.Create(s))
+
+	req := httptest.NewRequest(http.MethodPost, "/token?grant_type=password", nil)
+	token, _, err := ts.API.generateAccessToken(req, ts.API.db, u, &s.ID, models.PasswordGrant)
+	ts.Require().NoError(err)
+	return token
+}
+
+func (ts *ExternalTestSuite) tokenExchangeLink(subjectToken, authToken string) *httptest.ResponseRecorder {
+	var buffer bytes.Buffer
+	ts.Require().NoError(json.NewEncoder(&buffer).Encode(map[string]interface{}{
+		"subject_token":      subjectToken,
+		"subject_token_type": FacebookAccessTokenType,
+		"link_identity":      true,
+	}))
+
+	req := httptest.NewRequest(http.MethodPost, "http://localhost/token?grant_type="+TokenExchangeGrantType, &buffer)
+	req.Header.Set("Content-Type", "application/json")
+	if authToken != "" {
+		req.Header.Set("Authorization", "Bearer "+authToken)
+	}
+	w := httptest.NewRecorder()
+	ts.API.handler.ServeHTTP(w, req)
+	return w
+}
+
+func (ts *ExternalTestSuite) TestTokenExchangeLinkIdentity() {
+	// User exists with an email identity but no facebook identity yet.
+	user, err := ts.createUser("link-user-sub", "linkme@example.com", "Link Me", "", "")
+	ts.Require().NoError(err)
+	authToken := ts.generateAccessTokenAndSession(user)
+
+	server := FacebookAccessTokenSetup(ts, ts.Config.External.Facebook.ClientID[0], true, "USER", "fbLinkTarget")
+	defer server.Close()
+
+	w := ts.tokenExchangeLink("valid_access_token", authToken)
+	ts.Require().Equal(http.StatusOK, w.Code, w.Body.String())
+
+	var response AccessTokenResponse
+	ts.Require().NoError(json.NewDecoder(w.Body).Decode(&response))
+	ts.Require().NotNil(response.User)
+	ts.Equal(user.ID, response.User.ID)
+
+	// the facebook identity should now be linked to the existing user
+	ts.Require().NoError(ts.API.db.Load(user, "Identities"))
+	var providers []string
+	for _, identity := range user.Identities {
+		providers = append(providers, identity.Provider)
+	}
+	ts.Contains(providers, "facebook")
+}
+
+func (ts *ExternalTestSuite) TestTokenExchangeLinkIdentityRequiresAuth() {
+	server := FacebookAccessTokenSetup(ts, ts.Config.External.Facebook.ClientID[0], true, "USER", "fbLinkTarget")
+	defer server.Close()
+
+	w := ts.tokenExchangeLink("valid_access_token", "")
+	ts.Require().Equal(http.StatusBadRequest, w.Code)
+}
+
+func (ts *ExternalTestSuite) TestTokenExchangeLinkIdentityRejectsBannedUser() {
+	user, err := ts.createUser("link-user-sub", "linkme@example.com", "Link Me", "", "")
+	ts.Require().NoError(err)
+	authToken := ts.generateAccessTokenAndSession(user)
+	t := time.Now().Add(24 * time.Hour)
+	user.BannedUntil = &t
+	ts.Require().NoError(ts.API.db.UpdateOnly(user, "banned_until"))
+
+	server := FacebookAccessTokenSetup(ts, ts.Config.External.Facebook.ClientID[0], true, "USER", "fbLinkTarget")
+	defer server.Close()
+
+	w := ts.tokenExchangeLink("valid_access_token", authToken)
+	ts.Require().Equal(http.StatusBadRequest, w.Code)
+}


### PR DESCRIPTION
## What

Adds `link_identity` support to the token-exchange grant (#2609), so an already-authenticated user can attach a provider identity using a provider access token.

```
POST /token?grant_type=urn:ietf:params:oauth:grant-type:token-exchange
Authorization: Bearer <current user session>
{
  "provider": "facebook",
  "subject_token": "<facebook access token>",
  "subject_token_type": "urn:ietf:params:oauth:token-type:access_token",
  "link_identity": true
}
```

## Why

Parity with the `id_token` grant, which already supports `link_identity`. Lets a user who signed in another way connect their Facebook account natively (no browser). Because it only needs the verified provider subject, it works even when the app is already authorized (the token is a classic access token with no id token), which is the common case.

## How

- When `link_identity` is set, require a valid user access token in the `Authorization` header (`requireAuthentication`), resolve the target user, and reject the request if that user is banned (`requireAuthentication` itself does not check bans).
- After verifying the provider token, branch to `linkIdentityToUser` (using the verified subject) instead of the sign-in-existing lookup. No profile claims are needed, only the subject from `debug_token`.

## Limitations

- **Email-less target users** (anonymous / phone-only with no email) cannot complete a link here: `linkIdentityToUser` requires an email to confirm and the Facebook access token carries none. Those users should link via the existing web flow (`LinkIdentity`, which fetches the profile via `/me`).
- The linked identity's `identity_data` is **sparse** (only the subject), unlike the web flow which stores the full profile (email/name/avatar).

## Tests

- `TestTokenExchangeLinkIdentity`: links Facebook to an existing signed-in user; asserts the same user is returned and the `facebook` identity is attached.
- `TestTokenExchangeLinkIdentityRequiresAuth`: linking without an `Authorization` header is rejected.
- `TestTokenExchangeLinkIdentityRejectsBannedUser`: a banned user cannot link (and thus cannot re-establish a session).

## Stacking

Stacked on #2609 (base branch `feat/facebook-access-token-grant`). Review/merge that first; this diff is only the linking addition.
