### PR TITLE
fix(mfa): use AMR method (not factor type) when downgrading sessions to AAL1

### DIFF
--- a/internal/models/factor.go
+++ b/internal/models/factor.go
@@ -135,7 +135,7 @@ func ParseAuthenticationMethod(authMethod string) (AuthenticationMethod, error) 
 		return EmailChange, nil
 	case "token_refresh":
 		return TokenRefresh, nil
-	case "mfa/sms":
+	case "mfa/phone":
 		return MFAPhone, nil
 	case "mfa/webauthn":
 		return MFAWebAuthn, nil
@@ -397,13 +397,32 @@ func (f *Factor) UpdateStatus(tx *storage.Connection, state FactorState) error {
 	return tx.UpdateOnly(f, "status", "updated_at")
 }
 
+// amrMethodForFactorType returns the AMR authentication_method string stored in
+// mfa_amr_claims for a given factor type.
+func amrMethodForFactorType(factorType string) (string, error) {
+	switch factorType {
+	case TOTP:
+		return TOTPSignIn.String(), nil
+	case Phone:
+		return MFAPhone.String(), nil
+	case WebAuthn:
+		return MFAWebAuthn.String(), nil
+	default:
+		return "", fmt.Errorf("no AMR authentication method mapped for factor type %q", factorType)
+	}
+}
+
 func (f *Factor) DowngradeSessionsToAAL1(tx *storage.Connection) error {
 	sessions, err := FindSessionsByFactorID(tx, f.ID)
 	if err != nil {
 		return err
 	}
+	amrMethod, err := amrMethodForFactorType(f.FactorType)
+	if err != nil {
+		return err
+	}
 	for _, session := range sessions {
-		if err := tx.RawQuery("DELETE FROM "+(&pop.Model{Value: AMRClaim{}}).TableName()+" WHERE session_id = ? AND authentication_method = ?", session.ID, f.FactorType).Exec(); err != nil {
+		if err := tx.RawQuery("DELETE FROM "+(&pop.Model{Value: AMRClaim{}}).TableName()+" WHERE session_id = ? AND authentication_method = ?", session.ID, amrMethod).Exec(); err != nil {
 			return err
 		}
 	}

--- a/internal/models/factor_test.go
+++ b/internal/models/factor_test.go
@@ -2,6 +2,7 @@ package models
 
 import (
 	"encoding/json"
+	"fmt"
 	"testing"
 
 	"github.com/gofrs/uuid"
@@ -29,6 +30,31 @@ func TestFactor(t *testing.T) {
 	}
 	defer ts.db.Close()
 	suite.Run(t, ts)
+}
+
+// TestAMRMethodForFactorType pins the factor-type -> AMR method mapping.
+func TestAMRMethodForFactorType(t *testing.T) {
+	for factorType, want := range map[string]AuthenticationMethod{
+		TOTP:     TOTPSignIn,
+		Phone:    MFAPhone,
+		WebAuthn: MFAWebAuthn,
+	} {
+		got, err := amrMethodForFactorType(factorType)
+		require.NoError(t, err, "factor type %q must map", factorType)
+		require.Equal(t, want.String(), got)
+	}
+
+	_, err := amrMethodForFactorType("not-a-real-factor-type")
+	require.Error(t, err)
+}
+
+// TestAuthenticationMethodRoundTrip guards the String() <-> ParseAuthenticationMethod symmetry.
+func TestAuthenticationMethodRoundTrip(t *testing.T) {
+	for _, m := range []AuthenticationMethod{TOTPSignIn, MFAPhone, MFAWebAuthn} {
+		parsed, err := ParseAuthenticationMethod(m.String())
+		require.NoError(t, err, "method %q must round-trip", m.String())
+		require.Equal(t, m, parsed)
+	}
 }
 
 func (ts *FactorTestSuite) SetupTest() {
@@ -71,4 +97,70 @@ func (ts *FactorTestSuite) TestEncodedFactorDoesNotLeakSecret() {
 	decodedFactor := Factor{}
 	json.Unmarshal(encodedFactor, &decodedFactor)
 	require.Equal(ts.T(), decodedFactor.Secret, "")
+}
+
+// TestDowngradeSessionsToAAL1RemovesAMRClaim asserts that unenrolling a verified
+// factor strips the AMR claim it granted, dropping the session back to AAL1.
+func (ts *FactorTestSuite) TestDowngradeSessionsToAAL1RemovesAMRClaim() {
+	cases := []struct {
+		desc       string
+		newFactor  func(u *User) *Factor
+		authMethod AuthenticationMethod
+	}{
+		{
+			desc:       "phone",
+			newFactor:  func(u *User) *Factor { return NewPhoneFactor(u, "+15555555555", "") },
+			authMethod: MFAPhone,
+		},
+		{
+			desc:       "webauthn",
+			newFactor:  func(u *User) *Factor { return NewWebAuthnFactor(u, "webauthnfactor") },
+			authMethod: MFAWebAuthn,
+		},
+		{
+			desc:       "totp",
+			newFactor:  func(u *User) *Factor { return NewTOTPFactor(u, "totpfactor") },
+			authMethod: TOTPSignIn,
+		},
+	}
+
+	for i, c := range cases {
+		ts.Run(c.desc, func() {
+			user, err := NewUser("", fmt.Sprintf("downgrade-%d@example.com", i), "secret", "test", nil)
+			require.NoError(ts.T(), err)
+			require.NoError(ts.T(), ts.db.Create(user))
+
+			factor := c.newFactor(user)
+			require.NoError(ts.T(), factor.SetSecret("secretkey", false, "", ""))
+			require.NoError(ts.T(), ts.db.Create(factor))
+			require.NoError(ts.T(), factor.UpdateStatus(ts.db, FactorStateVerified))
+
+			session, err := NewSession(user.ID, &factor.ID)
+			require.NoError(ts.T(), err)
+			require.NoError(ts.T(), ts.db.Create(session))
+			require.NoError(ts.T(), AddClaimToSession(ts.db, session.ID, c.authMethod))
+			require.NoError(ts.T(), session.UpdateAALAndAssociatedFactor(ts.db, AAL2, &factor.ID))
+
+			// the claim upgrades the session to AAL2.
+			loaded, err := FindSessionByID(ts.db, session.ID, false)
+			require.NoError(ts.T(), err)
+			aal, _, err := loaded.CalculateAALAndAMR(user)
+			require.NoError(ts.T(), err)
+			require.Equal(ts.T(), AAL2, aal)
+
+			require.NoError(ts.T(), factor.DowngradeSessionsToAAL1(ts.db))
+
+			downgraded, err := FindSessionByID(ts.db, session.ID, false)
+			require.NoError(ts.T(), err)
+			require.Equal(ts.T(), AAL1.String(), downgraded.GetAAL())
+			require.Nil(ts.T(), downgraded.FactorID)
+
+			aal, _, err = downgraded.CalculateAALAndAMR(user)
+			require.NoError(ts.T(), err)
+			require.Equal(ts.T(), AAL1, aal)
+			for _, claim := range downgraded.AMRClaims {
+				require.NotEqual(ts.T(), c.authMethod.String(), claim.GetAuthenticationMethod())
+			}
+		})
+	}
 }


### PR DESCRIPTION
`DowngradeSessionsToAAL1` deleted AMR claims where `authentication_method = factor_type`, but the column stores the AMR method (`mfa/phone`, `mfa/webauthn`) — only "totp" matched, so unenrolling a phone/webauthn factor left a stale AAL2 claim.

This PR:

- Maps factor type → AMR method before the delete
- Unknown types now error instead of silently mismatching
- Drops the dead "mfa/sms" alias