### PR TITLE
chore: fix docker dev build

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -9,6 +9,7 @@ WORKDIR /go/src/github.com/supabase/auth
 
 # Pulling dependencies
 COPY ./Makefile ./go.* ./
+COPY ./internal/forks/godotenv ./internal/forks/godotenv
 
 # Production dependencies
 RUN make deps


### PR DESCRIPTION
## What kind of change does this PR introduce?

Include the godotenv fork in the docker build context.

Related to:

* https://github.com/supabase/auth/pull/2567

## What is the current behavior?

```bash
モ docker compose -f docker-compose-dev.yml build
[+] Building 2.5s (19/21)
 => [internal] load local bake definitions                                                                                         0.0s
 => => reading from stdin 1.02kB                                                                                                   0.0s
 => [postgres internal] load build definition from Dockerfile.postgres.dev                                                         0.0s
 => => transferring dockerfile: 224B                                                                                               0.0s
 => [auth internal] load build definition from Dockerfile.dev                                                                      0.0s
 => => transferring dockerfile: 422B                                                                                               0.0s
 => [auth internal] load metadata for docker.io/library/golang:1.25.11-alpine3.23                                                  0.7s
 => [postgres internal] load metadata for docker.io/library/postgres:15                                                            0.6s
 => [auth internal] load .dockerignore                                                                                             0.0s
 => => transferring context: 62B                                                                                                   0.0s
 => [auth 1/7] FROM docker.io/library/golang:1.25.11-alpine3.23@sha256:60e626bbde32def8694687d03536ea4341b19e5f068e9a630225a1dfbd  0.0s
 => => resolve docker.io/library/golang:1.25.11-alpine3.23@sha256:60e626bbde32def8694687d03536ea4341b19e5f068e9a630225a1dfbd0505c  0.0s
 => [auth internal] load build context                                                                                             0.0s
 => => transferring context: 77.99kB                                                                                               0.0s
 => [postgres 1/5] FROM docker.io/library/postgres:15@sha256:3b0d656f5fff31c7d8a64f500a703dcf3f35e98ce78f602831a73059a5e6a012      0.0s
 => => resolve docker.io/library/postgres:15@sha256:3b0d656f5fff31c7d8a64f500a703dcf3f35e98ce78f602831a73059a5e6a012               0.0s
 => [postgres internal] load build context                                                                                         0.0s
 => => transferring context: 569B                                                                                                  0.0s
 => CACHED [postgres 2/5] RUN pwd                                                                                                  0.0s
 => CACHED [postgres 3/5] COPY init_postgres.sh /docker-entrypoint-initdb.d/init.sh                                                0.0s
 => CACHED [postgres 4/5] RUN chmod +x /docker-entrypoint-initdb.d/init.sh                                                         0.0s
 => CACHED [auth 2/7] RUN apk add --no-cache make git bash                                                                         0.0s
 => CACHED [auth 3/7] WORKDIR /go/src/github.com/supabase/auth                                                                     0.0s
 => CACHED [auth 4/7] COPY ./Makefile ./go.* ./                                                                                    0.0s
 => ERROR [auth 5/7] RUN make deps                                                                                                 1.6s
 => [postgres] exporting to image                                                                                                  0.0s
 => => exporting layers                                                                                                            0.0s
 => => exporting manifest sha256:21fb5f1f04ca4c8efab0ae69dc0d3854dd0e4f1e0798e50fb79017f07638dc7b                                  0.0s
 => => exporting config sha256:bd0195ba063db96107055b82683a66ceb010260406fb695706e89ccaad0661ce                                    0.0s
 => => exporting attestation manifest sha256:10325eb2d922d0a762e5b71fbc3c557d561ec2565ec97ece8f3685491f63a7b8                      0.0s
 => => exporting manifest list sha256:184fc0cef401a1e9b16365998a70c2695ebd9e5225ad7abf1f2f03609fbe1ce5                             0.0s
 => => naming to docker.io/library/auth-postgres:latest                                                                            0.0s
 => => unpacking to docker.io/library/auth-postgres:latest                                                                         0.0s
 => [postgres] resolving provenance for metadata file                                                                              0.0s
------
 > [auth 5/7] RUN make deps:
0.071 fatal: not a git repository (or any of the parent directories): .git
0.072 fatal: not a git repository (or any of the parent directories): .git
0.072 fatal: not a git repository (or any of the parent directories): .git
0.073 fatal: not a git repository (or any of the parent directories): .git
0.073 fatal: not a git repository (or any of the parent directories): .git
0.073 fatal: not a git repository (or any of the parent directories): .git
0.074 fatal: not a git repository (or any of the parent directories): .git
0.074 fatal: not a git repository (or any of the parent directories): .git
1.523 go: github.com/joho/godotenv@v1.5.1 (replaced by ./internal/forks/godotenv): reading internal/forks/godotenv/go.mod: open /go/src/github.com/supabase/auth/internal/forks/godotenv/go.mod: no such file or directory
1.524 make: *** [Makefile:72: deps] Error 1
------
[+] build 0/2
 ⠙ Image auth-postgres Building                                                                                                     2.6s
 ⠙ Image auth-auth     Building                                                                                                     2.6s
Dockerfile.dev:14

--------------------

  12 |

  13 |     # Production dependencies

  14 | >>> RUN make deps

  15 |

  16 |     # Development dependences

--------------------

target auth: failed to solve: process "/bin/sh -c make deps" did not complete successfully: exit code: 2
```

## What is the new behavior?

```bash
モ docker compose -f docker-compose-dev.yml build
[+] Building 2.8s (24/24) FINISHED
 => [internal] load local bake definitions                                                                                         0.0s
 => => reading from stdin 1.02kB                                                                                                   0.0s
 => [auth internal] load build definition from Dockerfile.dev                                                                      0.0s
 => => transferring dockerfile: 479B                                                                                               0.0s
 => [postgres internal] load build definition from Dockerfile.postgres.dev                                                         0.0s
 => => transferring dockerfile: 224B                                                                                               0.0s
 => [auth internal] load metadata for docker.io/library/golang:1.25.11-alpine3.23                                                  0.6s
 => [postgres internal] load metadata for docker.io/library/postgres:15                                                            0.5s
 => [auth internal] load .dockerignore                                                                                             0.0s
 => => transferring context: 62B                                                                                                   0.0s
 => [postgres 1/5] FROM docker.io/library/postgres:15@sha256:3b0d656f5fff31c7d8a64f500a703dcf3f35e98ce78f602831a73059a5e6a012      0.0s
 => => resolve docker.io/library/postgres:15@sha256:3b0d656f5fff31c7d8a64f500a703dcf3f35e98ce78f602831a73059a5e6a012               0.0s
 => [postgres internal] load build context                                                                                         0.0s
 => => transferring context: 569B                                                                                                  0.0s
 => CACHED [postgres 2/5] RUN pwd                                                                                                  0.0s
 => CACHED [postgres 3/5] COPY init_postgres.sh /docker-entrypoint-initdb.d/init.sh                                                0.0s
 => CACHED [postgres 4/5] RUN chmod +x /docker-entrypoint-initdb.d/init.sh                                                         0.0s
 => [postgres] exporting to image                                                                                                  0.0s
 => => exporting layers                                                                                                            0.0s
 => => exporting manifest sha256:21fb5f1f04ca4c8efab0ae69dc0d3854dd0e4f1e0798e50fb79017f07638dc7b                                  0.0s
 => => exporting config sha256:bd0195ba063db96107055b82683a66ceb010260406fb695706e89ccaad0661ce                                    0.0s
 => => exporting attestation manifest sha256:68ff70d3bc6cf38019f0c8d27db8c87c8aaa0dda8c124b806a9464c89f869e70                      0.0s
 => => exporting manifest list sha256:b38c57ab4e1fdae5b2af6ee87bd3a7e1127b7ab5e896feb902756c030812a3fd                             0.0s
 => => naming to docker.io/library/auth-postgres:latest                                                                            0.0s
 => => unpacking to docker.io/library/auth-postgres:latest                                                                         0.0s
 => [auth 1/8] FROM docker.io/library/golang:1.25.11-alpine3.23@sha256:60e626bbde32def8694687d03536ea4341b19e5f068e9a630225a1dfbd  0.0s
 => => resolve docker.io/library/golang:1.25.11-alpine3.23@sha256:60e626bbde32def8694687d03536ea4341b19e5f068e9a630225a1dfbd0505c  0.0s
 => [auth internal] load build context                                                                                             0.0s
 => => transferring context: 114.73kB                                                                                              0.0s
 => CACHED [auth 2/8] RUN apk add --no-cache make git bash                                                                         0.0s
 => CACHED [auth 3/8] WORKDIR /go/src/github.com/supabase/auth                                                                     0.0s
 => CACHED [auth 4/8] COPY ./Makefile ./go.* ./                                                                                    0.0s
 => CACHED [auth 5/8] COPY ./internal/forks/godotenv ./internal/forks/godotenv                                                     0.0s
 => CACHED [auth 6/8] RUN make deps                                                                                                0.0s
 => CACHED [auth 7/8] RUN go get github.com/githubnemo/CompileDaemon                                                               0.0s
 => CACHED [auth 8/8] RUN go install github.com/githubnemo/CompileDaemon                                                           0.0s
 => [auth] exporting to image                                                                                                      2.0s
 => => exporting layers                                                                                                            0.0s
 => => exporting manifest sha256:565657ef549a8a0581fbff8a359a27fee4bb0ecb9a2d86c0ed7465fc8bf0fa90                                  0.0s
 => => exporting config sha256:ba5f55b03e9922e25ca67479e7e3c4b6d9e65257e6c3f494d34a8fb72f3c3342                                    0.0s
 => => exporting attestation manifest sha256:18e5dfbc6200a7297a4e2d4a96ce7e40b235a3296d22f908321d6374a8d78af1                      0.0s
 => => exporting manifest list sha256:ada355d250877297e5c7ce0db2b7a717d5f62a618b8ecadb958536443cbb32e7                             0.0s
 => => naming to docker.io/library/auth-auth:latest                                                                                0.0s
 => => unpacking to docker.io/library/auth-auth:latest                                                                             1.9s
 => [postgres] resolving provenance for metadata file                                                                              0.0s
 => [auth] resolving provenance for metadata file                                                                                  0.0s
[+] build 2/2
 ✔ Image auth-auth     Built                                                                                                        2.8s
 ✔ Image auth-postgres Built                                                                                                        2.8s
```

## Additional context