### PR TITLE
fix: ensure legacy refresh token revoked

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -186,7 +186,7 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-go 1.25.11
+go 1.25.12
 
 replace (
 	github.com/joho/godotenv => ./internal/forks/godotenv

--- a/internal/models/refresh_token.go
+++ b/internal/models/refresh_token.go
@@ -110,7 +110,7 @@ func RevokeTokenFamily(tx *storage.Connection, token *RefreshToken) error {
 
 func FindTokenBySessionID(tx *storage.Connection, sessionId *uuid.UUID) (*RefreshToken, error) {
 	refreshToken := &RefreshToken{}
-	err := tx.Q().Where("instance_id = ? and session_id = ?", uuid.Nil, sessionId).Order("created_at asc").First(refreshToken)
+	err := tx.Q().Where("instance_id = ? and session_id = ? and revoked = false", uuid.Nil, sessionId).Order("created_at asc").First(refreshToken)
 	if err != nil {
 		if errors.Cause(err) == sql.ErrNoRows {
 			return nil, RefreshTokenNotFoundError{}

--- a/internal/models/refresh_token_test.go
+++ b/internal/models/refresh_token_test.go
@@ -67,6 +67,48 @@ func (ts *RefreshTokenTestSuite) TestGrantRefreshTokenSwap() {
 	require.Equal(ts.T(), u.ID, s.UserID)
 }
 
+func (ts *RefreshTokenTestSuite) TestFindTokenBySessionID() {
+	u := ts.createUser()
+	r, err := GrantAuthenticatedUser(ts.db, u, GrantParams{})
+	require.NoError(ts.T(), err)
+
+	found, err := FindTokenBySessionID(ts.db, r.SessionId)
+	require.NoError(ts.T(), err)
+
+	require.Equal(ts.T(), r.ID, found.ID)
+	require.Equal(ts.T(), r.Token, found.Token)
+	require.False(ts.T(), found.Revoked)
+}
+
+func (ts *RefreshTokenTestSuite) TestFindTokenBySessionIDExcludesRevokedToken() {
+	u := ts.createUser()
+	r, err := GrantAuthenticatedUser(ts.db, u, GrantParams{})
+	require.NoError(ts.T(), err)
+
+	s, err := GrantRefreshTokenSwap(ts.config.AuditLog, &http.Request{}, ts.db, u, r)
+	require.NoError(ts.T(), err)
+
+	found, err := FindTokenBySessionID(ts.db, r.SessionId)
+	require.NoError(ts.T(), err)
+
+	require.Equal(ts.T(), s.ID, found.ID, "expected the active (post-swap) token, not the revoked one")
+	require.NotEqual(ts.T(), r.ID, found.ID)
+	require.False(ts.T(), found.Revoked)
+}
+
+func (ts *RefreshTokenTestSuite) TestFindTokenBySessionIDNotFoundWhenAllRevoked() {
+	u := ts.createUser()
+	r, err := GrantAuthenticatedUser(ts.db, u, GrantParams{})
+	require.NoError(ts.T(), err)
+
+	r.Revoked = true
+	require.NoError(ts.T(), ts.db.UpdateOnly(r, "revoked"))
+
+	_, err = FindTokenBySessionID(ts.db, r.SessionId)
+	require.Error(ts.T(), err)
+	require.True(ts.T(), IsNotFoundError(err), "expected NotFoundError")
+}
+
 func (ts *RefreshTokenTestSuite) TestLogout() {
 	u := ts.createUser()
 	r, err := GrantAuthenticatedUser(ts.db, u, GrantParams{})


### PR DESCRIPTION


## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

FindTokenBySessionID did not exclude revoked tokens from its lookup. Allowing a refresh token to be reused when switching legacy refresh tokensduring an MFA session update

## What is the new behavior?

The revoked status of the legacy refresh token is checked when doing MFA upgrade