### PR TITLE
fix(siwe): return false instead of panicking on malformed signatures

### DIFF
--- a/internal/utilities/siwe/parser.go
+++ b/internal/utilities/siwe/parser.go
@@ -211,7 +211,9 @@ func ParseMessage(raw string) (*SIWEMessage, error) {
 func (m *SIWEMessage) VerifySignature(signatureHex string) bool {
 	sig, err := hexutil.Decode(signatureHex)
 	if err != nil || len(sig) != 65 {
-		panic("siwe: signature must be a 65-byte hex string")
+		// Signature is attacker-controlled request input; a verifier must
+		// reject it, not panic (which the API turns into a 500 + stack trace).
+		return false
 	}
 
 	// Create signature in [R || S || V] format
@@ -229,7 +231,9 @@ func (m *SIWEMessage) VerifySignature(signatureHex string) bool {
 	// Recover public key
 	pubKey, err := crypto.Ecrecover(hash, signature)
 	if err != nil {
-		panic("siwe: failed to recover public key: " + err.Error())
+		// A malformed signature (e.g. an invalid recovery byte) fails recovery;
+		// treat it as a non-matching signature rather than panicking.
+		return false
 	}
 
 	// Convert to address

--- a/internal/utilities/siwe/parser_test.go
+++ b/internal/utilities/siwe/parser_test.go
@@ -2,6 +2,7 @@ package siwe
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -131,6 +132,39 @@ func TestParseMessage(t *testing.T) {
 			// require.Equal(t, "abcdef", *parsed.RequestID)
 
 			require.Equal(t, true, parsed.VerifySignature((example.signature)))
+		})
+	}
+}
+
+// VerifySignature receives an attacker-controlled signature (via POST /token
+// grant_type=web3). It must return false for malformed input, not panic — a
+// panic is turned into an HTTP 500 + stack-trace log instead of the intended
+// clean 400. The sibling internal/utilities/siws implementation is the
+// reference: it returns false on every error path.
+func TestVerifySignatureRejectsMalformedInput(t *testing.T) {
+	message := "example.com wants you to sign in with your Ethereum account:\n0x196a28d05bA75C8dC35B0F6e71DD622D1aC82b7E\n\nURI: https://example.com\nVersion: 1\nChain ID: 1\nNonce: 12345678\nIssued At: 2025-01-01T00:00:00.000Z"
+	parsed, err := ParseMessage(message)
+	require.Nil(t, err)
+
+	malformed := []struct {
+		name      string
+		signature string
+	}{
+		{"empty", ""},
+		// 130 hex chars but no 0x prefix -> hexutil.Decode errors (previously panicked).
+		{"missing 0x prefix", strings.Repeat("a", 130)},
+		// non-hex characters after the prefix -> decode errors.
+		{"non-hex characters", "0x" + strings.Repeat("z", 130)},
+		// decodes fine but is not 65 bytes.
+		{"wrong length", "0xdeadbeef"},
+		// valid 65-byte hex but unrecoverable -> crypto.Ecrecover errors (previously panicked).
+		{"unrecoverable signature", "0x" + strings.Repeat("0", 130)},
+	}
+	for _, tc := range malformed {
+		t.Run(tc.name, func(t *testing.T) {
+			require.NotPanics(t, func() {
+				require.False(t, parsed.VerifySignature(tc.signature))
+			})
 		})
 	}
 }


### PR DESCRIPTION
## Problem

`SIWEMessage.VerifySignature` (`internal/utilities/siwe/parser.go`) returns `bool`, but **panics** on two attacker-controlled inputs instead of returning `false`:

```go
sig, err := hexutil.Decode(signatureHex)
if err != nil || len(sig) != 65 {
    panic("siwe: signature must be a 65-byte hex string")
}
...
pubKey, err := crypto.Ecrecover(hash, signature)
if err != nil {
    panic("siwe: failed to recover public key: " + err.Error())
}
```

Both are reachable from the **public, unauthenticated** endpoint `POST /token?grant_type=web3` (`web3GrantEthereum`). The caller's pre-check only gates on length via `strings.TrimPrefix(params.Signature, "0x")` — which is a no-op when the `0x` prefix is absent and does not validate hex-ness — so malformed signatures reach `VerifySignature` and trigger a panic.

The `recoverer` middleware catches it, so the process doesn't crash, but it converts the panic into an **HTTP 500 with a logged stack trace** rather than the clean `400 invalid_grant` that a bad signature should produce. That's an API-contract bug plus a stack-trace log-flooding vector on an unauthenticated endpoint.

## Fix

Return `false` on both error paths, matching the sibling Solana verifier `internal/utilities/siws/parser.go` (`SIWSMessage.VerifySignature`), which never panics. Behavior-only change; no signature/API change.

## Tests

Adds `TestVerifySignatureRejectsMalformedInput` covering empty, missing-`0x`-prefix, non-hex, wrong-length, and unrecoverable signatures — asserting `require.NotPanics` + `require.False`. The `unrecoverable`/`wrong-length`/`missing-prefix` cases exercise both former panic paths.

Verified with `go test ./internal/utilities/siwe/` — passes on the fix and **panics/fails on the old code**; `gofmt` and `go vet` clean. The `siwe` package is pure (no DB needed to test).
