### PR TITLE
chore: add lint rule to ensure Go versions stay in sync

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.11-alpine3.23 as build
+FROM golang:1.25.12-alpine3.23 as build
 ENV GO111MODULE=on
 ENV CGO_ENABLED=0
 ENV GOOS=linux

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM golang:1.25.11-alpine3.23
+FROM golang:1.25.12-alpine3.23
 ENV GO111MODULE=on
 ENV CGO_ENABLED=0
 ENV GOOS=linux

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: all build deps image migrate test vet sec vulncheck format unused release
-.PHONY: check-gosec check-govulncheck check-oapi-codegen check-staticcheck
+.PHONY: check-gosec check-govulncheck check-oapi-codegen check-staticcheck check-go-version
 CHECK_FILES ?= ./...
 
 ifdef RELEASE_VERSION
@@ -41,7 +41,7 @@ TOOL_TARGETS = \
 help: ## Show this help.
 	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {sub("\\\\n",sprintf("\n%22c"," "), $$2);printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
 
-all: vet sec static build ## Run the tests and build the binary.
+all: check-go-version vet sec static build ## Run the tests and build the binary.
 
 build: auth auth-amd64 auth-arm64 auth-darwin-arm64 ## Build the binaries.
 
@@ -73,6 +73,7 @@ deps: ## Install dependencies.
 	@go mod verify
 
 release-test: \
+	check-go-version \
 	vet \
 	static \
 	sec \
@@ -117,6 +118,9 @@ test: auth ## Run tests.
 
 vet: # Vet the code
 	go vet $(CHECK_FILES)
+
+check-go-version: ## Verify the pinned Go version matches across go.mod, Dockerfiles, and submodules.
+	./hack/check-go-version.sh
 
 .NOTPARALLEL: $(TOOL_TARGETS)
 $(TOOL_TARGETS):

--- a/hack/check-go-version.sh
+++ b/hack/check-go-version.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+# Ensures the pinned Go patch version is identical everywhere it appears.
+# Source of truth is the `go` directive in the root go.mod.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+# "X.Y.Z" from a go.mod `go` directive.
+gomod_version() { grep -m1 -E '^go [0-9]' "$1" | awk '{print $2}'; }
+# "X.Y.Z" from a Dockerfile `FROM golang:X.Y.Z-...` line.
+dockerfile_version() { grep -m1 -oE 'golang:[0-9]+\.[0-9]+\.[0-9]+' "$1" | cut -d: -f2; }
+
+WANT="$(gomod_version go.mod)"
+FAIL=false
+
+check() { # <label> <found>
+  if [ "$2" != "$WANT" ]; then
+    echo "✗ $1 pins Go $2, expected $WANT (from go.mod)"
+    FAIL=true
+  fi
+}
+
+check "tools/go.mod"                   "$(gomod_version tools/go.mod)"
+check "internal/forks/godotenv/go.mod" "$(gomod_version internal/forks/godotenv/go.mod)"
+check "Dockerfile"                     "$(dockerfile_version Dockerfile)"
+check "Dockerfile.dev"                 "$(dockerfile_version Dockerfile.dev)"
+
+if [ "$FAIL" = true ]; then
+  echo
+  echo "Go version mismatch. Update every pinned spot above to match go.mod ($WANT)."
+  exit 1
+fi
+
+echo "Go version $WANT is consistent across all pinned files."

--- a/internal/forks/godotenv/go.mod
+++ b/internal/forks/godotenv/go.mod
@@ -1,3 +1,3 @@
 module github.com/joho/godotenv
 
-go 1.25.11
+go 1.25.12

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/supabase/auth/tools
 
-go 1.25.11
+go 1.25.12
 
 tool (
 	github.com/securego/gosec/v2/cmd/gosec


### PR DESCRIPTION
Adds lint rule to ensure Go versions remain in sync across go.mod files and Dockerfiles.

Errors would show up as follows:

<img width="807" height="199" alt="Screenshot 2026-07-16 at 13 11 33" src="https://github.com/user-attachments/assets/1338c22c-ca7e-4709-85c3-8a191b055cc3" />
