### PR TITLE
fix: prefer Site URL over origin-only Referer for email redirects

### DIFF
--- a/internal/api/external.go
+++ b/internal/api/external.go
@@ -412,7 +412,7 @@ func (a *API) createAccountFromExternalIdentity(tx *storage.Connection, r *http.
 		} else {
 			emailConfirmationSent := false
 			if decision.CandidateEmail.Email != "" {
-				if terr = a.sendConfirmation(r, tx, user, models.ImplicitFlow); terr != nil {
+				if terr = a.sendConfirmation(r, tx, user, models.ImplicitFlow, ""); terr != nil {
 					return 0, nil, terr
 				}
 				emailConfirmationSent = true

--- a/internal/api/identity.go
+++ b/internal/api/identity.go
@@ -144,7 +144,7 @@ func (a *API) linkIdentityToUser(r *http.Request, ctx context.Context, tx *stora
 			return nil, terr
 		}
 		if !userData.Metadata.EmailVerified {
-			if terr := a.sendConfirmation(r, tx, targetUser, models.ImplicitFlow); terr != nil {
+			if terr := a.sendConfirmation(r, tx, targetUser, models.ImplicitFlow, ""); terr != nil {
 				return nil, terr
 			}
 			return nil, storage.NewCommitWithError(apierrors.NewUnprocessableEntityError(apierrors.ErrorCodeEmailNotConfirmed, "Unverified email with %v. A confirmation email has been sent to your %v email", providerType, providerType))

--- a/internal/api/mail.go
+++ b/internal/api/mail.go
@@ -315,7 +315,7 @@ func (a *API) adminGenerateLink(w http.ResponseWriter, r *http.Request) error {
 	return sendJSON(w, http.StatusOK, resp)
 }
 
-func (a *API) sendConfirmation(r *http.Request, tx *storage.Connection, u *models.User, flowType models.FlowType) error {
+func (a *API) sendConfirmation(r *http.Request, tx *storage.Connection, u *models.User, flowType models.FlowType, redirectTo string) error {
 	var err error
 
 	config := a.config
@@ -335,6 +335,7 @@ func (a *API) sendConfirmation(r *http.Request, tx *storage.Connection, u *model
 		emailActionType:     mail.SignupVerification,
 		otp:                 otp,
 		tokenHashWithPrefix: u.ConfirmationToken,
+		redirectTo:          redirectTo,
 	}); err != nil {
 		u.ConfirmationToken = oldToken
 		if errors.Is(err, EmailRateLimitExceeded) {
@@ -754,12 +755,17 @@ type sendEmailParams struct {
 	oldPhone            string
 	provider            string
 	factorType          string
+	// redirectTo, when set and allow-listed, overrides GetReferrer (e.g. signup JSON body).
+	redirectTo string
 }
 
 func (a *API) sendEmail(r *http.Request, tx *storage.Connection, u *models.User, params sendEmailParams) error {
 	ctx := r.Context()
 	config := a.config
 	referrerURL := utilities.GetReferrer(r, config)
+	if params.redirectTo != "" && utilities.IsRedirectURLValid(config, params.redirectTo) {
+		referrerURL = params.redirectTo
+	}
 	externalURL := getExternalHost(ctx)
 	otp := params.otp
 

--- a/internal/api/resend.go
+++ b/internal/api/resend.go
@@ -133,7 +133,7 @@ func (a *API) Resend(w http.ResponseWriter, r *http.Request) error {
 					return terr
 				}
 			}
-			return a.sendConfirmation(r, tx, user, flowType)
+			return a.sendConfirmation(r, tx, user, flowType, "")
 		case smsVerification:
 			if terr := models.NewAuditLogEntry(config.AuditLog, r, tx, user, models.UserRecoveryRequestedAction, "", nil); terr != nil {
 				return terr

--- a/internal/api/signup.go
+++ b/internal/api/signup.go
@@ -27,6 +27,17 @@ type SignupParams struct {
 	Channel             string                 `json:"channel"`
 	CodeChallengeMethod string                 `json:"code_challenge_method"`
 	CodeChallenge       string                 `json:"code_challenge"`
+	// RedirectTo is the post-confirm redirect. Clients may also send email_redirect_to.
+	RedirectTo      string `json:"redirect_to"`
+	EmailRedirectTo string `json:"email_redirect_to"`
+}
+
+// GetRedirectTo returns the explicit redirect from the signup body, if any.
+func (p *SignupParams) GetRedirectTo() string {
+	if p.RedirectTo != "" {
+		return p.RedirectTo
+	}
+	return p.EmailRedirectTo
 }
 
 func (a *API) validateSignupParams(ctx context.Context, p *SignupParams) error {
@@ -247,7 +258,7 @@ func (a *API) Signup(w http.ResponseWriter, r *http.Request) error {
 						return terr
 					}
 				}
-				if terr = a.sendConfirmation(r, tx, user, flowType); terr != nil {
+				if terr = a.sendConfirmation(r, tx, user, flowType, params.GetRedirectTo()); terr != nil {
 					return terr
 				}
 			}

--- a/internal/utilities/request.go
+++ b/internal/utilities/request.go
@@ -81,11 +81,26 @@ func GetReferrer(r *http.Request, config *conf.GlobalConfiguration) string {
 
 	// instead try referrer header value
 	reqref = r.Referer()
-	if IsRedirectURLValid(config, reqref) {
+	if IsRedirectURLValid(config, reqref) && !shouldPreferSiteURLOverReferer(config.SiteURL, reqref) {
 		return reqref
 	}
 
 	return config.SiteURL
+}
+
+// shouldPreferSiteURLOverReferer is true when Referer is origin-only (empty or "/")
+// but SiteURL includes a non-root path. Cross-origin browser requests often strip the
+// path from Referer (Referrer-Policy: strict-origin-when-cross-origin), which would
+// otherwise drop project paths such as GitHub Pages /repo/.
+func shouldPreferSiteURLOverReferer(siteURL, referer string) bool {
+	site, serr := url.Parse(siteURL)
+	ref, rerr := url.Parse(referer)
+	if serr != nil || rerr != nil {
+		return false
+	}
+	sitePath := strings.TrimSuffix(site.Path, "/")
+	refPath := strings.TrimSuffix(ref.Path, "/")
+	return sitePath != "" && refPath == ""
 }
 
 var decimalIPAddressPattern = regexp.MustCompile("^[0-9]+$")

--- a/internal/utilities/request_test.go
+++ b/internal/utilities/request_test.go
@@ -336,3 +336,57 @@ func TestGetReferrer(t *tst.T) {
 		})
 	}
 }
+
+func TestGetReferrerPrefersSiteURLOverOriginOnlyReferer(t *tst.T) {
+	cases := []struct {
+		desc     string
+		siteURL  string
+		referer  string
+		query    string
+		expected string
+	}{
+		{
+			desc:     "origin-only referer loses to site url with path",
+			siteURL:  "https://user.github.io/repo/",
+			referer:  "https://user.github.io/",
+			expected: "https://user.github.io/repo/",
+		},
+		{
+			desc:     "explicit redirect_to still wins",
+			siteURL:  "https://user.github.io/repo/",
+			referer:  "https://user.github.io/",
+			query:    "https://user.github.io/repo/welcome",
+			expected: "https://user.github.io/repo/welcome",
+		},
+		{
+			desc:     "referer with path still used",
+			siteURL:  "https://user.github.io/repo/",
+			referer:  "https://user.github.io/repo/signup",
+			expected: "https://user.github.io/repo/signup",
+		},
+		{
+			desc:     "origin-only referer kept when site url has no path",
+			siteURL:  "https://example.com",
+			referer:  "https://example.com/",
+			expected: "https://example.com/",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.desc, func(t *tst.T) {
+			config := conf.GlobalConfiguration{
+				SiteURL: c.siteURL,
+				JWT:     conf.JWTConfiguration{Secret: "testsecret"},
+			}
+			require.NoError(t, config.ApplyDefaults())
+
+			reqURL := "http://localhost/signup"
+			if c.query != "" {
+				reqURL += "?redirect_to=" + c.query
+			}
+			r := httptest.NewRequest("POST", reqURL, nil)
+			r.Header.Set("Referer", c.referer)
+			require.Equal(t, c.expected, GetReferrer(r, &config))
+		})
+	}
+}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

When sending a signup confirmation email, Auth chooses the post-confirm redirect with `GetReferrer()` in this order:

1. Explicit `redirect_to` (query/header)
2. `Referer` header
3. Configured Site URL

For apps hosted on a path-based origin (for example GitHub Pages at `https://user.github.io/repo/`), a browser `POST` to `*.supabase.co` is cross-origin. With a typical `Referrer-Policy` such as `strict-origin-when-cross-origin`, the browser often sends an **origin-only** Referer (`https://user.github.io/`), with the `/repo/` path removed.

Because that origin still matches the Site URL hostname, Auth treats it as valid and prefers it over a Site URL that includes the project path. The confirmation link then contains:

```text
.../auth/v1/verify?...&redirect_to=https://user.github.io/
```

instead of the intended:

```text
...&redirect_to=https://user.github.io/repo/
```

In addition, `POST /signup` did not read `redirect_to` / `email_redirect_to` from the JSON body (`SignupParams` had no such fields). Clients that only sent the redirect in the body therefore fell through to the Referer / Site URL logic above.

Relevant issue: https://github.com/supabase/auth/issues/2634

## What is the new behavior?

- **`GetReferrer`**: if the fallback candidate is an origin-only Referer (empty path or `/`) and Site URL has a non-root path, prefer Site URL. An explicit `redirect_to` still takes precedence. Referers that already include a path are unchanged.
- **Signup**: `SignupParams` accepts `redirect_to` and `email_redirect_to` from the JSON body and, when allow-listed, uses that value for the confirmation email.

Unit coverage was added for the origin-only Referer vs path-based Site URL case.

## Additional context

This is aimed at path-based deployments (GitHub Pages project sites and similar). Password recovery already behaved correctly when `redirect_to` was supplied as a query parameter; this change mainly fixes signup confirmation when Auth would otherwise trust a stripped Referer, and when the redirect is only present in the signup JSON body.

Happy to adjust naming, tests, or scope if maintainers prefer a narrower change. Thank you for reviewing.