### PR TITLE
fix: accept offline_access OAuth scope for MCP refresh clients

### DIFF
--- a/internal/models/oauth_scope.go
+++ b/internal/models/oauth_scope.go
@@ -4,10 +4,11 @@ import "strings"
 
 // OAuth/OIDC scope constants
 const (
-	ScopeOpenID  = "openid"
-	ScopeEmail   = "email"
-	ScopeProfile = "profile"
-	ScopePhone   = "phone"
+	ScopeOpenID        = "openid"
+	ScopeEmail         = "email"
+	ScopeProfile       = "profile"
+	ScopePhone         = "phone"
+	ScopeOfflineAccess = "offline_access"
 )
 
 // SupportedOAuthScopes defines all OAuth/OIDC scopes supported by the server
@@ -16,6 +17,7 @@ var SupportedOAuthScopes = []string{
 	ScopeProfile,
 	ScopeEmail,
 	ScopePhone,
+	ScopeOfflineAccess,
 }
 
 // IsSupportedScope checks if a scope is in the supported scopes list

--- a/internal/models/oauth_scope_test.go
+++ b/internal/models/oauth_scope_test.go
@@ -225,6 +225,11 @@ func TestIsSupportedScope(t *testing.T) {
 			expected: true,
 		},
 		{
+			name:     "offline_access scope is supported",
+			scope:    ScopeOfflineAccess,
+			expected: true,
+		},
+		{
 			name:     "unsupported scope address",
 			scope:    "address",
 			expected: false,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

The OAuth 2.1 authorization server already issues refresh tokens on the authorization-code grant and supports the `refresh_token` grant. However, `offline_access` is not in the supported scope allowlist (`SupportedOAuthScopes`), so:

1. `GET /oauth/authorize?...&scope=openid%20offline_access` fails with `error=invalid_request` / `unsupported scope: offline_access`
2. `/.well-known/oauth-authorization-server` advertises `scopes_supported: ["openid","profile","email","phone"]` without `offline_access`

MCP clients (Copilot Studio, ChatGPT, and similar) often require `offline_access` to be advertised and granted before they will use refresh tokens. Without it, they hold unused refresh tokens, access tokens expire after ~1 hour, and users are forced to re-authenticate.

Fixes https://github.com/supabase/auth/issues/2628

## What is the new behavior?

`offline_access` is added to `SupportedOAuthScopes` (accept-and-ignore). Because authorize validation and discovery metadata both use that shared list:

- Authorize requests that include `offline_access` succeed
- Discovery metadata includes `offline_access` in `scopes_supported`

No change to token issuance: refresh tokens were already issued unconditionally when configured.

## Additional context

Single-source change in `internal/models/oauth_scope.go`, with a unit test asserting `IsSupportedScope("offline_access")`. Happy to adjust if maintainers prefer a different approach. Thank you for reviewing.