### PR TITLE
fix: use raw Basic auth for custom OIDC/OAuth token exchange

### DIFF
--- a/internal/api/provider/custom_oauth.go
+++ b/internal/api/provider/custom_oauth.go
@@ -36,8 +36,9 @@ func NewCustomOAuthProvider(
 		RedirectURL:  redirectURL,
 		Scopes:       scopes,
 		Endpoint: oauth2.Endpoint{
-			AuthURL:  authorizationURL,
-			TokenURL: tokenURL,
+			AuthURL:   authorizationURL,
+			TokenURL:  tokenURL,
+			AuthStyle: oauth2.AuthStyleInHeader,
 		},
 	}
 
@@ -66,7 +67,7 @@ func (p *CustomOAuthProvider) AuthCodeURL(state string, opts ...oauth2.AuthCodeO
 
 // GetOAuthToken exchanges the authorization code for an access token
 func (p *CustomOAuthProvider) GetOAuthToken(ctx context.Context, code string, opts ...oauth2.AuthCodeOption) (*oauth2.Token, error) {
-	return p.config.Exchange(ctx, code, opts...)
+	return exchangeAuthorizationCode(ctx, p.config, code, opts...)
 }
 
 // GetUserData fetches user data from the provider's userinfo endpoint
@@ -152,6 +153,7 @@ func NewCustomOIDCProvider(
 
 	// Get endpoints from the OIDC provider
 	endpoint := oidcProvider.Endpoint()
+	endpoint.AuthStyle = oauth2.AuthStyleInHeader
 	userinfoEndpoint := oidcProvider.UserInfoEndpoint()
 
 	config := &oauth2.Config{
@@ -188,7 +190,7 @@ func (p *CustomOIDCProvider) AuthCodeURL(state string, opts ...oauth2.AuthCodeOp
 
 // GetOAuthToken exchanges the authorization code for an access token
 func (p *CustomOIDCProvider) GetOAuthToken(ctx context.Context, code string, opts ...oauth2.AuthCodeOption) (*oauth2.Token, error) {
-	return p.config.Exchange(ctx, code, opts...)
+	return exchangeAuthorizationCode(ctx, p.config, code, opts...)
 }
 
 // GetUserData fetches user data from the provider's userinfo endpoint or ID token

--- a/internal/api/provider/custom_oauth_test.go
+++ b/internal/api/provider/custom_oauth_test.go
@@ -40,6 +40,7 @@ func TestNewCustomOAuthProvider(t *testing.T) {
 	assert.Equal(t, []string{"openid", "profile"}, provider.config.Scopes)
 	assert.Equal(t, "https://example.com/authorize", provider.config.Endpoint.AuthURL)
 	assert.Equal(t, "https://example.com/token", provider.config.Endpoint.TokenURL)
+	assert.Equal(t, oauth2.AuthStyleInHeader, provider.config.Endpoint.AuthStyle)
 	assert.Equal(t, "https://example.com/userinfo", provider.userinfoURL)
 	assert.True(t, provider.RequiresPKCE())
 	assert.Equal(t, []string{"ios-client-id", "android-client-id"}, provider.acceptableClientIDs)

--- a/internal/api/provider/oauth_exchange.go
+++ b/internal/api/provider/oauth_exchange.go
@@ -1,0 +1,60 @@
+package provider
+
+import (
+	"context"
+	"net/http"
+
+	"golang.org/x/oauth2"
+)
+
+// rawBasicAuthTransport rewrites Authorization: Basic to use the raw client
+// id and secret. golang.org/x/oauth2 url.QueryEscape-s credentials for
+// AuthStyleInHeader (RFC 6749 §2.3.1), which breaks providers that expect a
+// raw secret (e.g. Epic Games). See https://github.com/supabase/auth/issues/2623
+type rawBasicAuthTransport struct {
+	base                   http.RoundTripper
+	clientID, clientSecret string
+}
+
+func (t *rawBasicAuthTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	base := t.base
+	if base == nil {
+		base = http.DefaultTransport
+	}
+	if req.Header.Get("Authorization") != "" {
+		req = req.Clone(req.Context())
+		req.SetBasicAuth(t.clientID, t.clientSecret)
+	}
+	return base.RoundTrip(req)
+}
+
+// exchangeAuthorizationCode exchanges an auth code using HTTP Basic with the
+// raw (unescaped) client secret. AuthStyle is forced to InHeader so oauth2
+// does not auto-detect and retry as client_secret_post (which masks errors).
+func exchangeAuthorizationCode(ctx context.Context, cfg *oauth2.Config, code string, opts ...oauth2.AuthCodeOption) (*oauth2.Token, error) {
+	cfgCopy := *cfg
+	cfgCopy.Endpoint.AuthStyle = oauth2.AuthStyleInHeader
+
+	base := http.DefaultTransport
+	timeout := defaultTimeout
+	if existing, ok := ctx.Value(oauth2.HTTPClient).(*http.Client); ok && existing != nil {
+		if existing.Timeout != 0 {
+			timeout = existing.Timeout
+		}
+		if existing.Transport != nil {
+			base = existing.Transport
+		}
+	}
+
+	client := &http.Client{
+		Timeout: timeout,
+		Transport: &rawBasicAuthTransport{
+			base:         base,
+			clientID:     cfg.ClientID,
+			clientSecret: cfg.ClientSecret,
+		},
+	}
+	ctx = context.WithValue(ctx, oauth2.HTTPClient, client)
+
+	return cfgCopy.Exchange(ctx, code, opts...)
+}

--- a/internal/api/provider/oauth_exchange_test.go
+++ b/internal/api/provider/oauth_exchange_test.go
@@ -1,0 +1,155 @@
+package provider
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/oauth2"
+)
+
+func TestExchangeAuthorizationCode_RawBasicAuth(t *testing.T) {
+	const (
+		clientID     = "epic-client"
+		clientSecret = "secret+with/special=chars"
+		authCode     = "auth-code-123"
+	)
+
+	var requestCount atomic.Int32
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount.Add(1)
+
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "application/x-www-form-urlencoded", r.Header.Get("Content-Type"))
+
+		user, pass, ok := r.BasicAuth()
+		require.True(t, ok, "expected Authorization: Basic header")
+		assert.Equal(t, clientID, user)
+		assert.Equal(t, clientSecret, pass, "client secret must be raw, not url.QueryEscape-d")
+
+		// Confirm the wire header is not the QueryEscaped form oauth2 would send.
+		authHeader := r.Header.Get("Authorization")
+		require.True(t, strings.HasPrefix(authHeader, "Basic "))
+		decoded, err := base64.StdEncoding.DecodeString(strings.TrimPrefix(authHeader, "Basic "))
+		require.NoError(t, err)
+		assert.Equal(t, clientID+":"+clientSecret, string(decoded))
+		assert.NotContains(t, string(decoded), "%2B")
+		assert.NotContains(t, string(decoded), "%2F")
+		assert.NotContains(t, string(decoded), "%3D")
+
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		values, err := url.ParseQuery(string(body))
+		require.NoError(t, err)
+		assert.Equal(t, "authorization_code", values.Get("grant_type"))
+		assert.Equal(t, authCode, values.Get("code"))
+		assert.Equal(t, "https://myapp.com/callback", values.Get("redirect_uri"))
+		assert.Equal(t, "pkce-verifier", values.Get("code_verifier"))
+		assert.Empty(t, values.Get("client_secret"), "secret must not be in the body (no client_secret_post fallback)")
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"access_token":  "access-token",
+			"token_type":    "Bearer",
+			"expires_in":    3600,
+			"refresh_token": "refresh-token",
+			"id_token":      "id-token",
+		})
+	}))
+	defer server.Close()
+
+	cfg := &oauth2.Config{
+		ClientID:     clientID,
+		ClientSecret: clientSecret,
+		RedirectURL:  "https://myapp.com/callback",
+		Endpoint: oauth2.Endpoint{
+			AuthURL:   server.URL + "/authorize",
+			TokenURL:  server.URL + "/token",
+			AuthStyle: oauth2.AuthStyleInHeader,
+		},
+	}
+
+	tok, err := exchangeAuthorizationCode(context.Background(), cfg, authCode, oauth2.VerifierOption("pkce-verifier"))
+	require.NoError(t, err)
+	require.NotNil(t, tok)
+	assert.Equal(t, "access-token", tok.AccessToken)
+	assert.Equal(t, "refresh-token", tok.RefreshToken)
+	assert.Equal(t, "id-token", tok.Extra("id_token"))
+	assert.Equal(t, int32(1), requestCount.Load(), "must not auto-detect/retry as client_secret_post")
+}
+
+func TestExchangeAuthorizationCode_SurfacesFirstError(t *testing.T) {
+	var requestCount atomic.Int32
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":"invalid_client","error_description":"invalid_client_credentials"}`))
+	}))
+	defer server.Close()
+
+	cfg := &oauth2.Config{
+		ClientID:     "client",
+		ClientSecret: "sec+ret",
+		RedirectURL:  "https://myapp.com/callback",
+		Endpoint: oauth2.Endpoint{
+			TokenURL:  server.URL + "/token",
+			AuthStyle: oauth2.AuthStyleAutoDetect, // exchangeAuthorizationCode must override this
+		},
+	}
+
+	_, err := exchangeAuthorizationCode(context.Background(), cfg, "code")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid_client")
+	assert.Equal(t, int32(1), requestCount.Load(), "AuthStyleAutoDetect must not trigger a second attempt")
+}
+
+func TestCustomOAuthProvider_GetOAuthToken_UsesRawBasicAuth(t *testing.T) {
+	const clientSecret = "a+b/c=d"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		user, pass, ok := r.BasicAuth()
+		require.True(t, ok)
+		assert.Equal(t, "client-id", user)
+		assert.Equal(t, clientSecret, pass)
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"access_token": "tok",
+			"token_type":   "Bearer",
+			"expires_in":   60,
+		})
+	}))
+	defer server.Close()
+
+	provider := NewCustomOAuthProvider(
+		"client-id",
+		clientSecret,
+		server.URL+"/authorize",
+		server.URL+"/token",
+		server.URL+"/userinfo",
+		"https://myapp.com/callback",
+		[]string{"openid"},
+		false,
+		nil,
+		nil,
+		nil,
+		nil,
+	)
+	assert.Equal(t, oauth2.AuthStyleInHeader, provider.config.Endpoint.AuthStyle)
+
+	tok, err := provider.GetOAuthToken(context.Background(), "code")
+	require.NoError(t, err)
+	assert.Equal(t, "tok", tok.AccessToken)
+}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Custom OIDC / OAuth2 providers exchange the authorization code via `oauth2.Config.Exchange` without setting `Endpoint.AuthStyle`. In that case `golang.org/x/oauth2` uses auto-detect:

1. **Attempt 1:** `Authorization: Basic` with `url.QueryEscape(client_id)` / `url.QueryEscape(client_secret)`
2. **On failure:** retries as `client_secret_post` (credentials in the body)

Providers that expect a **raw** client secret in Basic auth (for example Epic Games, same as `curl -u`) reject Attempt 1 when the secret contains characters that `QueryEscape` rewrites (`+`, `/`, `=`, …). Attempt 2 then fails because those providers require an Authorization header. Callers only see the Attempt-2 error (e.g. “Authorization header may be invalid or not present”), which hides the real `invalid_client_credentials` failure.

Fixes https://github.com/supabase/auth/issues/2623

## What is the new behavior?

For Custom OIDC and Custom OAuth2 providers:

- Token exchange uses an explicit `AuthStyleInHeader` (no auto-detect / second attempt).
- A small HTTP transport rewrites the Basic header to the **raw** client id and secret before the request is sent (no `QueryEscape`).
- PKCE and other `AuthCodeOption`s still go through `Exchange` as before.

Unit tests assert a single token request, raw credentials on the wire for secrets containing `+/ =`, and that the first provider error is surfaced.

## Additional context

This follows RFC 7617-style Basic auth (`curl -u`) rather than the library’s QueryEscape-in-header behavior, which is a known footgun for several IdPs. Built-in providers (Google, etc.) are unchanged. Happy to adjust if maintainers prefer an opt-in config flag instead of the default for custom providers. Thank you for reviewing.