### PR TITLE
chore: use appropriate log level based on HTTP status

### DIFF
--- a/internal/api/errors.go
+++ b/internal/api/errors.go
@@ -133,7 +133,7 @@ func HandleResponseError(err error, w http.ResponseWriter, r *http.Request) {
 			e.ErrorID = errorID
 			// this will get us the stack trace too
 			log.WithError(e.Cause()).Error(e.Error())
-		case e.HTTPStatus == http.StatusTooManyRequests:
+		case e.HTTPStatus >= http.StatusBadRequest:
 			log.WithError(e.Cause()).Warn(e.Error())
 		default:
 			log.WithError(e.Cause()).Info(e.Error())

--- a/internal/observability/request-logger.go
+++ b/internal/observability/request-logger.go
@@ -90,7 +90,7 @@ func (e *logEntry) Write(status, bytes int, header http.Header, elapsed time.Dur
 	}
 
 	entry := e.Entry.WithFields(fields)
-	entry.Info("request completed")
+	entry.Log(LogLevelForHttp(status), "request completed")
 	e.Entry = entry
 }
 
@@ -135,5 +135,16 @@ func LogEntrySetField(r *http.Request, key string, value interface{}) {
 func LogEntrySetFields(r *http.Request, fields logrus.Fields) {
 	if l, ok := r.Context().Value(chimiddleware.LogEntryCtxKey).(*logEntry); ok {
 		l.Entry = l.Entry.WithFields(fields)
+	}
+}
+
+func LogLevelForHttp(status int) logrus.Level {
+	switch {
+	case status >= http.StatusInternalServerError:
+		return logrus.ErrorLevel
+	case status >= http.StatusBadRequest:
+		return logrus.WarnLevel
+	default:
+		return logrus.InfoLevel
 	}
 }

--- a/internal/observability/request-logger_test.go
+++ b/internal/observability/request-logger_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -48,6 +49,45 @@ func TestLogger(t *testing.T) {
 	require.Equal(t, "/path", logs["path"])
 	require.Equal(t, "test-request-id", logs["request_id"])
 	require.NotNil(t, logs["time"])
+}
+
+func TestLoggerLevelReflectsStatus(t *testing.T) {
+	cases := []struct {
+		status        int
+		expectedLevel string
+	}{
+		{http.StatusOK, "info"},
+		{http.StatusBadRequest, "warning"},
+		{http.StatusTooManyRequests, "warning"},
+		{http.StatusInternalServerError, "error"},
+		{http.StatusServiceUnavailable, "error"},
+	}
+
+	config, err := confload.LoadGlobal(apiTestConfig)
+	require.NoError(t, err)
+
+	config.Logging.Level = "info"
+	require.NoError(t, ConfigureLogging(&config.Logging))
+
+	for _, c := range cases {
+		t.Run(fmt.Sprintf("status_%d", c.status), func(t *testing.T) {
+			var logBuffer bytes.Buffer
+			logrus.SetOutput(&logBuffer)
+
+			logHandler := NewStructuredLogger(logrus.StandardLogger(), config)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(c.status)
+			}))
+			w := httptest.NewRecorder()
+			req, err := http.NewRequest(http.MethodGet, "http://example.com/path", nil)
+			require.NoError(t, err)
+			logHandler.ServeHTTP(w, req)
+			require.Equal(t, c.status, w.Code)
+
+			var logs map[string]interface{}
+			require.NoError(t, json.NewDecoder(&logBuffer).Decode(&logs))
+			require.Equal(t, c.expectedLevel, logs["level"])
+		})
+	}
 }
 
 func TestExcludeHealthFromLogs(t *testing.T) {


### PR DESCRIPTION
## What kind of change does this PR introduce?

This changes the log level based on the HTTP response status code.

* Server Errors (500+): Use the `error` log level
* Client Errors (400-499): Use the `warning` log level
* 100-399: Use the `info` log level

## What is the current behavior?

https://linear.app/supabase/issue/AUTH-1309/auth-log-level-should-reflect-http-status

```bash
モ curl http://localhost:9999/authorize
{"code":400,"error_code":"validation_failed","msg":"Unsupported provider: Provider  could not be found"}~/supabase/github.com/supabase/auth [xlgmokha/auth-1309]
```

```bash
{"component":"api","error":"Provider  could not be found","level":"info","method":"GET","msg":"400: Unsupported provider: Provider  could not be found","path":"/authorize","referer":"http://localhost:3000","remote_addr":"127.0.0.1","request_id":"a6700057-9a55-47be-8b57-5a3445d692d6","time":"2026-07-20T21:26:24Z"}
{"component":"api","duration":117333,"error_code":"validation_failed","level":"info","method":"GET","msg":"request completed","path":"/authorize","referer":"http://localhost:3000","remote_addr":"127.0.0.1","request_id":"a6700057-9a55-47be-8b57-5a3445d692d6","status":400,"time":"2026-07-20T21:26:24Z"}
```

## What is the new behavior?

```bash
モ curl http://localhost:9999/authorize
{"code":400,"error_code":"validation_failed","msg":"Unsupported provider: Provider  could not be found"}~/supabase/github.com/supabase/auth [xlgmokha/auth-1309]
```

```bash
{"component":"api","error":"Provider  could not be found","level":"warning","method":"GET","msg":"400: Unsupported provider: Provider  could not be found","path":"/authorize","referer":"http://localhost:3000","remote_addr":"127.0.0.1","request_id":"cfde08d8-48f8-4398-a1ef-9c6cdf7e8fde","time":"2026-07-20T21:41:13Z"}
{"component":"api","duration":132333,"error_code":"validation_failed","level":"warning","method":"GET","msg":"request completed","path":"/authorize","referer":"http://localhost:3000","remote_addr":"127.0.0.1","request_id":"cfde08d8-48f8-4398-a1ef-9c6cdf7e8fde","status":400,"time":"2026-07-20T21:41:13Z"}
```

## Additional context
