### PR TITLE
feat: add cursor-based pagination for admin users list

### DIFF
--- a/internal/api/admin.go
+++ b/internal/api/admin.go
@@ -44,8 +44,9 @@ type adminUserUpdateFactorParams struct {
 }
 
 type AdminListUsersResponse struct {
-	Users []*models.User `json:"users"`
-	Aud   string         `json:"aud"`
+	Users      []*models.User            `json:"users"`
+	Aud        string                    `json:"aud"`
+	Pagination *CursorPaginationResponse `json:"pagination,omitempty"`
 }
 
 func (a *API) loadUser(w http.ResponseWriter, r *http.Request) (context.Context, error) {
@@ -101,16 +102,23 @@ func (a *API) getAdminParams(r *http.Request) (*AdminUserParams, error) {
 	return params, nil
 }
 
+// useCursorPagination reports whether the request should be served with
+// cursor-based (keyset) pagination. It requires the experimental flag to be on
+// and neither offset-style param (`page`, `per_page`) present, so existing
+// clients that page by number keep the offset behavior.
+func (a *API) useCursorPagination(r *http.Request) bool {
+	if !a.config.Experimental.CursorPaginationEnabled {
+		return false
+	}
+	query := r.URL.Query()
+	return query.Get("page") == "" && query.Get("per_page") == ""
+}
+
 // adminUsers responds with a list of all users in a given audience
 func (a *API) adminUsers(w http.ResponseWriter, r *http.Request) error {
 	ctx := r.Context()
 	db := a.db.WithContext(ctx)
 	aud := a.requestAud(ctx, r)
-
-	pageParams, err := paginate(r)
-	if err != nil {
-		return apierrors.NewBadRequestError(apierrors.ErrorCodeValidationFailed, "Bad Pagination Parameters: %v", err).WithInternalError(err)
-	}
 
 	sortParams, err := sort(r, map[string]bool{models.CreatedAt: true}, []models.SortField{{Name: models.CreatedAt, Dir: models.Descending}})
 	if err != nil {
@@ -118,6 +126,15 @@ func (a *API) adminUsers(w http.ResponseWriter, r *http.Request) error {
 	}
 
 	filter := r.URL.Query().Get("filter")
+
+	if a.useCursorPagination(r) {
+		return a.adminUsersKeyset(w, r, db, aud, sortParams, filter)
+	}
+
+	pageParams, err := paginate(r)
+	if err != nil {
+		return apierrors.NewBadRequestError(apierrors.ErrorCodeValidationFailed, "Bad Pagination Parameters: %v", err).WithInternalError(err)
+	}
 
 	users, err := models.FindUsersInAudience(db, aud, pageParams, sortParams, filter)
 	if err != nil {
@@ -128,6 +145,43 @@ func (a *API) adminUsers(w http.ResponseWriter, r *http.Request) error {
 	return sendJSON(w, http.StatusOK, AdminListUsersResponse{
 		Users: users,
 		Aud:   aud,
+	})
+}
+
+// adminUsersKeyset serves the admin user list with cursor-based pagination:
+// no COUNT(*) and no OFFSET. It fetches Limit+1 rows to detect whether another
+// page exists, trims to Limit, and emits the next cursor via both the response
+// body and a Link: rel="next" header.
+func (a *API) adminUsersKeyset(w http.ResponseWriter, r *http.Request, db *storage.Connection, aud string, sortParams *models.SortParams, filter string) error {
+	p, err := parseKeysetParams(r)
+	if err != nil {
+		return apierrors.NewBadRequestError(apierrors.ErrorCodeValidationFailed, "Bad Pagination Parameters: %v", err).WithInternalError(err)
+	}
+
+	users, err := models.FindUsersInAudienceKeyset(db, aud, p, sortParams, filter)
+	if err != nil {
+		return apierrors.NewInternalServerError("Database error finding users").WithInternalError(err)
+	}
+
+	hasMore := uint64(len(users)) > p.Limit
+	var nextCursor *Cursor
+	if hasMore {
+		users = users[:p.Limit]
+		last := users[len(users)-1]
+		nextCursor = &Cursor{CreatedAt: last.CreatedAt, ID: last.ID}
+	}
+
+	addKeysetPaginationHeaders(w, r, nextCursor)
+
+	pagination := &CursorPaginationResponse{HasMore: hasMore}
+	if nextCursor != nil {
+		pagination.NextCursor = nextCursor.String()
+	}
+
+	return sendJSON(w, http.StatusOK, AdminListUsersResponse{
+		Users:      users,
+		Aud:        aud,
+		Pagination: pagination,
 	})
 }
 

--- a/internal/api/admin_test.go
+++ b/internal/api/admin_test.go
@@ -173,6 +173,145 @@ func (ts *AdminTestSuite) TestAdminUsers_SortDesc() {
 	assert.Equal(ts.T(), "test1@example.com", data.Users[1].GetEmail())
 }
 
+type adminUsersCursorResponse struct {
+	Users      []*models.User            `json:"users"`
+	Aud        string                    `json:"aud"`
+	Pagination *CursorPaginationResponse `json:"pagination"`
+}
+
+// TestAdminUsers_CursorPaginationDisabled ensures that with the flag off the
+// endpoint serves the unchanged offset response (X-Total-Count set, no
+// pagination block) even when a client passes cursor-style params.
+func (ts *AdminTestSuite) TestAdminUsers_CursorPaginationDisabled() {
+	ts.Config.Experimental.CursorPaginationEnabled = false
+
+	u, err := models.NewUser("", "test1@example.com", "test", ts.Config.JWT.Aud, nil)
+	require.NoError(ts.T(), err)
+	require.NoError(ts.T(), ts.API.db.Create(u))
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/admin/users?limit=1", nil)
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", ts.token))
+
+	ts.API.handler.ServeHTTP(w, req)
+	require.Equal(ts.T(), http.StatusOK, w.Code)
+
+	assert.Equal(ts.T(), "1", w.Header().Get("X-Total-Count"))
+	assert.NotContains(ts.T(), w.Header().Get("Link"), `rel="next"`)
+
+	var data adminUsersCursorResponse
+	require.NoError(ts.T(), json.NewDecoder(w.Body).Decode(&data))
+	assert.Nil(ts.T(), data.Pagination, "offset mode must not emit a pagination block")
+}
+
+// TestAdminUsers_CursorPaginationEnabled walks every page with cursor mode on
+// and asserts full coverage with no duplicates or skips.
+func (ts *AdminTestSuite) TestAdminUsers_CursorPaginationEnabled() {
+	ts.Config.Experimental.CursorPaginationEnabled = true
+	defer func() { ts.Config.Experimental.CursorPaginationEnabled = false }()
+
+	const total = 5
+	want := map[string]bool{}
+	for i := 0; i < total; i++ {
+		email := fmt.Sprintf("cursor%d@example.com", i)
+		u, err := models.NewUser("", email, "test", ts.Config.JWT.Aud, nil)
+		require.NoError(ts.T(), err)
+		require.NoError(ts.T(), ts.API.db.Create(u))
+		want[email] = true
+	}
+
+	seen := map[string]bool{}
+	cursor := ""
+	sawNextLink := false
+	for page := 0; page < 20; page++ {
+		target := "/admin/users?limit=2"
+		if cursor != "" {
+			target += "&cursor=" + cursor
+		}
+
+		w := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, target, nil)
+		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", ts.token))
+
+		ts.API.handler.ServeHTTP(w, req)
+		require.Equal(ts.T(), http.StatusOK, w.Code)
+
+		// offset-only headers must be absent in cursor mode
+		assert.Empty(ts.T(), w.Header().Get("X-Total-Count"))
+
+		var data adminUsersCursorResponse
+		require.NoError(ts.T(), json.NewDecoder(w.Body).Decode(&data))
+		require.NotNil(ts.T(), data.Pagination)
+
+		for _, u := range data.Users {
+			require.False(ts.T(), seen[u.GetEmail()], "user returned twice: %s", u.GetEmail())
+			seen[u.GetEmail()] = true
+		}
+
+		if data.Pagination.HasMore {
+			require.NotEmpty(ts.T(), data.Pagination.NextCursor)
+			require.Contains(ts.T(), w.Header().Get("Link"), `rel="next"`)
+			sawNextLink = true
+			cursor = data.Pagination.NextCursor
+			continue
+		}
+
+		require.Empty(ts.T(), data.Pagination.NextCursor)
+		assert.NotContains(ts.T(), w.Header().Get("Link"), `rel="next"`)
+		break
+	}
+
+	require.Equal(ts.T(), want, seen, "cursor walk must cover every user exactly once")
+	require.True(ts.T(), sawNextLink, "expected at least one intermediate page with a next cursor")
+}
+
+// TestAdminUsers_CursorPaginationBackwardCompat ensures that even with the flag
+// on, a client that still pages by number stays in offset mode.
+func (ts *AdminTestSuite) TestAdminUsers_CursorPaginationBackwardCompat() {
+	ts.Config.Experimental.CursorPaginationEnabled = true
+	defer func() { ts.Config.Experimental.CursorPaginationEnabled = false }()
+
+	for i := 0; i < 2; i++ {
+		u, err := models.NewUser("", fmt.Sprintf("compat%d@example.com", i), "test", ts.Config.JWT.Aud, nil)
+		require.NoError(ts.T(), err)
+		require.NoError(ts.T(), ts.API.db.Create(u))
+	}
+
+	// either offset-style param must keep the request in offset mode, even
+	// with the flag on
+	for _, target := range []string{
+		"/admin/users?page=1&per_page=1",
+		"/admin/users?per_page=1",
+	} {
+		w := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, target, nil)
+		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", ts.token))
+
+		ts.API.handler.ServeHTTP(w, req)
+		require.Equal(ts.T(), http.StatusOK, w.Code)
+
+		assert.Equal(ts.T(), "2", w.Header().Get("X-Total-Count"), "offset mode expected for %s", target)
+
+		var data adminUsersCursorResponse
+		require.NoError(ts.T(), json.NewDecoder(w.Body).Decode(&data))
+		assert.Nil(ts.T(), data.Pagination)
+		require.Len(ts.T(), data.Users, 1, "per_page must be honored for %s", target)
+	}
+}
+
+// TestAdminUsers_CursorPaginationBadCursor ensures a malformed cursor is a 400.
+func (ts *AdminTestSuite) TestAdminUsers_CursorPaginationBadCursor() {
+	ts.Config.Experimental.CursorPaginationEnabled = true
+	defer func() { ts.Config.Experimental.CursorPaginationEnabled = false }()
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/admin/users?cursor=not-a-valid-cursor*", nil)
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", ts.token))
+
+	ts.API.handler.ServeHTTP(w, req)
+	require.Equal(ts.T(), http.StatusBadRequest, w.Code)
+}
+
 // TestAdminUsers tests API /admin/users route
 func (ts *AdminTestSuite) TestAdminUsers_FilterEmail() {
 	u, err := models.NewUser("", "test1@example.com", "test", ts.Config.JWT.Aud, nil)

--- a/internal/api/pagination.go
+++ b/internal/api/pagination.go
@@ -1,15 +1,27 @@
 package api
 
 import (
+	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/url"
 	"strconv"
+	"time"
 
+	"github.com/gofrs/uuid"
 	"github.com/supabase/auth/internal/models"
 )
 
 const defaultPerPage = 50
+
+// defaultKeysetPerPage is the page size used in cursor mode when the client
+// does not pass a `limit`. maxKeysetPerPage caps the page size a client may
+// request.
+const (
+	defaultKeysetPerPage = 50
+	maxKeysetPerPage     = 1000
+)
 
 func calculateTotalPages(perPage, total uint64) uint64 {
 	pages := total / perPage
@@ -61,4 +73,104 @@ func paginate(r *http.Request) (*models.Pagination, error) {
 		Page:    page,
 		PerPage: perPage,
 	}, nil
+}
+
+// Cursor is the wire form of a keyset position. It is serialized as an opaque
+// base64url(json) token; clients must treat it as opaque and pass it back
+// verbatim.
+type Cursor struct {
+	CreatedAt time.Time `json:"created_at"`
+	ID        uuid.UUID `json:"id"`
+}
+
+// String encodes the cursor as an opaque base64url(json) token.
+func (c *Cursor) String() string {
+	// json.Marshal of this fixed struct cannot fail.
+	b, _ := json.Marshal(c)
+	return base64.RawURLEncoding.EncodeToString(b)
+}
+
+// decodeCursor parses an opaque cursor token back into a keyset position. A
+// malformed token or one with an empty id is rejected so the caller can map it
+// to a 400.
+func decodeCursor(raw string) (*models.KeysetCursor, error) {
+	b, err := base64.RawURLEncoding.DecodeString(raw)
+	if err != nil {
+		return nil, fmt.Errorf("invalid cursor encoding: %w", err)
+	}
+
+	var c models.KeysetCursor
+	if err := json.Unmarshal(b, &c); err != nil {
+		return nil, fmt.Errorf("invalid cursor: %w", err)
+	}
+
+	if c.ID == uuid.Nil {
+		return nil, fmt.Errorf("invalid cursor: missing id")
+	}
+
+	// A malformed timestamp is caught by Unmarshal, but a missing/zero
+	// created_at unmarshals to the zero time and would otherwise be treated as
+	// a valid (empty-matching) cursor. We never emit such a cursor, so reject.
+	if c.CreatedAt.IsZero() {
+		return nil, fmt.Errorf("invalid cursor: missing created_at")
+	}
+
+	return &c, nil
+}
+
+// parseKeysetParams reads the keyset pagination inputs (`limit`, `cursor`) from
+// the request. limit defaults to defaultPerPage, is capped at maxKeysetPerPage,
+// and must be greater than 0. An absent cursor means the first page.
+func parseKeysetParams(r *http.Request) (*models.KeysetPagination, error) {
+	params := r.URL.Query()
+
+	p := &models.KeysetPagination{Limit: defaultKeysetPerPage}
+
+	if queryLimit := params.Get("limit"); queryLimit != "" {
+		limit, err := strconv.ParseUint(queryLimit, 10, 64)
+		if err != nil {
+			return nil, err
+		}
+		if limit == 0 {
+			return nil, fmt.Errorf("limit must be greater than 0")
+		}
+		p.Limit = limit
+	}
+
+	if p.Limit > maxKeysetPerPage {
+		p.Limit = maxKeysetPerPage
+	}
+
+	if queryCursor := params.Get("cursor"); queryCursor != "" {
+		after, err := decodeCursor(queryCursor)
+		if err != nil {
+			return nil, err
+		}
+		p.After = after
+	}
+
+	return p, nil
+}
+
+// addKeysetPaginationHeaders sets the Link: rel="next" header pointing at the
+// next cursor page. It is a no-op when next is nil (no further pages). The
+// `page` param is dropped so the follow-up request stays in cursor mode.
+func addKeysetPaginationHeaders(w http.ResponseWriter, r *http.Request, next *Cursor) {
+	if next == nil {
+		return
+	}
+
+	u, _ := url.ParseRequestURI(r.URL.String())
+	query := u.Query()
+	query.Del("page")
+	query.Set("cursor", next.String())
+	u.RawQuery = query.Encode()
+
+	w.Header().Add("Link", "<"+u.String()+">; rel=\"next\"")
+}
+
+// CursorPaginationResponse is the pagination block returned in cursor mode.
+type CursorPaginationResponse struct {
+	NextCursor string `json:"next_cursor,omitempty"`
+	HasMore    bool   `json:"has_more"`
 }

--- a/internal/api/pagination_test.go
+++ b/internal/api/pagination_test.go
@@ -1,0 +1,131 @@
+package api
+
+import (
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gofrs/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCursorRoundTrip(t *testing.T) {
+	id := uuid.Must(uuid.NewV4())
+	// include sub-second precision to ensure the nanosecond component survives
+	created := time.Date(2024, 3, 4, 5, 6, 7, 123456789, time.UTC)
+
+	c := &Cursor{CreatedAt: created, ID: id}
+	decoded, err := decodeCursor(c.String())
+	require.NoError(t, err)
+	require.True(t, created.Equal(decoded.CreatedAt), "created_at must round-trip: got %v want %v", decoded.CreatedAt, created)
+	require.Equal(t, id, decoded.ID)
+}
+
+func TestDecodeCursorErrors(t *testing.T) {
+	// invalid base64
+	{
+		_, err := decodeCursor("not*base64*")
+		require.Error(t, err)
+	}
+
+	// valid base64 but not json
+	{
+		_, err := decodeCursor("bm90LWpzb24") // base64url("not-json")
+		require.Error(t, err)
+	}
+
+	// json with nil uuid must be rejected
+	{
+		c := &Cursor{CreatedAt: time.Now(), ID: uuid.Nil}
+		_, err := decodeCursor(c.String())
+		require.Error(t, err)
+	}
+
+	// json with a missing/zero created_at must be rejected
+	{
+		c := &Cursor{ID: uuid.Must(uuid.NewV4())} // CreatedAt left as zero value
+		_, err := decodeCursor(c.String())
+		require.Error(t, err)
+	}
+}
+
+func TestParseKeysetParams(t *testing.T) {
+	// default limit when absent
+	{
+		r := httptest.NewRequest("GET", "/admin/users", nil)
+		p, err := parseKeysetParams(r)
+		require.NoError(t, err)
+		require.Equal(t, uint64(defaultKeysetPerPage), p.Limit)
+		require.Nil(t, p.After)
+	}
+
+	// explicit limit honored
+	{
+		r := httptest.NewRequest("GET", "/admin/users?limit=25", nil)
+		p, err := parseKeysetParams(r)
+		require.NoError(t, err)
+		require.Equal(t, uint64(25), p.Limit)
+	}
+
+	// limit capped at max
+	{
+		r := httptest.NewRequest("GET", "/admin/users?limit=5000", nil)
+		p, err := parseKeysetParams(r)
+		require.NoError(t, err)
+		require.Equal(t, uint64(maxKeysetPerPage), p.Limit)
+	}
+
+	// limit=0 is invalid
+	{
+		r := httptest.NewRequest("GET", "/admin/users?limit=0", nil)
+		_, err := parseKeysetParams(r)
+		require.Error(t, err)
+	}
+
+	// non-numeric limit is invalid
+	{
+		r := httptest.NewRequest("GET", "/admin/users?limit=abc", nil)
+		_, err := parseKeysetParams(r)
+		require.Error(t, err)
+	}
+
+	// cursor decoded into After
+	{
+		id := uuid.Must(uuid.NewV4())
+		c := &Cursor{CreatedAt: time.Now(), ID: id}
+		r := httptest.NewRequest("GET", "/admin/users?cursor="+c.String(), nil)
+		p, err := parseKeysetParams(r)
+		require.NoError(t, err)
+		require.NotNil(t, p.After)
+		require.Equal(t, id, p.After.ID)
+	}
+
+	// bad cursor errors
+	{
+		r := httptest.NewRequest("GET", "/admin/users?cursor=not*base64*", nil)
+		_, err := parseKeysetParams(r)
+		require.Error(t, err)
+	}
+}
+
+func TestAddKeysetPaginationHeaders(t *testing.T) {
+	// nil cursor: no Link header
+	{
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest("GET", "/admin/users?page=2&limit=10", nil)
+		addKeysetPaginationHeaders(w, r, nil)
+		require.Empty(t, w.Header().Get("Link"))
+	}
+
+	// non-nil cursor: Link rel=next set, page dropped, cursor present
+	{
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest("GET", "/admin/users?page=2&limit=10", nil)
+		next := &Cursor{CreatedAt: time.Now(), ID: uuid.Must(uuid.NewV4())}
+		addKeysetPaginationHeaders(w, r, next)
+		link := w.Header().Get("Link")
+		require.Contains(t, link, `rel="next"`)
+		require.Contains(t, link, "cursor=")
+		require.NotContains(t, link, "page=")
+	}
+}

--- a/internal/conf/configuration.go
+++ b/internal/conf/configuration.go
@@ -353,6 +353,12 @@ type ExperimentalConfiguration struct {
 	// it belongs to. See the ProviderLinkingDomains type for the env format.
 	// Env: GOTRUE_EXPERIMENTAL_PROVIDER_LINKING_DOMAINS="custom:github=social,custom:google=social"
 	ProviderLinkingDomains ProviderLinkingDomains `split_words:"true"`
+
+	// CursorPaginationEnabled turns on cursor-based (keyset) pagination for the
+	// admin user list endpoint. When enabled and no `page` query param is
+	// provided, GET /admin/users serves fast, count-free cursor pages.
+	// Env: GOTRUE_EXPERIMENTAL_CURSOR_PAGINATION_ENABLED=true
+	CursorPaginationEnabled bool `split_words:"true" default:"false"`
 }
 
 // ReloadingConfiguration holds the configuration values for runtime

--- a/internal/conf/confload/confload_test.go
+++ b/internal/conf/confload/confload_test.go
@@ -235,6 +235,37 @@ func TestExperimentalProviderLinkingDomains(t *testing.T) {
 	}, cfg.Experimental.ProviderLinkingDomains)
 }
 
+func TestExperimentalCursorPaginationEnabled(t *testing.T) {
+	baseEnv := func() {
+		os.Clearenv()
+		os.Setenv("GOTRUE_SITE_URL", "http://localhost:8080")
+		os.Setenv("GOTRUE_DB_DRIVER", "postgres")
+		os.Setenv("GOTRUE_DB_DATABASE_URL", "fake")
+		os.Setenv("GOTRUE_OPERATOR_TOKEN", "token")
+		os.Setenv("GOTRUE_JWT_SECRET", "secret")
+		os.Setenv("API_EXTERNAL_URL", "http://localhost:9999")
+	}
+
+	// defaults to false when unset
+	{
+		baseEnv()
+		cfg, err := LoadGlobalFromEnv()
+		require.NoError(t, err)
+		require.NotNil(t, cfg)
+		assert.Equal(t, false, cfg.Experimental.CursorPaginationEnabled)
+	}
+
+	// maps GOTRUE_EXPERIMENTAL_CURSOR_PAGINATION_ENABLED=true into the field
+	{
+		baseEnv()
+		os.Setenv("GOTRUE_EXPERIMENTAL_CURSOR_PAGINATION_ENABLED", "true")
+		cfg, err := LoadGlobalFromEnv()
+		require.NoError(t, err)
+		require.NotNil(t, cfg)
+		assert.Equal(t, true, cfg.Experimental.CursorPaginationEnabled)
+	}
+}
+
 func TestLoading(t *testing.T) {
 	os.Clearenv()
 

--- a/internal/models/connection.go
+++ b/internal/models/connection.go
@@ -1,7 +1,10 @@
 package models
 
 import (
+	"time"
+
 	"github.com/gobuffalo/pop/v6"
+	"github.com/gofrs/uuid"
 	"github.com/supabase/auth/internal/storage"
 )
 
@@ -13,6 +16,22 @@ type Pagination struct {
 
 func (p *Pagination) Offset() uint64 {
 	return (p.Page - 1) * p.PerPage
+}
+
+// KeysetCursor is the position of a row within a keyset-paginated result set.
+// It captures the ordering columns of the last row returned so the next page
+// can resume from just after it. The (CreatedAt, ID) tuple is used because
+// created_at is not unique, so ID acts as a stable tiebreaker.
+type KeysetCursor struct {
+	CreatedAt time.Time `json:"created_at"`
+	ID        uuid.UUID `json:"id"`
+}
+
+// KeysetPagination describes a single keyset (cursor-based) page request.
+// After == nil requests the first page.
+type KeysetPagination struct {
+	Limit uint64
+	After *KeysetCursor
 }
 
 type SortDirection string

--- a/internal/models/user.go
+++ b/internal/models/user.go
@@ -810,10 +810,15 @@ func FindUsersInAudienceKeyset(tx *storage.Connection, aud string, p *KeysetPagi
 	}
 
 	if p != nil && p.After != nil {
+		// Row-value comparison, NOT the equivalent
+		// (created_at <dir> ? OR (created_at = ? AND id <dir> ?)) form. Postgres
+		// can push a row comparison's leading column into the btree as a range
+		// bound (Index Cond: created_at <= ?) and seek straight to the cursor.
+		// The OR form forces a full index scan + filter
 		if dir == Ascending {
-			q = q.Where("(created_at > ? OR (created_at = ? AND id > ?))", p.After.CreatedAt, p.After.CreatedAt, p.After.ID)
+			q = q.Where("(created_at, id) > (?, ?)", p.After.CreatedAt, p.After.ID)
 		} else {
-			q = q.Where("(created_at < ? OR (created_at = ? AND id < ?))", p.After.CreatedAt, p.After.CreatedAt, p.After.ID)
+			q = q.Where("(created_at, id) < (?, ?)", p.After.CreatedAt, p.After.ID)
 		}
 	}
 

--- a/internal/models/user.go
+++ b/internal/models/user.go
@@ -6,6 +6,7 @@ import (
 	"database/sql"
 	"encoding/base64"
 	"fmt"
+	"math"
 	"strings"
 	"time"
 
@@ -773,6 +774,66 @@ func FindUsersInAudience(tx *storage.Connection, aud string, pageParams *Paginat
 	}
 
 	return users, err
+}
+
+// FindUsersInAudienceKeyset finds users with the matching audience using
+// keyset (cursor-based) pagination. Unlike FindUsersInAudience it issues no
+// COUNT(*) and no OFFSET: it resumes from the cursor in p.After (if any) and
+// fetches p.Limit+1 rows so the caller can detect whether another page exists.
+//
+// Ordering is (created_at, id) in the direction of the first sort field
+// (default DESC). The id tiebreaker is required because created_at is not
+// unique; without it a page boundary inside a same-timestamp group would skip
+// or duplicate rows.
+func FindUsersInAudienceKeyset(tx *storage.Connection, aud string, p *KeysetPagination, sortParams *SortParams, filter string) ([]*User, error) {
+	users := []*User{}
+	q := tx.Q().Where("instance_id = ? and aud = ?", uuid.Nil, aud)
+
+	if filter != "" {
+		lf := "%" + filter + "%"
+		// we must specify the collation in order to get case insensitive search for the JSON column
+		q = q.Where("(email LIKE ? OR raw_user_meta_data->>'full_name' ILIKE ?)", lf, lf)
+	}
+
+	dir := Descending
+	if sortParams != nil && len(sortParams.Fields) > 0 {
+		// Keyset pagination is only valid over created_at, which is exactly
+		// what the cursor encodes; ordering by any other column would compare
+		// rows against the cursor's timestamp value, which is meaningless.
+		// Restricting the sort field is the caller's responsibility (e.g. the
+		// admin handler's sort allowlist) — this guard makes misuse fail loudly
+		// instead of silently mis-sorting.
+		if sortParams.Fields[0].Name != CreatedAt {
+			return nil, errors.Errorf("keyset pagination only supports ordering by %q", CreatedAt)
+		}
+		dir = sortParams.Fields[0].Dir
+	}
+
+	if p != nil && p.After != nil {
+		if dir == Ascending {
+			q = q.Where("(created_at > ? OR (created_at = ? AND id > ?))", p.After.CreatedAt, p.After.CreatedAt, p.After.ID)
+		} else {
+			q = q.Where("(created_at < ? OR (created_at = ? AND id < ?))", p.After.CreatedAt, p.After.CreatedAt, p.After.ID)
+		}
+	}
+
+	q = q.Order("created_at " + string(dir)).Order("id " + string(dir))
+
+	if p != nil {
+		limit := p.Limit
+		// callers cap the page size well below this; the guard keeps the +1
+		// below from overflowing if one ever doesn't
+		if limit > math.MaxInt-1 {
+			limit = math.MaxInt - 1
+		}
+		q = q.Limit(int(limit + 1)) // #nosec G115 -- bounded above
+	}
+
+	if err := q.All(&users); err != nil {
+		return nil, err
+	}
+
+	return users, nil
 }
 
 // IsDuplicatedEmail returns whether a user exists with a matching email and

--- a/internal/models/user_test.go
+++ b/internal/models/user_test.go
@@ -2,7 +2,9 @@ package models
 
 import (
 	"context"
+	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -130,6 +132,131 @@ func (ts *UserTestSuite) TestFindUsersInAudience() {
 	n, err = FindUsersInAudience(ts.db, u.Aud, nil, sp, "")
 	require.NoError(ts.T(), err)
 	require.Len(ts.T(), n, 1)
+}
+
+// createUserAt inserts a user in the "test" audience with an exact created_at.
+// pop sets created_at on insert, so we force it afterwards and reload to get
+// the microsecond-truncated value Postgres actually stores.
+func (ts *UserTestSuite) createUserAt(email string, createdAt time.Time) *User {
+	user, err := NewUser("", email, "secret", "test", nil)
+	require.NoError(ts.T(), err)
+	require.NoError(ts.T(), ts.db.Create(user))
+	require.NoError(ts.T(), ts.db.RawQuery("UPDATE users SET created_at = ? WHERE id = ?", createdAt, user.ID).Exec())
+	reloaded, err := FindUserByID(ts.db, user.ID)
+	require.NoError(ts.T(), err)
+	return reloaded
+}
+
+func (ts *UserTestSuite) TestFindUsersInAudienceKeyset() {
+	base := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
+
+	ts.Run("first page fetches Limit+1 when more rows exist", func() {
+		TruncateAll(ts.db)
+		for i := 0; i < 5; i++ {
+			ts.createUserAt(fmt.Sprintf("u%d@example.com", i), base.Add(time.Duration(i)*time.Minute))
+		}
+
+		p := &KeysetPagination{Limit: 2}
+		users, err := FindUsersInAudienceKeyset(ts.db, "test", p, nil, "")
+		require.NoError(ts.T(), err)
+		// Limit+1 fetched so the caller can detect there is a next page.
+		require.Len(ts.T(), users, 3)
+		// default direction is DESC on created_at: newest first, non-increasing.
+		for i := 1; i < len(users); i++ {
+			require.False(ts.T(), users[i-1].CreatedAt.Before(users[i].CreatedAt),
+				"rows must be ordered created_at DESC")
+		}
+	})
+
+	ts.Run("tiebreaker walks same-created_at rows exactly once", func() {
+		TruncateAll(ts.db)
+		same := base
+		want := map[string]bool{}
+		for i := 0; i < 3; i++ {
+			u := ts.createUserAt(fmt.Sprintf("tie%d@example.com", i), same)
+			want[u.ID.String()] = true
+		}
+
+		seen := map[string]bool{}
+		var after *KeysetCursor
+		for page := 0; page < 10; page++ {
+			p := &KeysetPagination{Limit: 1, After: after}
+			users, err := FindUsersInAudienceKeyset(ts.db, "test", p, nil, "")
+			require.NoError(ts.T(), err)
+			if len(users) == 0 {
+				break
+			}
+
+			hasMore := uint64(len(users)) > p.Limit
+			rows := users
+			if hasMore {
+				rows = users[:p.Limit]
+			}
+			for _, u := range rows {
+				require.False(ts.T(), seen[u.ID.String()], "row returned twice: %s", u.ID)
+				seen[u.ID.String()] = true
+			}
+			if !hasMore {
+				break
+			}
+			last := rows[len(rows)-1]
+			after = &KeysetCursor{CreatedAt: last.CreatedAt, ID: last.ID}
+		}
+		require.Equal(ts.T(), want, seen, "every same-created_at row returned exactly once")
+	})
+
+	ts.Run("last page returns <= Limit", func() {
+		TruncateAll(ts.db)
+		for i := 0; i < 2; i++ {
+			ts.createUserAt(fmt.Sprintf("last%d@example.com", i), base.Add(time.Duration(i)*time.Minute))
+		}
+
+		p := &KeysetPagination{Limit: 50}
+		users, err := FindUsersInAudienceKeyset(ts.db, "test", p, nil, "")
+		require.NoError(ts.T(), err)
+		require.Len(ts.T(), users, 2)
+	})
+
+	ts.Run("filter still applies alongside keyset", func() {
+		TruncateAll(ts.db)
+		ts.createUserAt("needle@example.com", base)
+		ts.createUserAt("haystack@example.com", base.Add(time.Minute))
+
+		p := &KeysetPagination{Limit: 50}
+		users, err := FindUsersInAudienceKeyset(ts.db, "test", p, nil, "needle")
+		require.NoError(ts.T(), err)
+		require.Len(ts.T(), users, 1)
+		require.Equal(ts.T(), "needle@example.com", users[0].GetEmail())
+	})
+
+	ts.Run("non-created_at sort field is rejected", func() {
+		TruncateAll(ts.db)
+		ts.createUserAt("x@example.com", base)
+
+		sp := &SortParams{Fields: []SortField{{Name: "email", Dir: Ascending}}}
+		_, err := FindUsersInAudienceKeyset(ts.db, "test", &KeysetPagination{Limit: 10}, sp, "")
+		require.Error(ts.T(), err)
+	})
+
+	ts.Run("ascending direction resumes with > comparison", func() {
+		TruncateAll(ts.db)
+		for i := 0; i < 3; i++ {
+			ts.createUserAt(fmt.Sprintf("asc%d@example.com", i), base.Add(time.Duration(i)*time.Minute))
+		}
+
+		sp := &SortParams{Fields: []SortField{{Name: CreatedAt, Dir: Ascending}}}
+		p := &KeysetPagination{Limit: 1}
+		first, err := FindUsersInAudienceKeyset(ts.db, "test", p, sp, "")
+		require.NoError(ts.T(), err)
+		require.Len(ts.T(), first, 2) // Limit+1
+		require.Equal(ts.T(), "asc0@example.com", first[0].GetEmail())
+
+		after := &KeysetCursor{CreatedAt: first[0].CreatedAt, ID: first[0].ID}
+		next, err := FindUsersInAudienceKeyset(ts.db, "test", &KeysetPagination{Limit: 1, After: after}, sp, "")
+		require.NoError(ts.T(), err)
+		require.Len(ts.T(), next, 2)
+		require.Equal(ts.T(), "asc1@example.com", next[0].GetEmail())
+	})
 }
 
 func (ts *UserTestSuite) TestFindUserByID() {


### PR DESCRIPTION
## What

  Adds cursor-based (keyset) pagination to `GET /admin/users`, behind a new
  experimental feature flag. Offset pagination's `COUNT(*)` + `OFFSET` deep-scan
  is the primary cause of request timeouts on large user tables; keyset paging
  removes both, making page fetches constant-time regardless of how deep you page.

  ## Feature flag

  `GOTRUE_EXPERIMENTAL_CURSOR_PAGINATION_ENABLED` (default `false`) →
  `Experimental.CursorPaginationEnabled`.

  **Nothing changes unless you opt in.** With the flag off, the endpoint behaves
  exactly as today. Mode selection:

  ## API (cursor mode)

  Request: `GET /admin/users?limit=50&cursor=<opaque>`
  - `limit`: default 50, capped at 1000, `0`/invalid → 400
  - `cursor`: opaque base64url token; absent = first page; malformed → 400

  Response adds a `pagination` block and a `Link: rel="next"` header:
  ```json
  { "users": [ ... ], "aud": "authenticated",
    "pagination": { "next_cursor": "eyJ...", "has_more": true } }
```
`next_cursor`/`Link` are omitted on the last page. No X-Total-Count in cursor
mode: `has_more` signals whether more pages exist. Forward-only for now.

##   Notes

  - Orders by (created_at, id); the id tiebreaker is required because creaxed_at isn't unique (batch/seeded/migrated users share timestamps).
  - No migration: reuses the existing idx_users_created_at_desc
  - Cursors are opaque but unsigned; aud/instance_id filters still apply, so tampering only yields a different valid start point or a 400, never unauthorized data.
  - Scoped to `adminUsers` now ; the cursor helper is built to be reused for OAuth clients and audit logs in a follow-up.