### PR TITLE
fix: consolidate error logs into single log entry

### DIFF
--- a/internal/api/errors.go
+++ b/internal/api/errors.go
@@ -79,7 +79,6 @@ type HTTPErrorResponse20240101 struct {
 
 func HandleResponseError(err error, w http.ResponseWriter, r *http.Request) {
 	log := observability.GetLogEntry(r).Entry
-	errorID := utilities.GetRequestID(r.Context())
 
 	apiVersion, averr := DetermineClosestAPIVersion(r.Header.Get(APIVersionHeaderName))
 	if averr != nil {
@@ -91,6 +90,8 @@ func HandleResponseError(err error, w http.ResponseWriter, r *http.Request) {
 
 	switch e := err.(type) {
 	case *WeakPasswordError:
+		observability.LogEntrySetField(r, "error", e.Error())
+
 		if apiVersion.Compare(APIVersion20240101) >= 0 {
 			var output struct {
 				HTTPErrorResponse20240101
@@ -128,16 +129,10 @@ func HandleResponseError(err error, w http.ResponseWriter, r *http.Request) {
 		}
 
 	case *HTTPError:
-		switch {
-		case e.HTTPStatus >= http.StatusInternalServerError:
-			e.ErrorID = errorID
-			// this will get us the stack trace too
-			log.WithError(e.Cause()).Error(e.Error())
-		case e.HTTPStatus >= http.StatusBadRequest:
-			log.WithError(e.Cause()).Warn(e.Error())
-		default:
-			log.WithError(e.Cause()).Info(e.Error())
+		if e.HTTPStatus >= http.StatusInternalServerError {
+			e.ErrorID = utilities.GetRequestID(r.Context())
 		}
+		observability.LogEntrySetField(r, "error", e.Cause().Error())
 
 		if e.ErrorCode != "" {
 			w.Header().Set("x-sb-error-code", e.ErrorCode)
@@ -183,7 +178,7 @@ func HandleResponseError(err error, w http.ResponseWriter, r *http.Request) {
 		}
 
 	case *OAuthError:
-		log.WithError(e.Cause()).Info(e.Error())
+		observability.LogEntrySetField(r, "error", e.Cause().Error())
 		if jsonErr := sendJSON(w, http.StatusBadRequest, e); jsonErr != nil && jsonErr != context.DeadlineExceeded {
 			log.WithError(jsonErr).Warn("Failed to send JSON on ResponseWriter")
 		}
@@ -192,7 +187,7 @@ func HandleResponseError(err error, w http.ResponseWriter, r *http.Request) {
 		HandleResponseError(e.Cause(), w, r)
 
 	default:
-		log.WithError(e).Errorf("Unhandled server error: %s", e.Error())
+		observability.LogEntrySetField(r, "error", fmt.Sprintf("Unhandled server error: %s", e.Error()))
 
 		if apiVersion.Compare(APIVersion20240101) >= 0 {
 			resp := HTTPErrorResponse20240101{

--- a/internal/api/errors_test.go
+++ b/internal/api/errors_test.go
@@ -3,6 +3,7 @@ package api
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -103,4 +104,77 @@ func TestRecoverer(t *testing.T) {
 	require.Equal(t, "request panicked", logs["msg"])
 	require.Equal(t, "test panic", logs["panic"])
 	require.NotEmpty(t, logs["stack"])
+}
+
+func TestHandleResponseErrorConsolidatesLogs(t *testing.T) {
+	config, err := confload.LoadGlobal(apiTestConfig)
+	require.NoError(t, err)
+	require.NoError(t, observability.ConfigureLogging(&config.Logging))
+
+	cases := []struct {
+		name          string
+		err           error
+		expectedError string
+		expectedCode  string
+	}{
+		{
+			name:          "http error with internal error",
+			err:           apierrors.NewInternalServerError("boom").WithInternalError(errors.New("connection reset")),
+			expectedError: "connection reset",
+			expectedCode:  string(apierrors.ErrorCodeUnexpectedFailure),
+		},
+		{
+			name:          "http error without internal error",
+			err:           apierrors.NewBadRequestError(apierrors.ErrorCodeBadJSON, "Unable to parse JSON"),
+			expectedError: "400: Unable to parse JSON",
+			expectedCode:  string(apierrors.ErrorCodeBadJSON),
+		},
+		{
+			name:          "oauth error",
+			err:           apierrors.NewOAuthError("invalid_request", "missing code").WithInternalError(errors.New("code param missing")),
+			expectedError: "code param missing",
+		},
+		{
+			name:          "weak password error",
+			err:           &WeakPasswordError{Message: "Password is too weak"},
+			expectedError: "Password is too weak",
+			expectedCode:  string(apierrors.ErrorCodeWeakPassword),
+		},
+		{
+			name:          "unhandled error",
+			err:           errors.New("unexpected failure"),
+			expectedError: "Unhandled server error: unexpected failure",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			var logBuffer bytes.Buffer
+			logrus.SetOutput(&logBuffer)
+
+			logHandler := observability.NewStructuredLogger(logrus.StandardLogger(), config)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				HandleResponseError(c.err, w, r)
+			}))
+
+			req, err := http.NewRequest(http.MethodPost, "http://example.com", nil)
+			require.NoError(t, err)
+
+			rec := httptest.NewRecorder()
+			logHandler.ServeHTTP(rec, req)
+
+			decoder := json.NewDecoder(&logBuffer)
+
+			var logs map[string]interface{}
+			require.NoError(t, decoder.Decode(&logs))
+
+			require.Equal(t, "request completed", logs["msg"])
+			require.NotNil(t, logs["status"])
+			require.Equal(t, c.expectedError, logs["error"])
+			if c.expectedCode != "" {
+				require.Equal(t, c.expectedCode, logs["error_code"])
+			}
+
+			require.False(t, decoder.More(), "expected exactly one log entry for the request, found a second")
+		})
+	}
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Reduce multiple log lines per request to a single line.

```bash
モ curl http://localhost:9999/admin/sso/providers | jq '.'
{
  "code": 401,
  "error_code": "no_authorization",
  "msg": "This endpoint requires a valid Bearer token"
}
```

## What is the current behavior?

```json
{"component":"api","error":"401: This endpoint requires a valid Bearer token","level":"warning","method":"GET","msg":"401: This endpoint requires a valid Bearer token","path":"/admin/sso/providers","referer":"http://localhost:3000","remote_addr":"127.0.0.1","request_id":"6f771103-e037-464d-951e-25a46ff2fce7","time":"2026-07-21T23:24:27Z"}
{"component":"api","duration":91167,"error_code":"no_authorization","level":"warning","method":"GET","msg":"request completed","path":"/admin/sso/providers","referer":"http://localhost:3000","remote_addr":"127.0.0.1","request_id":"6f771103-e037-464d-951e-25a46ff2fce7","status":401,"time":"2026-07-21T23:24:27Z"}
```

Errored requests used to emit two log lines:

1. an immediate one with the error message but no status/error_code
1. a second "request completed" line with status/error_code but no error message.

https://linear.app/supabase/issue/AUTH-1289/consolidate-auth-error-logs-into-a-single-log-entry

## What is the new behavior?

Moves the error message onto the request-scoped log entry via `observability.LogEntrySetField` so it rides along on the single deferred completion log instead.

```json
{"component":"api","duration":184917,"error":"401: This endpoint requires a valid Bearer token","error_code":"no_authorization","level":"warning","method":"GET","msg":"request completed","path":"/admin/sso/providers","referer":"http://localhost:3000","remote_addr":"127.0.0.1","request_id":"f1cc79f2-da29-4213-880b-06c193734cf8","status":401,"time":"2026-07-21T23:25:36Z"}
```

## Additional context