### PR TITLE
fix: upgrade to x/text@v0.39.0 GO-2026-5970

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -78,7 +78,7 @@ require (
 	github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f // indirect
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
-	golang.org/x/mod v0.34.0 // indirect
+	golang.org/x/mod v0.37.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260401024825-9d38bb4040a9 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260401024825-9d38bb4040a9 // indirect
 )
@@ -175,9 +175,9 @@ require (
 	go.opentelemetry.io/proto/otlp v1.10.0 // indirect
 	golang.org/x/exp v0.0.0-20230811145659-89c5cff77bcb
 	golang.org/x/net v0.52.0 // indirect
-	golang.org/x/sync v0.20.0
+	golang.org/x/sync v0.21.0
 	golang.org/x/sys v0.43.0
-	golang.org/x/text v0.36.0
+	golang.org/x/text v0.39.0
 	golang.org/x/time v0.9.0
 	google.golang.org/grpc v1.80.0 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect

--- a/go.sum
+++ b/go.sum
@@ -535,6 +535,8 @@ golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91
 golang.org/x/mod v0.8.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
 golang.org/x/mod v0.34.0 h1:xIHgNUUnW6sYkcM5Jleh05DvLOtwc6RitGHbDk4akRI=
 golang.org/x/mod v0.34.0/go.mod h1:ykgH52iCZe79kzLLMhyCUzhMci+nQj+0XkbXpNYtVjY=
+golang.org/x/mod v0.37.0 h1:vF1DjpVEshcIqoEaauuHebaLk1O1forxjxBaVn884JQ=
+golang.org/x/mod v0.37.0/go.mod h1:m8S8VeM9r4dzDwjrKO0a1sZP3YjeMamRRlD+fmR2Q/0=
 golang.org/x/net v0.0.0-20161007143504-f4b625ec9b21/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
@@ -561,6 +563,8 @@ golang.org/x/sync v0.0.0-20220929204114-8fcdb60fdcc0/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.1.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.20.0 h1:e0PTpb7pjO8GAtTs2dQ6jYa5BWYlMuX047Dco/pItO4=
 golang.org/x/sync v0.20.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
+golang.org/x/sync v0.21.0 h1:HLII4xRRTtCRkxYp4HNFF0Js/Og6q2i++KXbg0gHCwM=
+golang.org/x/sync v0.21.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -607,6 +611,8 @@ golang.org/x/text v0.9.0/go.mod h1:e1OnstbJyHTd6l/uOt8jFFHp6TRDWZR/bV3emEE/zU8=
 golang.org/x/text v0.14.0/go.mod h1:18ZOQIKpY8NJVqYksKHtTdi31H5itFRjB5/qKTNYzSU=
 golang.org/x/text v0.36.0 h1:JfKh3XmcRPqZPKevfXVpI1wXPTqbkE5f7JA92a55Yxg=
 golang.org/x/text v0.36.0/go.mod h1:NIdBknypM8iqVmPiuco0Dh6P5Jcdk8lJL0CUebqK164=
+golang.org/x/text v0.39.0 h1:UbZz4pLOvn600D6Oh6GGEI6VAmndrEBLv8/6BEXzyus=
+golang.org/x/text v0.39.0/go.mod h1:3UwRclnC2g0TU9x8PZiyfOajCd1zaUNHF9cvqcQZ+ZM=
 golang.org/x/time v0.0.0-20160926182426-711ca1cb8763/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.9.0 h1:EsRrnYcQiGH+5FfbgvV4AP7qEZstoyrHB0DzarOQ4ZY=
 golang.org/x/time v0.9.0/go.mod h1:3BpzKBy/shNhVucY/MWOyx10tF3SFh9QdLuxbVysPQM=


### PR DESCRIPTION
## What kind of change does this PR introduce?

Upgrade to `golang.org/x/text@v0.39.0`.

```bash
Vulnerability #1: GO-2026-5970
    Infinite loop on invalid input in golang.org/x/text
  More info: https://pkg.go.dev/vuln/GO-2026-5970
  Module: golang.org/x/text
    Found in: golang.org/x/text@v0.36.0
    Fixed in: golang.org/x/text@v0.39.0
    Example traces found:
      #1: internal/indexworker/indexworker.go:62:19: indexworker.CreateIndexes calls pop.Connection.Open, which eventually calls norm.Form.Properties
      #2: internal/indexworker/indexworker.go:62:19: indexworker.CreateIndexes calls pop.Connection.Open, which eventually calls norm.Form.Span
      #3: internal/indexworker/indexworker.go:62:19: indexworker.CreateIndexes calls pop.Connection.Open, which eventually calls norm.Form.Transform
```

## What is the current behavior?

```bash
モ go get golang.org/x/text@v0.39.0
...
モ ./tools/bin/govulncheck ./...
=== Symbol Results ===

Vulnerability #1: GO-2026-5970
    Infinite loop on invalid input in golang.org/x/text
  More info: https://pkg.go.dev/vuln/GO-2026-5970
  Module: golang.org/x/text
    Found in: golang.org/x/text@v0.36.0
    Fixed in: golang.org/x/text@v0.39.0
    Example traces found:
      #1: internal/indexworker/indexworker.go:62:19: indexworker.CreateIndexes calls pop.Connection.Open, which eventually calls norm.Form.Properties
      #2: internal/indexworker/indexworker.go:62:19: indexworker.CreateIndexes calls pop.Connection.Open, which eventually calls norm.Form.Span
      #3: internal/indexworker/indexworker.go:62:19: indexworker.CreateIndexes calls pop.Connection.Open, which eventually calls norm.Form.Transform

Vulnerability #2: GO-2026-5004
    SQL Injection via placeholder confusion with dollar quoted string literals
    in github.com/jackc/pgx
  More info: https://pkg.go.dev/vuln/GO-2026-5004
  Module: github.com/jackc/pgx/v4
    Found in: github.com/jackc/pgx/v4@v4.18.2
    Fixed in: N/A
    Example traces found:
      #1: internal/storage/dial.go:214:23: storage.Connection.ApplyConfig calls sql.DB.SetMaxIdleConns, which eventually calls sanitize.SanitizeSQL

Vulnerability #3: GO-2026-4518
    Denial of service in github.com/jackc/pgproto3/v2
  More info: https://pkg.go.dev/vuln/GO-2026-4518
  Module: github.com/jackc/pgproto3/v2
    Found in: github.com/jackc/pgproto3/v2@v2.3.3
    Fixed in: N/A
    Example traces found:
      #1: internal/e2e/e2eapi/e2eapi.go:82:3: e2eapi.Instance.Close calls sql.noteUnusedDriverStatement, which eventually calls pgproto3.Frontend.Receive

Your code is affected by 3 vulnerabilities from 3 modules.
This scan also found 7 vulnerabilities in packages you import and 16
vulnerabilities in modules you require, but your code doesn't appear to call
these vulnerabilities.
Use '-show verbose' for more details.
```

## What is the new behavior?

```bash
モ ./tools/bin/govulncheck ./...
=== Symbol Results ===

Vulnerability #1: GO-2026-5004
    SQL Injection via placeholder confusion with dollar quoted string literals
    in github.com/jackc/pgx
  More info: https://pkg.go.dev/vuln/GO-2026-5004
  Module: github.com/jackc/pgx/v4
    Found in: github.com/jackc/pgx/v4@v4.18.2
    Fixed in: N/A
    Example traces found:
      #1: internal/storage/dial.go:214:23: storage.Connection.ApplyConfig calls sql.DB.SetMaxIdleConns, which eventually calls sanitize.SanitizeSQL

Vulnerability #2: GO-2026-4518
    Denial of service in github.com/jackc/pgproto3/v2
  More info: https://pkg.go.dev/vuln/GO-2026-4518
  Module: github.com/jackc/pgproto3/v2
    Found in: github.com/jackc/pgproto3/v2@v2.3.3
    Fixed in: N/A
    Example traces found:
      #1: internal/e2e/e2eapi/e2eapi.go:82:3: e2eapi.Instance.Close calls sql.noteUnusedDriverStatement, which eventually calls pgproto3.Frontend.Receive

Your code is affected by 2 vulnerabilities from 2 modules.
This scan also found 7 vulnerabilities in packages you import and 16
vulnerabilities in modules you require, but your code doesn't appear to call
these vulnerabilities.
Use '-show verbose' for more details.
```

## Additional context
