### PR TITLE
feat: gate SCIM router behind an experimental feature flag

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -13,6 +13,7 @@ import (
 	"github.com/supabase/auth/internal/api/apitask"
 	"github.com/supabase/auth/internal/api/oauthserver"
 	"github.com/supabase/auth/internal/api/provider"
+	"github.com/supabase/auth/internal/api/scim"
 	"github.com/supabase/auth/internal/conf"
 	"github.com/supabase/auth/internal/hooks/hookshttp"
 	"github.com/supabase/auth/internal/hooks/hookspgfunc"
@@ -46,6 +47,7 @@ type API struct {
 	hooksMgr     *v0hooks.Manager
 	hibpClient   *hibp.PwnedClient
 	oauthServer  *oauthserver.Server
+	scim         *scim.Server
 	tokenService *tokens.Service
 	mailer       mailer.Mailer
 	oidcCache    *provider.OIDCProviderCache
@@ -209,6 +211,14 @@ func NewAPIWithVersion(globalConfig *conf.GlobalConfiguration, db *storage.Conne
 
 		r.Get("/", api.ExternalProviderCallback)
 		r.Post("/", api.ExternalProviderCallback)
+	})
+
+	api.scim = scim.NewServer(globalConfig)
+	r.Route("/scim/v2", func(r *router) {
+		r.Use(api.scim.Middleware)
+		r.Get("/ServiceProviderConfig", api.scim.ServiceProviderConfig)
+		r.Get("/ResourceTypes", api.scim.ResourceTypes)
+		r.Get("/Schemas", api.scim.Schemas)
 	})
 
 	r.Route("/", func(r *router) {

--- a/internal/api/scim/server.go
+++ b/internal/api/scim/server.go
@@ -1,0 +1,46 @@
+package scim
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/supabase/auth/internal/api/apierrors"
+	"github.com/supabase/auth/internal/conf"
+)
+
+const mediaType = "application/scim+json"
+
+type Server struct {
+	config *conf.GlobalConfiguration
+}
+
+func NewServer(config *conf.GlobalConfiguration) *Server {
+	return &Server{
+		config: config,
+	}
+}
+
+func (srv *Server) Middleware(w http.ResponseWriter, r *http.Request) (context.Context, error) {
+	if !srv.config.Experimental.ScimEnabled {
+		return nil, apierrors.NewNotFoundError(apierrors.ErrorCodeFeatureDisabled, "SCIM server is disabled")
+	}
+	return r.Context(), nil
+}
+
+func (srv *Server) ServiceProviderConfig(w http.ResponseWriter, r *http.Request) error {
+	return srv.notImplemented(w, r)
+}
+
+func (srv *Server) ResourceTypes(w http.ResponseWriter, r *http.Request) error {
+	return srv.notImplemented(w, r)
+}
+
+func (srv *Server) Schemas(w http.ResponseWriter, r *http.Request) error {
+	return srv.notImplemented(w, r)
+}
+
+func (srv *Server) notImplemented(w http.ResponseWriter, r *http.Request) error {
+	w.Header().Set("Content-Type", mediaType)
+	w.WriteHeader(http.StatusNotImplemented)
+	return nil
+}

--- a/internal/api/scim/server_test.go
+++ b/internal/api/scim/server_test.go
@@ -1,0 +1,32 @@
+package scim
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestServer(t *testing.T) {
+	srv := NewServer(nil)
+	require.NotNil(t, srv)
+
+	for _, tc := range []struct {
+		path    string
+		handler func(http.ResponseWriter, *http.Request) error
+	}{
+		{"ServiceProviderConfig", srv.ServiceProviderConfig},
+		{"ResourceTypes", srv.ResourceTypes},
+		{"Schemas", srv.Schemas},
+	} {
+		t.Run(tc.path, func(t *testing.T) {
+			r := httptest.NewRequest(http.MethodGet, "/scim/v2/"+tc.path, nil)
+			w := httptest.NewRecorder()
+
+			require.NoError(t, tc.handler(w, r))
+			require.Equal(t, w.Code, http.StatusNotImplemented)
+			require.Equal(t, "application/scim+json", w.Header().Get("Content-Type"))
+		})
+	}
+}

--- a/internal/api/scim_test.go
+++ b/internal/api/scim_test.go
@@ -1,0 +1,63 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/supabase/auth/internal/conf"
+	"github.com/supabase/auth/internal/storage"
+)
+
+var scimPaths = []string{
+	"/scim/v2/ServiceProviderConfig",
+	"/scim/v2/ResourceTypes",
+	"/scim/v2/Schemas",
+}
+
+func TestSCIM(t *testing.T) {
+	t.Run("Disabled by default", func(t *testing.T) {
+		api, _, err := setupAPIForTest()
+		require.NoError(t, err)
+
+		require.False(t, api.config.Experimental.ScimEnabled)
+
+		for _, path := range scimPaths {
+			r := httptest.NewRequest(http.MethodGet, path, nil)
+			w := httptest.NewRecorder()
+			api.handler.ServeHTTP(w, r)
+
+			require.Equal(t, http.StatusNotFound, w.Code)
+		}
+	})
+
+	t.Run("Can be enabled", func(t *testing.T) {
+		api, _, err := setupAPIForTestWithCallback(func(config *conf.GlobalConfiguration, conn *storage.Connection) {
+			if config != nil {
+				config.Experimental.ScimEnabled = true
+			}
+		})
+		require.NoError(t, err)
+
+		require.True(t, api.config.Experimental.ScimEnabled)
+		require.NotNil(t, api.scim)
+	})
+
+	for _, path := range scimPaths {
+		t.Run(path, func(t *testing.T) {
+			api, _, err := setupAPIForTestWithCallback(func(config *conf.GlobalConfiguration, conn *storage.Connection) {
+				if config != nil {
+					config.Experimental.ScimEnabled = true
+				}
+			})
+			require.NoError(t, err)
+
+			r := httptest.NewRequest(http.MethodGet, path, nil)
+			w := httptest.NewRecorder()
+			api.handler.ServeHTTP(w, r)
+
+			require.Equal(t, w.Code, http.StatusNotImplemented)
+		})
+	}
+}

--- a/internal/conf/configuration.go
+++ b/internal/conf/configuration.go
@@ -370,6 +370,11 @@ type ExperimentalConfiguration struct {
 	// provided, GET /admin/users serves fast, count-free cursor pages.
 	// Env: GOTRUE_EXPERIMENTAL_CURSOR_PAGINATION_ENABLED=true
 	CursorPaginationEnabled bool `split_words:"true" default:"false"`
+
+	// ScimEnabled gates the /scim/v2 router. Ships dark: no per-provider
+	// enablement yet, just a kill switch for internal verification.
+	// Env: GOTRUE_EXPERIMENTAL_SCIM_ENABLED=true
+	ScimEnabled bool `split_words:"true" default:"false"`
 }
 
 // ReloadingConfiguration holds the configuration values for runtime

--- a/internal/conf/confload/confload_test.go
+++ b/internal/conf/confload/confload_test.go
@@ -266,6 +266,34 @@ func TestExperimentalCursorPaginationEnabled(t *testing.T) {
 	}
 }
 
+func TestExperimentalScimEndpoints(t *testing.T) {
+	baseEnv := func() {
+		os.Clearenv()
+		os.Setenv("GOTRUE_SITE_URL", "http://localhost:8080")
+		os.Setenv("GOTRUE_DB_DRIVER", "postgres")
+		os.Setenv("GOTRUE_DB_DATABASE_URL", "fake")
+		os.Setenv("GOTRUE_JWT_SECRET", "secret")
+		os.Setenv("API_EXTERNAL_URL", "http://localhost:9999")
+	}
+
+	{
+		baseEnv()
+		cfg, err := LoadGlobalFromEnv()
+		require.NoError(t, err)
+		require.NotNil(t, cfg)
+		assert.Equal(t, false, cfg.Experimental.ScimEnabled)
+	}
+
+	{
+		baseEnv()
+		os.Setenv("GOTRUE_EXPERIMENTAL_SCIM_ENABLED", "true")
+		cfg, err := LoadGlobalFromEnv()
+		require.NoError(t, err)
+		require.NotNil(t, cfg)
+		assert.Equal(t, true, cfg.Experimental.ScimEnabled)
+	}
+}
+
 func TestLoading(t *testing.T) {
 	os.Clearenv()
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Add `GOTRUE_EXPERIMENTAL_SCIM_ENABLED` (default false) to conditionally mount `/scim/v2/*`, the first step toward SCIM (System for Cross-domain Identity Management) support for provisioning and deprovisioning users from an identity provider.

Ships dark: with the flag off, no SCIM routes are reachable; with it on, the router mounts three stub endpoints (ServiceProviderConfig, ResourceTypes, Schemas) that return 501 until real handlers land in follow-up PRs.

## What is the current behavior?

Currently, we do not have SCIM support. There is no `/scim/v2` router and no way for an identity provider to provision or deprovision users automatically.

https://linear.app/supabase/issue/AUTH-1361/enable-scim-via-feature-flag

## What is the new behavior?

This is the first step towards adding SCIM support: a feature flag that gates the `/scim/v2` router, shipped dark with no customer-facing toggle yet, so it can be verified internally before real per-provider enablement is added.

## Additional context

This reimplements a smaller, subset of SCIM support. It draws on ideas and endpoint shapes explored in two earlier PRs:

* https://github.com/supabase/auth/pull/2115: DB-backed multi-tenant SCIM provider model
* https://github.com/supabase/auth/pull/2309: Full Users/Groups CRUD, a SCIM-specific error schema, and Admin API integration
