### PR TITLE
fix: reject AT from banned users

### DIFF
--- a/internal/api/auth.go
+++ b/internal/api/auth.go
@@ -32,7 +32,13 @@ func (a *API) requireAuthentication(w http.ResponseWriter, r *http.Request) (con
 	if err != nil {
 		return ctx, err
 	}
-	return ctx, err
+
+	// Reject banned users who still hold an access token issued before the ban
+	if user := getUser(ctx); user != nil && user.IsBanned() {
+		return ctx, apierrors.NewForbiddenError(apierrors.ErrorCodeUserBanned, "User is banned")
+	}
+
+	return ctx, nil
 }
 
 func (a *API) requireNotAnonymous(w http.ResponseWriter, r *http.Request) (context.Context, error) {

--- a/internal/api/auth_test.go
+++ b/internal/api/auth_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/gofrs/uuid"
 	jwt "github.com/golang-jwt/jwt/v5"
@@ -87,6 +88,9 @@ func TestExtractBearerTokenCaseInsensitive(t *testing.T) {
 }
 
 func (ts *AuthTestSuite) TestParseJWTClaims() {
+	originalJWT := ts.Config.JWT
+	defer func() { ts.Config.JWT = originalJWT }()
+
 	cases := []struct {
 		desc string
 		key  map[string]interface{}
@@ -311,4 +315,55 @@ func (ts *AuthTestSuite) TestMaybeLoadUserOrSession() {
 			require.Equal(ts.T(), c.ExpectedSession, getSession(ctx))
 		})
 	}
+}
+
+// TestRequireAuthenticationBannedUser verifies that a banned user holding a
+// still-valid access token is rejected by requireAuthentication, while
+// non-banned users and users whose ban has expired are allowed through.
+func (ts *AuthTestSuite) TestRequireAuthenticationBannedUser() {
+	u, err := models.FindUserByEmailAndAudience(ts.API.db, "test@example.com", ts.Config.JWT.Aud)
+	require.NoError(ts.T(), err)
+
+	newAuthedRequest := func() *http.Request {
+		claims := &AccessTokenClaims{
+			RegisteredClaims: jwt.RegisteredClaims{
+				Subject: u.ID.String(),
+			},
+			Role: "authenticated",
+		}
+		userJwt, err := jwt.NewWithClaims(jwt.SigningMethodHS256, claims).SignedString([]byte(ts.Config.JWT.Secret))
+		require.NoError(ts.T(), err)
+
+		req := httptest.NewRequest(http.MethodGet, "http://localhost", nil)
+		req.Header.Set("Authorization", "Bearer "+userJwt)
+		return req
+	}
+
+	ts.Run("Banned user is rejected", func() {
+		require.NoError(ts.T(), u.Ban(ts.API.db, time.Hour))
+
+		_, err := ts.API.requireAuthentication(httptest.NewRecorder(), newAuthedRequest())
+		require.Error(ts.T(), err)
+		require.Equal(ts.T(),
+			apierrors.NewForbiddenError(apierrors.ErrorCodeUserBanned, "User is banned").Error(),
+			err.Error())
+	})
+
+	ts.Run("Expired ban is allowed", func() {
+		pastBan := time.Now().Add(-time.Hour)
+		u.BannedUntil = &pastBan
+		require.NoError(ts.T(), ts.API.db.UpdateOnly(u, "banned_until"))
+
+		ctx, err := ts.API.requireAuthentication(httptest.NewRecorder(), newAuthedRequest())
+		require.NoError(ts.T(), err)
+		require.NotNil(ts.T(), getUser(ctx))
+	})
+
+	ts.Run("Non-banned user is allowed", func() {
+		require.NoError(ts.T(), u.Ban(ts.API.db, 0))
+
+		ctx, err := ts.API.requireAuthentication(httptest.NewRecorder(), newAuthedRequest())
+		require.NoError(ts.T(), err)
+		require.NotNil(ts.T(), getUser(ctx))
+	})
 }


### PR DESCRIPTION
Reject requests from from banned users with still-valid access tokens.

The following endpoints will be affected:

### User & session
| Method | Path | Handler |
|---|---|---|
| `GET` | `/user` | `UserGet` |
| `PUT` | `/user` | `UserUpdate` |
| `GET` | `/reauthenticate` | `Reauthenticate` |
| `POST` | `/logout` | `Logout` (now also blocked for banned users) |

### Identities & OAuth grants
| Method | Path | Handler |
|---|---|---|
| `GET` | `/user/identities/authorize` | `LinkIdentity` |
| `DELETE` | `/user/identities/{identity_id}` | `DeleteIdentity` |
| `GET` | `/user/oauth/grants` | `UserListOAuthGrants` |
| `DELETE` | `/user/oauth/grants` | `UserRevokeOAuthGrant` |
| `POST` | `/token?grant_type=id_token` (with `link_identity=true`) | `IdTokenGrant` (via direct `requireAuthentication` call) |

### MFA / factors
| Method | Path | Handler |
|---|---|---|
| `POST` | `/factors` | `EnrollFactor` |
| `POST` | `/factors/{factor_id}/challenge` | `ChallengeFactor` |
| `POST` | `/factors/{factor_id}/verify` | `VerifyFactor` |
| `DELETE` | `/factors/{factor_id}` | `UnenrollFactor` |

### Passkeys
| Method | Path | Handler |
|---|---|---|
| `POST` | `/passkeys/registration/options` | `PasskeyRegistrationOptions` |
| `POST` | `/passkeys/registration/verify` | `PasskeyRegistrationVerify` |
| `GET` | `/passkeys` | `PasskeyList` |
| `PATCH` | `/passkeys/{passkey_id}` | `PasskeyUpdate` |
| `DELETE` | `/passkeys/{passkey_id}` | `PasskeyDelete` |

### OAuth server (OIDC)
| Method | Path | Handler |
|---|---|---|
| `GET` | `/oauth/userinfo` | `OAuthUserInfo` |
| `GET` | `/oauth/authorizations/{authorization_id}` | `OAuthServerGetAuthorization` |
| `POST` | `/oauth/authorizations/{authorization_id}/consent` | `OAuthServerConsent` |