### PR TITLE
fix: allow linking no-email OIDC identity to phone-only users

### DIFF
--- a/internal/api/identity.go
+++ b/internal/api/identity.go
@@ -143,14 +143,19 @@ func (a *API) linkIdentityToUser(r *http.Request, ctx context.Context, tx *stora
 			}
 			return nil, terr
 		}
-		if !userData.Metadata.EmailVerified {
-			if terr := a.sendConfirmation(r, tx, targetUser, models.ImplicitFlow); terr != nil {
+		// Only confirm/verify when linking claimed an email. Phone-only users
+		// linking an email-optional identity with no email must not enter the
+		// confirmation path (see https://github.com/supabase/auth/issues/2640).
+		if targetUser.GetEmail() != "" {
+			if !userData.Metadata.EmailVerified {
+				if terr := a.sendConfirmation(r, tx, targetUser, models.ImplicitFlow); terr != nil {
+					return nil, terr
+				}
+				return nil, storage.NewCommitWithError(apierrors.NewUnprocessableEntityError(apierrors.ErrorCodeEmailNotConfirmed, "Unverified email with %v. A confirmation email has been sent to your %v email", providerType, providerType))
+			}
+			if terr := targetUser.Confirm(tx); terr != nil {
 				return nil, terr
 			}
-			return nil, storage.NewCommitWithError(apierrors.NewUnprocessableEntityError(apierrors.ErrorCodeEmailNotConfirmed, "Unverified email with %v. A confirmation email has been sent to your %v email", providerType, providerType))
-		}
-		if terr := targetUser.Confirm(tx); terr != nil {
-			return nil, terr
 		}
 
 		if targetUser.IsAnonymous {

--- a/internal/api/identity_test.go
+++ b/internal/api/identity_test.go
@@ -111,6 +111,44 @@ func (ts *IdentityTestSuite) TestLinkIdentityToUser() {
 	require.Nil(ts.T(), u)
 }
 
+func (ts *IdentityTestSuite) TestLinkIdentityToUser_PhoneOnlyNoEmail() {
+	// Confirmed phone-only user linking an email-optional OIDC identity with no email.
+	u, err := models.NewUser("15551234567", "", "", ts.Config.JWT.Aud, nil)
+	require.NoError(ts.T(), err)
+	require.NoError(ts.T(), ts.API.db.Create(u))
+	require.NoError(ts.T(), u.ConfirmPhone(ts.API.db))
+
+	phoneIdentity, err := models.NewIdentity(u, "phone", map[string]interface{}{
+		"sub":   u.ID.String(),
+		"phone": u.GetPhone(),
+	})
+	require.NoError(ts.T(), err)
+	require.NoError(ts.T(), ts.API.db.Create(phoneIdentity))
+
+	ctx := withTargetUser(context.Background(), u)
+	r := httptest.NewRequest(http.MethodGet, "/identities", nil)
+	userData := &provider.UserProvidedData{
+		Metadata: &provider.Claims{
+			Subject:       "oidc-subject-no-email",
+			EmailVerified: false,
+		},
+	}
+
+	u, err = ts.API.linkIdentityToUser(r, ctx, ts.API.db, userData, "custom:line")
+	require.NoError(ts.T(), err)
+	require.NotNil(ts.T(), u)
+	require.Empty(ts.T(), u.GetEmail())
+	require.Equal(ts.T(), "15551234567", u.GetPhone())
+
+	require.NoError(ts.T(), ts.API.db.Load(u, "Identities"))
+	require.Len(ts.T(), u.Identities, 2)
+	providers := make([]string, 0, len(u.Identities))
+	for _, identity := range u.Identities {
+		providers = append(providers, identity.Provider)
+	}
+	require.ElementsMatch(ts.T(), []string{"phone", "custom:line"}, providers)
+}
+
 func (ts *IdentityTestSuite) TestUnlinkIdentityError() {
 	ts.Config.Security.ManualLinkingEnabled = true
 	userWithOneIdentity, err := models.FindUserByEmailAndAudience(ts.API.db, "one@example.com", ts.Config.JWT.Aud)


### PR DESCRIPTION
## What kind of change does this PR introduce?
Bug fix
## What is the current behavior?
`linkIdentityToUser` treats an empty primary email as “identity claimed an unverified email,” so phone-only users linking an email-optional OIDC identity with no email hit `sendConfirmation` and get 422 `EmailNotConfirmed`.
Fixes #2640
## What is the new behavior?
After `UpdateUserEmailFromIdentities`, email confirmation / `Confirm` only runs when `GetEmail() != ""`. Anonymous → non-anonymous still runs. Phone-only + no-email OIDC link succeeds.
## Additional context
Regression test: `TestLinkIdentityToUser_PhoneOnlyNoEmail`.