### PR TITLE
fix: update google.golang.org/grpc to v1.82.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -179,7 +179,7 @@ require (
 	golang.org/x/sys v0.45.0
 	golang.org/x/text v0.39.0
 	golang.org/x/time v0.9.0
-	google.golang.org/grpc v1.81.1 // indirect
+	google.golang.org/grpc v1.82.1 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
 	gopkg.in/alexcesaro/quotedprintable.v3 v3.0.0-20150716171945-2caba252f4dc // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -634,6 +634,8 @@ google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa h1:
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa/go.mod h1:4Hqkh8ycfw05ld/3BWL7rJOSfebL2Q+DVDeRgYgxUU8=
 google.golang.org/grpc v1.81.1 h1:VnnIIZ88UzOOKLukQi+ImGz8O1Wdp8nAGGnvOfEIWQQ=
 google.golang.org/grpc v1.81.1/go.mod h1:xGH9GfzOyMTGIOXBJmXt+BX/V0kcdQbdcuwQ/zNw42I=
+google.golang.org/grpc v1.82.1 h1:NnAxzGRA0677vCa4BUkOAnO5+FfQqVl9iUXeD0IqcGE=
+google.golang.org/grpc v1.82.1/go.mod h1:yzTZ1TB1Z3SG+LIYaI+WiE8D5+PZ3ArnrSp8zF3+/ZA=
 google.golang.org/protobuf v1.36.11 h1:fV6ZwhNocDyBLK0dj+fg8ektcVegBBuEolpbTQyBNVE=
 google.golang.org/protobuf v1.36.11/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=
 gopkg.in/alexcesaro/quotedprintable.v3 v3.0.0-20150716171945-2caba252f4dc h1:2gGKlE2+asNV9m7xrywl36YYNnBG5ZQ0r/BOOxqPpmk=


### PR DESCRIPTION
## What kind of change does this PR introduce?

This change updates google.golang.org/grpc to resolve https://pkg.go.dev/vuln/GO-2026-6061

## What is the current behavior?

```bash
モ make vulncheck
tools/bin/govulncheck ./... | go run ./hack/vulncheck-filter
ignoring GO-2026-5004: pgx/v4 SQL injection via dollar-quoted placeholder confusion, no fix available. Transitive via pop/v6.
ignoring GO-2026-4518: pgproto3/v2 DoS, no fix available (EOL). Transitive via pgconn v1 + pop/v6.

Vulnerability #1: GO-2026-6061
    Vulnerabilities in the xDS RBAC authorization engine and the HTTP/2
    transport server implementation in google.golang.org/grpc
  More info: https://pkg.go.dev/vuln/GO-2026-6061
  Module: google.golang.org/grpc
    Found in: google.golang.org/grpc@v1.81.1
    Fixed in: google.golang.org/grpc@v1.82.1
    Example traces found:
      #1: internal/observability/metrics.go:165:16: observability.ConfigureMetrics calls sync.Once.Do, which eventually calls transport.ClientStream.Close
      #2: internal/observability/metrics.go:165:16: observability.ConfigureMetrics calls sync.Once.Do, which eventually calls transport.ClientStream.Header
      #3: internal/observability/metrics.go:165:16: observability.ConfigureMetrics calls sync.Once.Do, which eventually calls transport.ClientStream.Read
      #4: internal/observability/metrics.go:165:16: observability.ConfigureMetrics calls sync.Once.Do, which eventually calls transport.ClientStream.RecvCompress
      #5: internal/observability/metrics.go:165:16: observability.ConfigureMetrics calls sync.Once.Do, which eventually calls transport.ClientStream.TrailersOnly
      #6: internal/observability/metrics.go:165:16: observability.ConfigureMetrics calls sync.Once.Do, which eventually calls transport.ClientStream.Write
      #7: internal/observability/metrics.go:165:16: observability.ConfigureMetrics calls sync.Once.Do, which eventually calls transport.NewHTTP2Client
      #8: internal/observability/metrics.go:165:16: observability.ConfigureMetrics calls sync.Once.Do, which eventually calls transport.Stream.ReadMessageHeader
      #9: internal/observability/metrics.go:165:16: observability.ConfigureMetrics calls sync.Once.Do, which eventually calls transport.http2Client.Close
      #10: internal/observability/metrics.go:165:16: observability.ConfigureMetrics calls sync.Once.Do, which eventually calls transport.http2Client.GracefulClose
      #11: internal/observability/metrics.go:165:16: observability.ConfigureMetrics calls sync.Once.Do, which eventually calls transport.http2Client.NewStream

vulncheck-filter: 1 unignored vulnerability(ies) found
exit status 1
make: *** [vulncheck] Error 1
```

## What is the new behavior?

```bash
モ make vulncheck
tools/bin/govulncheck ./... | go run ./hack/vulncheck-filter
ignoring GO-2026-5004: pgx/v4 SQL injection via dollar-quoted placeholder confusion, no fix available. Transitive via pop/v6.
ignoring GO-2026-4518: pgproto3/v2 DoS, no fix available (EOL). Transitive via pgconn v1 + pop/v6.
```

## Additional context
