### PR TITLE
fix: unblock openapi code generation

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3405,7 +3405,7 @@ components:
           format: uuid
         id:
           type: string
-          format: uuid
+          description: Subject identifier issued by the provider. Only a UUID for `email` and `phone`.
         user_id:
           type: string
           format: uuid

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3501,8 +3501,6 @@ components:
                   properties:
                     publicKey:
                       $ref: '#/components/schemas/CredentialRequestOptions'
-          discriminator:
-            propertyName: type
 
     CredentialRequestOptions:
       type: object

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -760,7 +760,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/responses/UnauthorizedResponse"
+                $ref: "#/components/schemas/ErrorSchema"
               examples:
                 example:
                   summary: no_authorization
@@ -771,7 +771,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/responses/ForbiddenResponse"
+                $ref: "#/components/schemas/ErrorSchema"
               examples:
                 example:
                   summary: bad_jwt

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -667,6 +667,9 @@ paths:
                   format: phone
                 password:
                   type: string
+                current_password:
+                  type: string
+                  description: Required when setting a new password and `GOTRUE_SECURITY_UPDATE_PASSWORD_REQUIRE_CURRENT_PASSWORD` is enabled.
                 nonce:
                   type: string
                 data:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3500,8 +3500,6 @@ components:
                   properties:
                     publicKey:
                       $ref: '#/components/schemas/CredentialRequestOptions'
-          discriminator:
-            propertyName: type
 
     CredentialRequestOptions:
       type: object

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1561,6 +1561,31 @@ paths:
           $ref: "#/components/responses/UnauthorizedResponse"
         403:
           $ref: "#/components/responses/ForbiddenResponse"
+    post:
+      summary: Create a user.
+      tags:
+        - admin
+      security:
+        - APIKeyAuth: []
+          AdminAuth: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AdminCreateUserSchema"
+      responses:
+        200:
+          description: The user was created.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UserSchema"
+        400:
+          $ref: "#/components/responses/BadRequestResponse"
+        401:
+          $ref: "#/components/responses/UnauthorizedResponse"
+        403:
+          $ref: "#/components/responses/ForbiddenResponse"
 
   /admin/users/{userId}:
     parameters:
@@ -3276,6 +3301,43 @@ components:
           format: date-time
         is_anonymous:
           type: boolean
+
+    AdminCreateUserSchema:
+      type: object
+      description: Object describing the user to create. Either an email or a phone must be provided.
+      properties:
+        id:
+          type: string
+          format: uuid
+          description: Generated when omitted.
+        aud:
+          type: string
+        role:
+          type: string
+        email:
+          type: string
+          format: email
+        phone:
+          type: string
+        password:
+          type: string
+          description: Mutually exclusive with `password_hash`. A random password is generated when neither is given.
+        password_hash:
+          type: string
+          description: Mutually exclusive with `password`.
+        email_confirm:
+          type: boolean
+          description: Marks the email confirmed, skipping the confirmation email.
+        phone_confirm:
+          type: boolean
+          description: Marks the phone confirmed, skipping the confirmation SMS.
+        user_metadata:
+          type: object
+        app_metadata:
+          type: object
+        ban_duration:
+          type: string
+          description: Duration such as `24h` (units `ns`, `us`, `ms`, `s`, `m`, `h`), or `none`.
 
     SAMLAttributeMappingSchema:
       type: object

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3406,7 +3406,7 @@ components:
           format: uuid
         id:
           type: string
-          format: uuid
+          description: Subject identifier issued by the provider. Only a UUID for `email` and `phone`.
         user_id:
           type: string
           format: uuid

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1562,6 +1562,31 @@ paths:
           $ref: "#/components/responses/UnauthorizedResponse"
         403:
           $ref: "#/components/responses/ForbiddenResponse"
+    post:
+      summary: Create a user.
+      tags:
+        - admin
+      security:
+        - APIKeyAuth: []
+          AdminAuth: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AdminCreateUserSchema"
+      responses:
+        200:
+          description: The user was created.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UserSchema"
+        400:
+          $ref: "#/components/responses/BadRequestResponse"
+        401:
+          $ref: "#/components/responses/UnauthorizedResponse"
+        403:
+          $ref: "#/components/responses/ForbiddenResponse"
 
   /admin/users/{userId}:
     parameters:
@@ -3277,6 +3302,43 @@ components:
           format: date-time
         is_anonymous:
           type: boolean
+
+    AdminCreateUserSchema:
+      type: object
+      description: Object describing the user to create. Either an email or a phone must be provided.
+      properties:
+        id:
+          type: string
+          format: uuid
+          description: Generated when omitted.
+        aud:
+          type: string
+        role:
+          type: string
+        email:
+          type: string
+          format: email
+        phone:
+          type: string
+        password:
+          type: string
+          description: Mutually exclusive with `password_hash`. A random password is generated when neither is given.
+        password_hash:
+          type: string
+          description: Mutually exclusive with `password`.
+        email_confirm:
+          type: boolean
+          description: Marks the email confirmed, skipping the confirmation email.
+        phone_confirm:
+          type: boolean
+          description: Marks the phone confirmed, skipping the confirmation SMS.
+        user_metadata:
+          type: object
+        app_metadata:
+          type: object
+        ban_duration:
+          type: string
+          description: Duration such as `24h` (units `ns`, `us`, `ms`, `s`, `m`, `h`), or `none`.
 
     SAMLAttributeMappingSchema:
       type: object


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix and docs update. Spec-only, no code changes.

## What is the current behavior?

`openapi.yaml` has not loaded in kin-openapi since February 2025, so `go generate ./...` fails on a clean checkout. Both the pinned generator (v2.4.2) and the current release (v2.8.0) reject it identically, so upgrading doesn't help.

The blocker is the unlink identity 401/403 responses, which reference Response Objects where a schema belongs. kin-openapi rejects the whole document over it.

Three smaller problems: the WebAuthn challenge discriminator points at inline oneOf arms so it can never resolve; identity id is marked as a UUID when it's really the provider's subject; and current_password on PUT /user plus POST /admin/users are undocumented.

## What is the new behavior?

- Unlink identity 401/403 wrap ErrorSchema, matching the 404 beside them. This is what unblocks generation.
- Removed the unresolvable discriminator. Each oneOf arm keeps its type enum, so clients can still branch on create vs request.
- Identity id is a string. The old format made generated clients fail to decode identities for every provider except email and phone, which use the user's UUID as the subject.
- Documented current_password on PUT /user, required when `GOTRUE_SECURITY_UPDATE_PASSWORD_REQUIRE_CURRENT_PASSWORD` is on and the user already has a password. Not enforced during recovery.
- Documented POST /admin/users.

## Additional context

> [!WARNING]
> Identity id becomes a string, so identity.Id.String() breaks the next time the admin client is regenerated. The UUID is still available on identity_id.

I left `client/admin` alone. It's 13 spec commits stale, so regenerating emits about 3,800 lines of unrelated code, plus roughly 2,900 more if the unpinned generator drifts to v2.8.0. Happy to do that separately. The first commit here unblocks it.

Verified by generating the admin client with both v2.4.2 and v2.8.0: both succeed on this branch, both fail on master. No tests added, make test not run.