### PR TITLE
docs: network hardening

### DIFF
--- a/README.md
+++ b/README.md
@@ -466,6 +466,12 @@ The URI a OAuth2 provider will redirect to with the `code` and `state` values.
 
 The base URL used for constructing the URLs to request authorization and access tokens. Used by `gitlab` and `keycloak`. For `gitlab` it defaults to `https://gitlab.com`. For `keycloak` you need to set this to your instance, for example: `https://keycloak.example.com/realms/myrealm`
 
+#### Network hardening
+
+Configuring an external authentication provider causes Auth to make outbound HTTP requests to that provider's authorization, token, and userinfo endpoints. Configuring a provider either via `GOTRUE_EXTERNAL_*` settings or an admin API is an administrative action, and doing so implies trust in the hosts and URLs that will be contacted.
+
+The network Auth runs in should be hardened so these outbound connections cannot reach internal-only resources you don't want exposed, such as `localhost`/loopback addresses or cloud metadata endpoints (e.g. `169.254.169.254`). This matters most for providers with admin-configurable or discoverable endpoints (e.g. custom OAuth/OIDC providers), where a misconfigured or malicious URL could otherwise be used to reach internal infrastructure.
+
 #### Apple OAuth
 
 To try out external authentication with Apple locally, you will need to do the following:


### PR DESCRIPTION
## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

External provider configuration must be flexible, however this does add some risk. Limiting the endpoints Auth can reach is best done at the infrastructure layer. 

## What is the new behavior?

Adds documentation calling out the need for network hardening.

## Additional context

Auth is deliberately not prescriptive in the endpoints that can be configured. Self hosting Auth might mean you want SAML metadata to be fetched from an internal endpoint (localhost or RFC1918 network). The best protection for this is always at the network layer, it helps prevent DNS rebinding attacks, IP address encoding bypasses of allow lists etc. 
