### PR TITLE
fix: persist last_sign_in_at on v2 refresh token issuance

### DIFF
--- a/internal/tokens/service.go
+++ b/internal/tokens/service.go
@@ -888,6 +888,10 @@ func (s *Service) IssueRefreshToken(r *http.Request, responseHeaders http.Header
 				return apierrors.NewInternalServerError("Database error creating new session").WithInternalError(terr)
 			}
 
+			if terr := user.UpdateLastSignInAt(tx); terr != nil {
+				return apierrors.NewInternalServerError("Database error updating user's last_sign_in_at").WithInternalError(terr)
+			}
+
 			signingKey, _, terr := session.GetRefreshTokenHmacKey(config.Security.DBEncryption)
 			if terr != nil {
 				return apierrors.NewInternalServerError("Failed to get session's refresh token key").WithInternalError(terr)

--- a/internal/tokens/service_test.go
+++ b/internal/tokens/service_test.go
@@ -152,6 +152,41 @@ func (ts *RefreshTokenV2Suite) TestNormalUse() {
 	}
 }
 
+func (ts *RefreshTokenV2Suite) TestUpdatesLastSignInAt() {
+	config := ts.config()
+	require.Equal(ts.T(), 2, config.Security.RefreshTokenAlgorithmVersion)
+
+	require.Nil(ts.T(), ts.User.LastSignInAt)
+
+	clock := time.Now()
+
+	srv := NewService(config, &panicHookManager{})
+	srv.SetTimeFunc(func() time.Time {
+		return clock
+	})
+
+	req, err := http.NewRequest("POST", "https://example.com/", nil)
+	require.NoError(ts.T(), err)
+
+	req = req.WithContext(context.Background())
+	responseHeaders := make(http.Header)
+
+	_, err = srv.IssueRefreshToken(
+		req,
+		responseHeaders,
+		ts.Conn,
+		ts.User,
+		models.PasswordGrant,
+		models.GrantParams{},
+	)
+	require.NoError(ts.T(), err)
+
+	dbUser, err := models.FindUserByID(ts.Conn, ts.User.ID)
+	require.NoError(ts.T(), err)
+	require.NotNil(ts.T(), dbUser.LastSignInAt)
+	require.WithinDuration(ts.T(), clock, *dbUser.LastSignInAt, time.Second)
+}
+
 func (ts *RefreshTokenV2Suite) TestMaliciousReuse() {
 	config := ts.config()
 	require.Equal(ts.T(), 2, config.Security.RefreshTokenAlgorithmVersion)


### PR DESCRIPTION
## Summary
The v2 refresh token path in IssueRefreshToken creates the session directly and never calls `UpdateLastSignInAt`, unlike the v1 path(via `GrantAuthenticatedUser/createRefreshToken`).