### PR TITLE
chore(scim): deliver SCIM responses through a protocol helper

### DIFF
--- a/internal/api/scim/protocol/protocol.go
+++ b/internal/api/scim/protocol/protocol.go
@@ -1,0 +1,14 @@
+// Package protocol implements the SCIM 2.0 protocol defined in RFC 7644.
+package protocol
+
+import (
+	"net/http"
+
+	"github.com/supabase/auth/internal/api/shared"
+)
+
+const MediaType = "application/scim+json"
+
+func Send(w http.ResponseWriter, status int, obj any) error {
+	return shared.SendJSONAs(w, status, MediaType, obj)
+}

--- a/internal/api/scim/protocol/protocol_test.go
+++ b/internal/api/scim/protocol/protocol_test.go
@@ -1,0 +1,23 @@
+package protocol
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSend(t *testing.T) {
+	t.Run("writes a JSON response with a SCIM media type", func(t *testing.T) {
+		w := httptest.NewRecorder()
+
+		err := Send(w, http.StatusTeapot, map[string]string{"key": "value"})
+		require.NoError(t, err)
+
+		assert.Equal(t, http.StatusTeapot, w.Code)
+		assert.Equal(t, "application/scim+json", w.Header().Get("Content-Type"))
+		assert.JSONEq(t, `{"key":"value"}`, w.Body.String())
+	})
+}

--- a/internal/api/scim/server.go
+++ b/internal/api/scim/server.go
@@ -5,10 +5,9 @@ import (
 	"net/http"
 
 	"github.com/supabase/auth/internal/api/apierrors"
+	"github.com/supabase/auth/internal/api/scim/protocol"
 	"github.com/supabase/auth/internal/conf"
 )
-
-const mediaType = "application/scim+json"
 
 type Server struct {
 	config *conf.GlobalConfiguration
@@ -40,7 +39,5 @@ func (srv *Server) Schemas(w http.ResponseWriter, r *http.Request) error {
 }
 
 func (srv *Server) notImplemented(w http.ResponseWriter, r *http.Request) error {
-	w.Header().Set("Content-Type", mediaType)
-	w.WriteHeader(http.StatusNotImplemented)
-	return nil
+	return protocol.Send(w, http.StatusNotImplemented, nil)
 }

--- a/internal/api/shared/http.go
+++ b/internal/api/shared/http.go
@@ -9,13 +9,21 @@ import (
 )
 
 // SendJSON sends a JSON response with proper error handling
-func SendJSON(w http.ResponseWriter, status int, obj interface{}) error {
-	w.Header().Set("Content-Type", "application/json")
-	b, err := json.Marshal(obj)
-	if err != nil {
-		return errors.Wrap(err, fmt.Sprintf("Error encoding json response: %v", obj))
+func SendJSON(w http.ResponseWriter, status int, obj any) error {
+	return SendJSONAs(w, status, "application/json", obj)
+}
+
+func SendJSONAs(w http.ResponseWriter, status int, contentType string, obj any) error {
+	var b []byte
+	if obj != nil {
+		var err error
+		b, err = json.Marshal(obj)
+		if err != nil {
+			return errors.Wrap(err, fmt.Sprintf("Error encoding json response: %v", obj))
+		}
 	}
+	w.Header().Set("Content-Type", contentType)
 	w.WriteHeader(status)
-	_, err = w.Write(b)
+	_, err := w.Write(b)
 	return err
 }

--- a/internal/api/shared/http.go
+++ b/internal/api/shared/http.go
@@ -2,7 +2,6 @@ package shared
 
 import (
 	"encoding/json"
-	"fmt"
 	"net/http"
 
 	"github.com/pkg/errors"
@@ -19,7 +18,7 @@ func SendJSONAs(w http.ResponseWriter, status int, contentType string, obj any) 
 		var err error
 		b, err = json.Marshal(obj)
 		if err != nil {
-			return errors.Wrap(err, fmt.Sprintf("Error encoding json response: %v", obj))
+			return errors.Wrapf(err, "Error encoding json response: %v", obj)
 		}
 	}
 	w.Header().Set("Content-Type", contentType)

--- a/internal/api/shared/http_test.go
+++ b/internal/api/shared/http_test.go
@@ -1,0 +1,32 @@
+package shared
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSendJSONAs(t *testing.T) {
+	t.Run("with an empty body", func(t *testing.T) {
+		w := httptest.NewRecorder()
+
+		require.NoError(t, SendJSONAs(w, http.StatusTeapot, "application/example+json", nil))
+
+		assert.Equal(t, http.StatusTeapot, w.Code)
+		assert.Equal(t, "application/example+json", w.Header().Get("Content-Type"))
+		assert.Equal(t, "", w.Body.String())
+	})
+
+	t.Run("with a JSON body", func(t *testing.T) {
+		w := httptest.NewRecorder()
+
+		require.NoError(t, SendJSONAs(w, http.StatusTeapot, "application/example+json", map[string]string{"key": "value"}))
+
+		assert.Equal(t, http.StatusTeapot, w.Code)
+		assert.Equal(t, "application/example+json", w.Header().Get("Content-Type"))
+		assert.Equal(t, `{"key":"value"}`, w.Body.String())
+	})
+}


### PR DESCRIPTION
Extract `SendJSONAs` from `SendJSON` so callers can specify a `Content-Type`, and add a protocol package that wraps it with the SCIM media type.

Extracted from https://github.com/supabase/auth/pull/2643

## What kind of change does this PR introduce?

Refactor. Extracts a `scim/protocol` package that writes responses using the SCIM media type, so the discovery endpoints in the follow-up PRs have one place to send from.

## What is the current behavior?

`shared.SendJSON` hardcodes `application/json`, so it is not usable for SCIM.
`scim.Server.notImplemented` writes its response by hand instead, setting `Content-Type` from a local `mediaType` const and calling `WriteHeader(501)` directly.

## What is the new behavior?

* `shared.SendJSONAs(w, status, contentType, obj)` takes the Content-Type; `SendJSON` delegates to it with `application/json`.
* A new `internal/api/scim/protocol` package holds `MediaType` (`application/scim+json`) and `Send`.
* `notImplemented` goes through `protocol.Send`, and the local `mediaType` const is gone.

## Additional context
