### PR TITLE
chore(scim): mount the SCIM router in the main route tree

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -138,6 +138,8 @@ func NewAPIWithVersion(globalConfig *conf.GlobalConfiguration, db *storage.Conne
 		api.oauthServer = oauthserver.NewServer(globalConfig, db, api.tokenService)
 	}
 
+	api.scim = scim.NewServer(globalConfig)
+
 	if api.config.Password.HIBP.Enabled {
 		httpClient := &http.Client{
 			// all HIBP API requests should finish quickly to avoid
@@ -211,14 +213,6 @@ func NewAPIWithVersion(globalConfig *conf.GlobalConfiguration, db *storage.Conne
 
 		r.Get("/", api.ExternalProviderCallback)
 		r.Post("/", api.ExternalProviderCallback)
-	})
-
-	api.scim = scim.NewServer(globalConfig)
-	r.Route("/scim/v2", func(r *router) {
-		r.Use(api.scim.Middleware)
-		r.Get("/ServiceProviderConfig", api.scim.ServiceProviderConfig)
-		r.Get("/ResourceTypes", api.scim.ResourceTypes)
-		r.Get("/Schemas", api.scim.Schemas)
 	})
 
 	r.Route("/", func(r *router) {
@@ -455,6 +449,14 @@ func NewAPIWithVersion(globalConfig *conf.GlobalConfiguration, db *storage.Conne
 			r.Get("/authorize", api.oauthServer.OAuthServerAuthorize)
 			r.With(api.requireAuthentication).Get("/authorizations/{authorization_id}", api.oauthServer.OAuthServerGetAuthorization)
 			r.With(api.requireAuthentication).Post("/authorizations/{authorization_id}/consent", api.oauthServer.OAuthServerConsent)
+		})
+
+		r.Route(scim.BasePath, func(r *router) {
+			r.Use(api.requireScimServerEnabled)
+
+			r.Get("/ServiceProviderConfig", api.scim.ServiceProviderConfig)
+			r.Get("/ResourceTypes", api.scim.ResourceTypes)
+			r.Get("/Schemas", api.scim.Schemas)
 		})
 	})
 

--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -420,6 +420,14 @@ func (a *API) requirePasskeyEnabled(w http.ResponseWriter, req *http.Request) (c
 	return ctx, nil
 }
 
+func (a *API) requireScimServerEnabled(w http.ResponseWriter, req *http.Request) (context.Context, error) {
+	ctx := req.Context()
+	if !a.config.Experimental.ScimEnabled {
+		return nil, apierrors.NewNotFoundError(apierrors.ErrorCodeFeatureDisabled, "SCIM server is disabled")
+	}
+	return ctx, nil
+}
+
 func (a *API) databaseCleanup(cleanup models.Cleaner) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/scim/protocol/protocol.go
+++ b/internal/api/scim/protocol/protocol.go
@@ -10,5 +10,5 @@ import (
 const MediaType = "application/scim+json"
 
 func Send(w http.ResponseWriter, status int, obj any) error {
-	return shared.SendJSONAs(w, status, MediaType, obj)
+	return shared.JSON(w).ContentType(MediaType).Status(status).Send(obj)
 }

--- a/internal/api/scim/server.go
+++ b/internal/api/scim/server.go
@@ -1,13 +1,13 @@
 package scim
 
 import (
-	"context"
 	"net/http"
 
-	"github.com/supabase/auth/internal/api/apierrors"
 	"github.com/supabase/auth/internal/api/scim/protocol"
 	"github.com/supabase/auth/internal/conf"
 )
+
+const BasePath = "/scim/v2"
 
 type Server struct {
 	config *conf.GlobalConfiguration
@@ -17,13 +17,6 @@ func NewServer(config *conf.GlobalConfiguration) *Server {
 	return &Server{
 		config: config,
 	}
-}
-
-func (srv *Server) Middleware(w http.ResponseWriter, r *http.Request) (context.Context, error) {
-	if !srv.config.Experimental.ScimEnabled {
-		return nil, apierrors.NewNotFoundError(apierrors.ErrorCodeFeatureDisabled, "SCIM server is disabled")
-	}
-	return r.Context(), nil
 }
 
 func (srv *Server) ServiceProviderConfig(w http.ResponseWriter, r *http.Request) error {

--- a/internal/api/scim_test.go
+++ b/internal/api/scim_test.go
@@ -26,9 +26,12 @@ func TestSCIM(t *testing.T) {
 		for _, path := range scimPaths {
 			r := httptest.NewRequest(http.MethodGet, path, nil)
 			w := httptest.NewRecorder()
+
 			api.handler.ServeHTTP(w, r)
 
 			require.Equal(t, http.StatusNotFound, w.Code)
+			require.Equal(t, "application/json", w.Header().Get("Content-Type"))
+			require.JSONEq(t, `{"code":404,"error_code":"feature_disabled","msg":"SCIM server is disabled"}`, w.Body.String())
 		}
 	})
 
@@ -55,6 +58,7 @@ func TestSCIM(t *testing.T) {
 
 			r := httptest.NewRequest(http.MethodGet, path, nil)
 			w := httptest.NewRecorder()
+
 			api.handler.ServeHTTP(w, r)
 
 			require.Equal(t, w.Code, http.StatusNotImplemented)

--- a/internal/api/shared/http.go
+++ b/internal/api/shared/http.go
@@ -1,28 +1,10 @@
 package shared
 
 import (
-	"encoding/json"
 	"net/http"
-
-	"github.com/pkg/errors"
 )
 
 // SendJSON sends a JSON response with proper error handling
 func SendJSON(w http.ResponseWriter, status int, obj any) error {
-	return SendJSONAs(w, status, "application/json", obj)
-}
-
-func SendJSONAs(w http.ResponseWriter, status int, contentType string, obj any) error {
-	var b []byte
-	if obj != nil {
-		var err error
-		b, err = json.Marshal(obj)
-		if err != nil {
-			return errors.Wrapf(err, "Error encoding json response: %v", obj)
-		}
-	}
-	w.Header().Set("Content-Type", contentType)
-	w.WriteHeader(status)
-	_, err := w.Write(b)
-	return err
+	return JSON(w).ContentType("application/json").Status(status).Send(obj)
 }

--- a/internal/api/shared/http_test.go
+++ b/internal/api/shared/http_test.go
@@ -9,24 +9,24 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestSendJSONAs(t *testing.T) {
+func TestSendJSON(t *testing.T) {
 	t.Run("with an empty body", func(t *testing.T) {
 		w := httptest.NewRecorder()
 
-		require.NoError(t, SendJSONAs(w, http.StatusTeapot, "application/example+json", nil))
+		require.NoError(t, SendJSON(w, http.StatusTeapot, nil))
 
 		assert.Equal(t, http.StatusTeapot, w.Code)
-		assert.Equal(t, "application/example+json", w.Header().Get("Content-Type"))
+		assert.Equal(t, "application/json", w.Header().Get("Content-Type"))
 		assert.Equal(t, "", w.Body.String())
 	})
 
 	t.Run("with a JSON body", func(t *testing.T) {
 		w := httptest.NewRecorder()
 
-		require.NoError(t, SendJSONAs(w, http.StatusTeapot, "application/example+json", map[string]string{"key": "value"}))
+		require.NoError(t, SendJSON(w, http.StatusTeapot, map[string]string{"key": "value"}))
 
 		assert.Equal(t, http.StatusTeapot, w.Code)
-		assert.Equal(t, "application/example+json", w.Header().Get("Content-Type"))
+		assert.Equal(t, "application/json", w.Header().Get("Content-Type"))
 		assert.Equal(t, `{"key":"value"}`, w.Body.String())
 	})
 }

--- a/internal/api/shared/json.go
+++ b/internal/api/shared/json.go
@@ -1,0 +1,53 @@
+package shared
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/pkg/errors"
+)
+
+type JSONResponse struct {
+	w      http.ResponseWriter
+	status int
+}
+
+func JSON(w http.ResponseWriter) *JSONResponse {
+	j := &JSONResponse{w: w}
+	return j.ContentType("application/json").Status(http.StatusOK)
+}
+
+func (j *JSONResponse) Header(key, value string) *JSONResponse {
+	j.w.Header().Set(key, value)
+	return j
+}
+
+func (j *JSONResponse) ContentType(contentType string) *JSONResponse {
+	return j.Header("Content-Type", contentType)
+}
+
+func (j *JSONResponse) Status(status int) *JSONResponse {
+	j.status = status
+	return j
+}
+
+func (j *JSONResponse) Write(b []byte) error {
+	j.w.WriteHeader(j.status)
+	if len(b) == 0 {
+		return nil
+	}
+	_, err := j.w.Write(b)
+	return err
+}
+
+func (j *JSONResponse) Send(obj any) error {
+	var b []byte
+	if obj != nil {
+		var err error
+		b, err = json.Marshal(obj)
+		if err != nil {
+			return errors.Wrapf(err, "Error encoding json response: %v", obj)
+		}
+	}
+	return j.Write(b)
+}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Moves the SCIM routes into the main route tree and hands the feature-flag check to the API layer, so the SCIM package stops carrying that concern.

Extracted from #2643.

## What is the current behavior?

`/scim/v2` is mounted at the top level of the router, outside the `r.Route("/")` block, so it does not run `isValidExternalHost` the way the rest of the API does.

The feature flag is enforced by `scim.Server.Middleware`, which means the SCIM package has to know about `Experimental.ScimEnabled` and depend on `apierrors`.

## What is the new behavior?

- The routes move into the `r.Route("/")` subtree, so they run `isValidExternalHost` alongside every other endpoint.
- `(*API).requireScimServerEnabled` replaces `scim.Server.Middleware`, following the existing `requireOAuthServerEnabled`, `requirePasskeyEnabled`, and `requireCustomOAuthEnabled`.

The three endpoints still return 501. With the flag off they still return the same 404, which the test now pins on the body rather than the status code alone:

```json
{
  "code": 404,
  "error_code": "feature_disabled",
  "msg": "SCIM server is disabled"
}
```

## Additional context
