### PR TITLE
fix: return RFC 6749 errors from the /oauth/token refresh grant

### DIFF
--- a/internal/api/oauthserver/errors.go
+++ b/internal/api/oauthserver/errors.go
@@ -1,0 +1,58 @@
+package oauthserver
+
+import (
+	"net/http"
+
+	"github.com/supabase/auth/internal/api/apierrors"
+)
+
+// Token endpoint error codes per RFC 6749 Section 5.2, extending the set in authorize.go.
+// https://datatracker.ietf.org/doc/html/rfc6749#section-5.2
+const (
+	oAuth2ErrorInvalidClient        = "invalid_client"
+	oAuth2ErrorInvalidGrant         = "invalid_grant"
+	oAuth2ErrorUnsupportedGrantType = "unsupported_grant_type"
+)
+
+// Only codes meaning the grant itself is dead may map to invalid_grant: that is the code telling a client to stop retrying and re-authorize the user.
+var grantErrorCodes = map[string]string{
+	apierrors.ErrorCodeRefreshTokenNotFound:    oAuth2ErrorInvalidGrant,
+	apierrors.ErrorCodeRefreshTokenAlreadyUsed: oAuth2ErrorInvalidGrant,
+	apierrors.ErrorCodeSessionNotFound:         oAuth2ErrorInvalidGrant,
+	apierrors.ErrorCodeSessionExpired:          oAuth2ErrorInvalidGrant,
+	apierrors.ErrorCodeUserBanned:              oAuth2ErrorInvalidGrant,
+
+	apierrors.ErrorCodeValidationFailed: oAuth2ErrorInvalidRequest,
+}
+
+// oauthTokenError translates an error from the shared token service into an error response the token endpoint is allowed to return, per RFC 6749 Section 5.2 (https://datatracker.ietf.org/doc/html/rfc6749#section-5.2). The service is shared with /auth/v1/token, whose clients parse the HTTPError shape, so the translation has to happen at this boundary.
+func oauthTokenError(err error) error {
+	switch e := err.(type) {
+	case nil:
+		return nil
+
+	case *apierrors.OAuthError:
+		return e
+
+	case *apierrors.HTTPError:
+		// A 409, 429 or 5xx says nothing about the grant, and every value in the spec's set asserts something about this request that retrying will not change.
+		if e.HTTPStatus != http.StatusBadRequest {
+			return e
+		}
+
+		code, ok := grantErrorCodes[e.ErrorCode]
+		if !ok {
+			code = oAuth2ErrorInvalidRequest
+		}
+
+		return apierrors.NewOAuthError(code, e.Message).WithInternalError(e)
+
+	case interface{ Cause() error }:
+		// storage.CommitWithError, used where the transaction must still commit.
+		if cause := e.Cause(); cause != nil && cause != err {
+			return oauthTokenError(cause)
+		}
+	}
+
+	return err
+}

--- a/internal/api/oauthserver/errors_test.go
+++ b/internal/api/oauthserver/errors_test.go
@@ -1,0 +1,91 @@
+package oauthserver
+
+import (
+	"testing"
+
+	"github.com/supabase/auth/internal/api/apierrors"
+	"github.com/supabase/auth/internal/storage"
+)
+
+func TestOAuthTokenError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		// the expected OAuth error code, empty when the error should pass through untranslated
+		expected string
+		// the expected error_description, when it needs asserting
+		expectedDescription string
+		// the status an untranslated error must keep
+		expectedStatus int
+	}{
+		{
+			name:     "refresh token not found should return invalid_grant",
+			err:      apierrors.NewBadRequestError(apierrors.ErrorCodeRefreshTokenNotFound, "Invalid Refresh Token: Refresh Token Not Found"),
+			expected: "invalid_grant",
+		},
+		{
+			name:     "session expired should return invalid_grant",
+			err:      apierrors.NewBadRequestError(apierrors.ErrorCodeSessionExpired, "Invalid Refresh Token: Session Expired"),
+			expected: "invalid_grant",
+		},
+		{
+			name:     "refresh token reuse wrapped in CommitWithError should return invalid_grant",
+			err:      storage.NewCommitWithError(apierrors.NewBadRequestError(apierrors.ErrorCodeRefreshTokenAlreadyUsed, "Invalid Refresh Token: Already Used")),
+			expected: "invalid_grant",
+		},
+		{
+			name:                "the internal message should not reach the client",
+			err:                 apierrors.NewBadRequestError(apierrors.ErrorCodeRefreshTokenAlreadyUsed, "Invalid Refresh Token: Already Used").WithInternalMessage("Possible abuse attempt: %v", "6a3c1f0e"),
+			expected:            "invalid_grant",
+			expectedDescription: "Invalid Refresh Token: Already Used",
+		},
+		{
+			name:     "validation failure should return invalid_request",
+			err:      apierrors.NewBadRequestError(apierrors.ErrorCodeValidationFailed, "Invalid Refresh Token: Not Issued By This Server"),
+			expected: "invalid_request",
+		},
+		{
+			name:     "unrecognized error code should return invalid_request, not invalid_grant",
+			err:      apierrors.NewBadRequestError("some_future_error_code", "Something new"),
+			expected: "invalid_request",
+		},
+		{
+			name:           "concurrent refresh should pass through as a 409",
+			err:            apierrors.NewConflictError("Too many concurrent token refresh requests on the same session or refresh token"),
+			expectedStatus: 409,
+		},
+		{
+			name:           "internal failure should pass through as a 500",
+			err:            apierrors.NewInternalServerError("error generating jwt token"),
+			expectedStatus: 500,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := oauthTokenError(tt.err)
+
+			if tt.expected == "" {
+				httpErr, ok := result.(*apierrors.HTTPError)
+				if !ok {
+					t.Fatalf("oauthTokenError() = %T, expected the error to pass through as *apierrors.HTTPError", result)
+				}
+				if httpErr.HTTPStatus != tt.expectedStatus {
+					t.Errorf("oauthTokenError() status = %v, expected %v", httpErr.HTTPStatus, tt.expectedStatus)
+				}
+				return
+			}
+
+			oauthErr, ok := result.(*apierrors.OAuthError)
+			if !ok {
+				t.Fatalf("oauthTokenError() = %T, expected *apierrors.OAuthError", result)
+			}
+			if oauthErr.Err != tt.expected {
+				t.Errorf("oauthTokenError() error = %v, expected %v", oauthErr.Err, tt.expected)
+			}
+			if tt.expectedDescription != "" && oauthErr.Description != tt.expectedDescription {
+				t.Errorf("oauthTokenError() error_description = %v, expected %v", oauthErr.Description, tt.expectedDescription)
+			}
+		})
+	}
+}

--- a/internal/api/oauthserver/handlers.go
+++ b/internal/api/oauthserver/handlers.go
@@ -271,12 +271,12 @@ func (s *Server) OAuthToken(w http.ResponseWriter, r *http.Request) error {
 	contentType := r.Header.Get("Content-Type")
 	if strings.Contains(contentType, "application/json") {
 		if err := json.NewDecoder(r.Body).Decode(&params); err != nil {
-			return apierrors.NewOAuthError("invalid_request", "Invalid JSON body")
+			return apierrors.NewOAuthError(oAuth2ErrorInvalidRequest, "Invalid JSON body")
 		}
 	} else {
 		// Parse form data
 		if err := r.ParseForm(); err != nil {
-			return apierrors.NewOAuthError("invalid_request", "Failed to parse form data")
+			return apierrors.NewOAuthError(oAuth2ErrorInvalidRequest, "Failed to parse form data")
 		}
 
 		params.GrantType = r.FormValue("grant_type")
@@ -290,17 +290,17 @@ func (s *Server) OAuthToken(w http.ResponseWriter, r *http.Request) error {
 
 	// Validate grant_type
 	if params.GrantType == "" {
-		return apierrors.NewOAuthError("invalid_request", "grant_type is required")
+		return apierrors.NewOAuthError(oAuth2ErrorInvalidRequest, "grant_type is required")
 	}
 
 	client := shared.GetOAuthServerClient(ctx)
 	if client == nil {
-		return apierrors.NewOAuthError("invalid_client", "Client authentication required")
+		return apierrors.NewOAuthError(oAuth2ErrorInvalidClient, "Client authentication required")
 	}
 
 	// Validate that the authenticated client is allowed to use the requested grant type
 	if !client.IsGrantTypeAllowed(params.GrantType) {
-		return apierrors.NewOAuthError("unsupported_grant_type", "Client is not allowed to use grant type: "+params.GrantType)
+		return apierrors.NewOAuthError(oAuth2ErrorUnsupportedGrantType, "Client is not allowed to use grant type: "+params.GrantType)
 	}
 
 	switch params.GrantType {
@@ -309,20 +309,20 @@ func (s *Server) OAuthToken(w http.ResponseWriter, r *http.Request) error {
 	case GrantTypeRefreshToken:
 		return s.handleRefreshTokenGrant(ctx, w, r, &params)
 	default:
-		return apierrors.NewOAuthError("unsupported_grant_type", "Unsupported grant type: "+params.GrantType)
+		return apierrors.NewOAuthError(oAuth2ErrorUnsupportedGrantType, "Unsupported grant type: "+params.GrantType)
 	}
 }
 
 // handleAuthorizationCodeGrant handles the authorization_code grant type
 func (s *Server) handleAuthorizationCodeGrant(ctx context.Context, w http.ResponseWriter, r *http.Request, params *OAuthTokenParams) error {
 	if params.Code == "" {
-		return apierrors.NewOAuthError("invalid_request", "code is required for authorization_code grant")
+		return apierrors.NewOAuthError(oAuth2ErrorInvalidRequest, "code is required for authorization_code grant")
 	}
 
 	// Get authenticated client from middleware
 	client := shared.GetOAuthServerClient(ctx)
 	if client == nil {
-		return apierrors.NewOAuthError("invalid_client", "Client authentication required")
+		return apierrors.NewOAuthError(oAuth2ErrorInvalidClient, "Client authentication required")
 	}
 
 	// Exchange authorization code for tokens
@@ -336,51 +336,51 @@ func (s *Server) handleAuthorizationCodeGrant(ctx context.Context, w http.Respon
 	authorization, err := models.FindOAuthServerAuthorizationByCode(db, params.Code)
 	if err != nil {
 		if models.IsNotFoundError(err) {
-			return apierrors.NewOAuthError("invalid_grant", "Invalid authorization code")
+			return apierrors.NewOAuthError(oAuth2ErrorInvalidGrant, "Invalid authorization code")
 		}
 		return apierrors.NewInternalServerError("Error finding authorization code").WithInternalError(err)
 	}
 
 	// Check if the authorization has expired
 	if authorization.IsExpired() {
-		return apierrors.NewOAuthError("invalid_grant", "Authorization code has expired")
+		return apierrors.NewOAuthError(oAuth2ErrorInvalidGrant, "Authorization code has expired")
 	}
 
 	// Validate that the authorization code was issued for this client
 	if authorization.ClientID != client.ID {
-		return apierrors.NewOAuthError("invalid_grant", "Authorization code was not issued for this client")
+		return apierrors.NewOAuthError(oAuth2ErrorInvalidGrant, "Authorization code was not issued for this client")
 	}
 
 	// Validate that (if exists) the resource parameter matches the authorization code resource
 	if params.Resource != "" && params.Resource != utilities.StringValue(authorization.Resource) {
-		return apierrors.NewOAuthError("invalid_grant", "Authorization code resource does not match the resource parameter")
+		return apierrors.NewOAuthError(oAuth2ErrorInvalidGrant, "Authorization code resource does not match the resource parameter")
 	}
 
 	// Validate redirect_uri if provided - must match the one used in authorization
 	if params.RedirectURI != "" && params.RedirectURI != authorization.RedirectURI {
-		return apierrors.NewOAuthError("invalid_grant", "Invalid redirect_uri")
+		return apierrors.NewOAuthError(oAuth2ErrorInvalidGrant, "Invalid redirect_uri")
 	}
 
 	// Validate PKCE if used in the authorization
 	if err := authorization.VerifyPKCE(params.CodeVerifier); err != nil {
-		return apierrors.NewOAuthError("invalid_grant", "PKCE verification failed: "+err.Error())
+		return apierrors.NewOAuthError(oAuth2ErrorInvalidGrant, "PKCE verification failed: "+err.Error())
 	}
 
 	// Get the user for the authorization code
 	if authorization.UserID == nil {
-		return apierrors.NewOAuthError("invalid_grant", "Authorization code has no associated user")
+		return apierrors.NewOAuthError(oAuth2ErrorInvalidGrant, "Authorization code has no associated user")
 	}
 
 	user, err := models.FindUserByID(db, *authorization.UserID)
 	if err != nil {
 		if models.IsNotFoundError(err) {
-			return apierrors.NewOAuthError("invalid_grant", "User not found for authorization code")
+			return apierrors.NewOAuthError(oAuth2ErrorInvalidGrant, "User not found for authorization code")
 		}
 		return apierrors.NewInternalServerError("Error finding user").WithInternalError(err)
 	}
 
 	if user.IsBanned() {
-		return apierrors.NewOAuthError("access_denied", "User is banned")
+		return apierrors.NewOAuthError(oAuth2ErrorAccessDenied, "User is banned")
 	}
 
 	// Exchange the authorization code for tokens
@@ -396,7 +396,7 @@ func (s *Server) handleAuthorizationCodeGrant(ctx context.Context, w http.Respon
 	err = db.Transaction(func(tx *storage.Connection) error {
 		if _, terr := models.FindOAuthServerAuthorizationByIDForUpdate(tx, authorization.AuthorizationID); terr != nil {
 			if models.IsNotFoundError(terr) {
-				return apierrors.NewOAuthError("invalid_grant", "Invalid authorization code")
+				return apierrors.NewOAuthError(oAuth2ErrorInvalidGrant, "Invalid authorization code")
 			}
 			return apierrors.NewInternalServerError("Error locking authorization code").WithInternalError(terr)
 		}
@@ -429,7 +429,7 @@ func (s *Server) handleAuthorizationCodeGrant(ctx context.Context, w http.Respon
 
 	if err != nil {
 		if httpErr, ok := err.(*apierrors.HTTPError); ok {
-			return httpErr
+			return oauthTokenError(httpErr)
 		}
 		if oauthErr, ok := err.(*apierrors.OAuthError); ok {
 			return oauthErr
@@ -478,7 +478,7 @@ func (s *Server) handleAuthorizationCodeGrant(ctx context.Context, w http.Respon
 // handleRefreshTokenGrant handles the refresh_token grant type
 func (s *Server) handleRefreshTokenGrant(ctx context.Context, w http.ResponseWriter, r *http.Request, params *OAuthTokenParams) error {
 	if params.RefreshToken == "" {
-		return apierrors.NewOAuthError("invalid_request", "refresh_token is required for refresh_token grant")
+		return apierrors.NewOAuthError(oAuth2ErrorInvalidRequest, "refresh_token is required for refresh_token grant")
 	}
 
 	// Use the token service to handle refresh token grant
@@ -499,7 +499,7 @@ func (s *Server) handleRefreshTokenGrant(ctx context.Context, w http.ResponseWri
 		ClientID:     clientID,
 	})
 	if err != nil {
-		return err
+		return oauthTokenError(err)
 	}
 
 	// Convert to OAuth-compliant response format (exclude user info for OAuth clients)


### PR DESCRIPTION
## The problem

`POST /oauth/token` returns two different error shapes, depending on the grant type:

```jsonc
// grant_type=authorization_code — HTTP 400
{ "error": "invalid_grant", "error_description": "Invalid authorization code" }

// grant_type=refresh_token — HTTP 400
{ "code": 400, "error_code": "refresh_token_not_found", "msg": "Invalid Refresh Token: Refresh Token Not Found" }
```

The second one has no `error` field, so an OAuth client cannot read it. RFC 6749 §5.2 requires that field.

The client therefore never learns that the grant is dead. It does not ask the user to re-authorize. It just presents the same dead refresh token again, forever.

## Evidence

We found this through an [FDX / Plaid Core Exchange](https://plaid.com/core-exchange/docs/authentication/oauth-flow/#error-response) integration. Plaid's error contract is RFC 6749 §5.2, so it cannot classify the response. It reports "an unexpected error occurred" and leaves the connection in place.

Seven days of `/oauth/token` on one project:

| | count |
|---|---|
| `400 refresh_token_not_found` | 173 |
| `400 session_expired` | 11 |
| `200` | 38 |
| re-authorization prompts raised by the client | **0** |

Eleven failures in a row from one client IP, all `refresh_token_not_found`:

```
Jul 24 03:03:01   —
Jul 24 09:03:08   +6h 00m 07s
Jul 24 15:03:11   +6h 00m 03s
Jul 24 21:03:14   +6h 00m 03s
Jul 25 03:03:23   +6h 00m 09s
Jul 25 09:03:27   +6h 00m 04s
Jul 25 15:03:36   +6h 00m 09s
Jul 25 21:03:46   +6h 00m 10s
Jul 26 03:03:49   +6h 00m 03s
Jul 26 09:04:19   +6h 00m 30s
Jul 26 15:04:27   +6h 00m 08s
```

A fixed six-hour interval, no backoff, and no point where the client gives up. That is what a client does when it never got an error it could understand. A refresh token going dead is normal. Retrying it every six hours forever is not.

## Cause

`handleAuthorizationCodeGrant` gets this right because it builds each of its own errors with `NewOAuthError(...)`, where the correct code is obvious as you write the line.

`handleRefreshTokenGrant` has no errors of its own. They all come from `tokens.Service.RefreshTokenGrant`, which builds grant failures with `NewBadRequestError(...)` — an `HTTPError` — and the handler returns it as is:

```go
tokenResponse, err := tokenService.RefreshTokenGrant(...)
if err != nil {
    return err   // HTTPError goes straight to the client
}
```

That service is also used by `/auth/v1/token`, whose clients read `error_code` — the reason for the `// do not rename the JSON tags!` comments in `apierrors`. So the service cannot return `OAuthError` instead. The conversion has to happen in the OAuth handler, and that is what was missing.

This is not a regression. It has been there since the endpoint was added. #2135 moved the refresh logic into a shared package and kept the error shape its only caller expected at the time. #2159 then added both grants at once, and the refresh grant inherited an error shape meant for a different endpoint.

#2339 is the same seam failing a different way.

## The fix

Two lines at the call sites, plus a small converter:

| token service `error_code` | → RFC 6749 error |
|---|---|
| `refresh_token_not_found`, `refresh_token_already_used`, `session_not_found`, `session_expired`, `user_banned` | `invalid_grant` |
| `validation_failed` | `invalid_request` |
| anything else | `invalid_request` |
| any status other than 400 | *left alone* |

Two rules decide that table.

**`invalid_grant` is only sent for codes we have listed.** It tells the client the grant is dead, which sends a real user back through a consent screen, so we only send it when we are sure. Every other error, including any `error_code` we have never seen, becomes `invalid_request`. The client reports that and leaves the grant alone. Guessing `invalid_grant` for an unknown error would break working connections over something we do not understand.

**Anything that is not a 400 is left alone.** Each code in the spec says something permanent about the request. A 409 (two refreshes at once), a 429, or a 5xx is temporary, and turning one into a spec code would make a short outage look like a dead grant to every client refreshing at that moment. It also matters in practice: `HandleResponseError` always sends `*OAuthError` as a 400, so converting a 503 would change its status too.

Errors that are already in the right shape are passed through. This endpoint does return correct bodies on some paths, and rewriting everything would break those.

`refresh_token_already_used` arrives wrapped in `storage.CommitWithError`, because that transaction still has to commit. The wrapper has `Cause()` but not `Unwrap()`, so a normal type check misses it. The converter unwraps it the same way `HandleResponseError` does.

The same call is added to the `HTTPError` branch of `handleAuthorizationCodeGrant`. That handler builds its own errors correctly, but the one error it gets back from the token service — from the `IssueRefreshToken` transaction — was also being returned as is.

## Tests

`internal/api/oauthserver/errors_test.go`, one table-driven test, no database needed. The rows that matter are the ones that stop this getting worse:

- an unknown `error_code` becomes `invalid_request`, never `invalid_grant`
- a 409 and a 500 come back untouched, with their status intact
- `refresh_token_already_used` is converted correctly through its `CommitWithError` wrapper
- the description comes from `Message`, not `Error()`, so an internal note like `"Possible abuse attempt: <token id>"` never reaches the client

## Compatibility

- `/auth/v1/token` is untouched. No `error_code` that a `supabase-js` client reads has changed.
- On `/oauth/token`, `refresh_token` error bodies change shape. That is the fix. They now match what the `authorization_code` grant on the same endpoint already returned.
- No status codes change.
