### PR TITLE
feat(scim): render SCIM errors in RFC 7644 form

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -453,6 +453,7 @@ func NewAPIWithVersion(globalConfig *conf.GlobalConfiguration, db *storage.Conne
 
 		r.Route(scim.BasePath, func(r *router) {
 			r.Use(api.requireScimServerEnabled)
+			r.NotFound(api.scim.NotFound)
 
 			r.Get("/ServiceProviderConfig", api.scim.ServiceProviderConfig)
 			r.Get("/ResourceTypes", api.scim.ResourceTypes)

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -54,6 +54,10 @@ func (r *router) UseBypass(fn func(next http.Handler) http.Handler) {
 	r.chi.Use(fn)
 }
 
+func (r *router) NotFound(fn apiHandler) {
+	r.chi.NotFound(handler(fn))
+}
+
 func (r *router) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	r.chi.ServeHTTP(w, req)
 }

--- a/internal/api/scim/protocol/error.go
+++ b/internal/api/scim/protocol/error.go
@@ -1,0 +1,24 @@
+package protocol
+
+import (
+	"strconv"
+)
+
+const SchemaError = "urn:ietf:params:scim:api:messages:2.0:Error"
+
+// Error is the error message form defined in RFC 7644, Section 3.12.
+type Error struct {
+	Schemas  []string `json:"schemas"`
+	ScimType string   `json:"scimType,omitempty"`
+	Detail   string   `json:"detail,omitempty"`
+	Status   string   `json:"status"`
+}
+
+func NewError(status int, scimType string, detail string) *Error {
+	return &Error{
+		Schemas:  []string{SchemaError},
+		ScimType: scimType,
+		Detail:   detail,
+		Status:   strconv.Itoa(status),
+	}
+}

--- a/internal/api/scim/protocol/error_test.go
+++ b/internal/api/scim/protocol/error_test.go
@@ -1,0 +1,47 @@
+package protocol
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewError(t *testing.T) {
+	t.Run("serializes to JSON correctly", func(t *testing.T) {
+		body, err := json.Marshal(NewError(http.StatusNotFound, "", "Endpoint or resource does not exist"))
+
+		require.NoError(t, err)
+		assert.JSONEq(t, `{
+			"schemas": [
+				"urn:ietf:params:scim:api:messages:2.0:Error"
+			],
+			"status": "404",
+			"detail": "Endpoint or resource does not exist"
+		}`, string(body))
+	})
+
+	t.Run("includes the scimType when one is given", func(t *testing.T) {
+		body, err := json.Marshal(NewError(http.StatusBadRequest, "invalidValue", "A required value was missing"))
+
+		require.NoError(t, err)
+		assert.JSONEq(t, `{
+			"schemas": ["urn:ietf:params:scim:api:messages:2.0:Error"],
+			"scimType": "invalidValue",
+			"detail": "A required value was missing",
+			"status": "400"
+		}`, string(body))
+	})
+
+	t.Run("omits the optional attributes when they are empty", func(t *testing.T) {
+		body, err := json.Marshal(NewError(http.StatusBadRequest, "", ""))
+
+		require.NoError(t, err)
+		assert.JSONEq(t, `{
+			"schemas": ["urn:ietf:params:scim:api:messages:2.0:Error"],
+			"status": "400"
+		}`, string(body))
+	})
+}

--- a/internal/api/scim/protocol/protocol.go
+++ b/internal/api/scim/protocol/protocol.go
@@ -12,3 +12,7 @@ const MediaType = "application/scim+json"
 func Send(w http.ResponseWriter, status int, obj any) error {
 	return shared.JSON(w).ContentType(MediaType).Status(status).Send(obj)
 }
+
+func SendError(w http.ResponseWriter, status int, scimType string, detail string) error {
+	return Send(w, status, NewError(status, scimType, detail))
+}

--- a/internal/api/scim/server.go
+++ b/internal/api/scim/server.go
@@ -20,17 +20,21 @@ func NewServer(config *conf.GlobalConfiguration) *Server {
 }
 
 func (srv *Server) ServiceProviderConfig(w http.ResponseWriter, r *http.Request) error {
-	return srv.notImplemented(w, r)
+	return srv.notImplemented(w)
 }
 
 func (srv *Server) ResourceTypes(w http.ResponseWriter, r *http.Request) error {
-	return srv.notImplemented(w, r)
+	return srv.notImplemented(w)
 }
 
 func (srv *Server) Schemas(w http.ResponseWriter, r *http.Request) error {
-	return srv.notImplemented(w, r)
+	return srv.notImplemented(w)
 }
 
-func (srv *Server) notImplemented(w http.ResponseWriter, r *http.Request) error {
-	return protocol.Send(w, http.StatusNotImplemented, nil)
+func (srv *Server) NotFound(w http.ResponseWriter, r *http.Request) error {
+	return protocol.SendError(w, http.StatusNotFound, "", "Endpoint or resource does not exist")
+}
+
+func (srv *Server) notImplemented(w http.ResponseWriter) error {
+	return protocol.SendError(w, http.StatusNotImplemented, "", "The request endpoint is not implemented")
 }

--- a/internal/api/scim/server_test.go
+++ b/internal/api/scim/server_test.go
@@ -1,12 +1,22 @@
 package scim
 
 import (
+	"embed"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
+
+//go:embed testdata/*
+var fixtures embed.FS
+
+func testFixture(t *testing.T, file string) string {
+	data, err := fixtures.ReadFile("testdata/" + file)
+	require.NoError(t, err)
+	return string(data)
+}
 
 func TestServer(t *testing.T) {
 	srv := NewServer(nil)
@@ -21,12 +31,24 @@ func TestServer(t *testing.T) {
 		{"Schemas", srv.Schemas},
 	} {
 		t.Run(tc.path, func(t *testing.T) {
-			r := httptest.NewRequest(http.MethodGet, "/scim/v2/"+tc.path, nil)
+			r := httptest.NewRequest(http.MethodGet, BasePath+"/"+tc.path, nil)
 			w := httptest.NewRecorder()
 
 			require.NoError(t, tc.handler(w, r))
-			require.Equal(t, w.Code, http.StatusNotImplemented)
+			require.Equal(t, http.StatusNotImplemented, w.Code)
 			require.Equal(t, "application/scim+json", w.Header().Get("Content-Type"))
+			require.JSONEq(t, testFixture(t, "not_implemented.json"), w.Body.String())
 		})
 	}
+
+	t.Run("NotFound", func(t *testing.T) {
+		r := httptest.NewRequest(http.MethodGet, BasePath+"/Unknown", nil)
+		w := httptest.NewRecorder()
+
+		require.NoError(t, srv.NotFound(w, r))
+
+		require.Equal(t, http.StatusNotFound, w.Code)
+		require.Equal(t, "application/scim+json", w.Header().Get("Content-Type"))
+		require.JSONEq(t, testFixture(t, "not_found.json"), w.Body.String())
+	})
 }

--- a/internal/api/scim/testdata/not_found.json
+++ b/internal/api/scim/testdata/not_found.json
@@ -1,0 +1,7 @@
+{
+  "schemas": [
+    "urn:ietf:params:scim:api:messages:2.0:Error"
+  ],
+  "status": "404",
+  "detail": "Endpoint or resource does not exist"
+}

--- a/internal/api/scim/testdata/not_implemented.json
+++ b/internal/api/scim/testdata/not_implemented.json
@@ -1,0 +1,7 @@
+{
+  "schemas": [
+    "urn:ietf:params:scim:api:messages:2.0:Error"
+  ],
+  "status": "501",
+  "detail": "The request endpoint is not implemented"
+}

--- a/internal/api/scim_test.go
+++ b/internal/api/scim_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	scimProtocol "github.com/supabase/auth/internal/api/scim/protocol"
 	"github.com/supabase/auth/internal/conf"
 	"github.com/supabase/auth/internal/storage"
 )
@@ -33,6 +34,16 @@ func TestSCIM(t *testing.T) {
 			require.Equal(t, "application/json", w.Header().Get("Content-Type"))
 			require.JSONEq(t, `{"code":404,"error_code":"feature_disabled","msg":"SCIM server is disabled"}`, w.Body.String())
 		}
+
+		t.Run("Unknown endpoints stay hidden while disabled", func(t *testing.T) {
+			r := httptest.NewRequest(http.MethodGet, "/scim/v2/Unknown", nil)
+			w := httptest.NewRecorder()
+
+			api.handler.ServeHTTP(w, r)
+
+			require.Equal(t, http.StatusNotFound, w.Code)
+			require.NotContains(t, w.Body.String(), scimProtocol.SchemaError)
+		})
 	})
 
 	t.Run("Can be enabled", func(t *testing.T) {
@@ -44,24 +55,45 @@ func TestSCIM(t *testing.T) {
 		require.NoError(t, err)
 
 		require.True(t, api.config.Experimental.ScimEnabled)
-		require.NotNil(t, api.scim)
-	})
 
-	for _, path := range scimPaths {
-		t.Run(path, func(t *testing.T) {
-			api, _, err := setupAPIForTestWithCallback(func(config *conf.GlobalConfiguration, conn *storage.Connection) {
-				if config != nil {
-					config.Experimental.ScimEnabled = true
-				}
+		for _, path := range scimPaths {
+			t.Run(path, func(t *testing.T) {
+				r := httptest.NewRequest(http.MethodGet, path, nil)
+				w := httptest.NewRecorder()
+
+				api.handler.ServeHTTP(w, r)
+
+				require.Equal(t, http.StatusNotImplemented, w.Code)
+				require.Equal(t, scimProtocol.MediaType, w.Header().Get("Content-Type"))
+				require.Contains(t, w.Body.String(), scimProtocol.SchemaError)
 			})
-			require.NoError(t, err)
+		}
 
-			r := httptest.NewRequest(http.MethodGet, path, nil)
+		t.Run("Returns a SCIM 404 for an unknown endpoint", func(t *testing.T) {
+			r := httptest.NewRequest(http.MethodGet, "/scim/v2/Unknown", nil)
 			w := httptest.NewRecorder()
 
 			api.handler.ServeHTTP(w, r)
 
-			require.Equal(t, w.Code, http.StatusNotImplemented)
+			require.Equal(t, http.StatusNotFound, w.Code)
+			require.Equal(t, scimProtocol.MediaType, w.Header().Get("Content-Type"))
+			require.Contains(t, w.Body.String(), scimProtocol.SchemaError)
 		})
-	}
+
+		t.Run("Returns a SCIM 405 for an unsupported method", func(t *testing.T) {
+			for _, method := range []string{http.MethodPost, http.MethodPut, http.MethodPatch, http.MethodDelete} {
+				for _, path := range scimPaths {
+					t.Run(method+" "+path, func(t *testing.T) {
+						r := httptest.NewRequest(method, path, nil)
+						w := httptest.NewRecorder()
+
+						api.handler.ServeHTTP(w, r)
+
+						require.Equal(t, http.StatusMethodNotAllowed, w.Code)
+						require.Equal(t, []string{http.MethodGet}, w.Header().Values("Allow"))
+					})
+				}
+			}
+		})
+	})
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature. Adds the RFC-7644 error form and returns it from the SCIM endpoints, so failures under `/scim/v2` answer in the shape a SCIM client expects.

Extracted from: https://github.com/supabase/auth/pull/2643

## What is the current behavior?

Nothing under `/scim/v2` produces a SCIM error. The discovery endpoints return a bare 501 with an empty body, an unknown path under `/scim/v2` falls to a plaintext 404, and a POST to a discovery endpoint gets a plaintext 405.

## What is the new behavior?

Adds the error message form from RFC-7644 and renders it as `application/scim+json`.
Handlers can now send a SCIM error by returning one.

* `GET /scim/v2/Unknown` -> 404 in SCIM form
* `POST|PUT|PATCH|DELETE` on a discovery endpoints -> 405 in SCIM form, with `Allow: GET`
* The three discovery endpoints still return 501, now with a SCIM body rather than an empty one

Example:

```bash
$ curl -i http://localhost:9999/scim/v2/Unknown
HTTP/1.1 404 Not Found
Content-Type: application/scim+json

{
  "schemas": [
    "urn:ietf:params:scim:api:messages:2.0:Error"
  ],
  "detail": "Endpoint or resource does not exist",
  "status": "404"
}
```

With `GOTRUE_EXPERIMENTAL_SCIM_ENABLED` unset, the routes still answer with the ordinary 404 (`feature_disabled`) rather than a SCIM error.

## Additional context
