### PR TITLE
chore: bump Go version to 1.26.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.12-alpine3.23 as build
+FROM golang:1.26.5-alpine3.23 as build
 ENV GO111MODULE=on
 ENV CGO_ENABLED=0
 ENV GOOS=linux

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM golang:1.25.12-alpine3.23
+FROM golang:1.26.5-alpine3.23
 ENV GO111MODULE=on
 ENV CGO_ENABLED=0
 ENV GOOS=linux

--- a/go.mod
+++ b/go.mod
@@ -186,6 +186,6 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-go 1.25.12
+go 1.26.5
 
 replace github.com/joho/godotenv => ./internal/forks/godotenv

--- a/go.sum
+++ b/go.sum
@@ -632,8 +632,6 @@ google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa h1:
 google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa/go.mod h1:q4lMZS6kskjT5HvCPrnnypcDPVJqT/f4nfxmkE7gryY=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa h1:mZHHdPZl0dbGHCflZgAq/Q468DWVFcU2whhB2KAo8fk=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa/go.mod h1:4Hqkh8ycfw05ld/3BWL7rJOSfebL2Q+DVDeRgYgxUU8=
-google.golang.org/grpc v1.81.1 h1:VnnIIZ88UzOOKLukQi+ImGz8O1Wdp8nAGGnvOfEIWQQ=
-google.golang.org/grpc v1.81.1/go.mod h1:xGH9GfzOyMTGIOXBJmXt+BX/V0kcdQbdcuwQ/zNw42I=
 google.golang.org/grpc v1.82.1 h1:NnAxzGRA0677vCa4BUkOAnO5+FfQqVl9iUXeD0IqcGE=
 google.golang.org/grpc v1.82.1/go.mod h1:yzTZ1TB1Z3SG+LIYaI+WiE8D5+PZ3ArnrSp8zF3+/ZA=
 google.golang.org/protobuf v1.36.11 h1:fV6ZwhNocDyBLK0dj+fg8ektcVegBBuEolpbTQyBNVE=

--- a/internal/forks/godotenv/go.mod
+++ b/internal/forks/godotenv/go.mod
@@ -1,3 +1,3 @@
 module github.com/joho/godotenv
 
-go 1.25.12
+go 1.26.5

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/supabase/auth/tools
 
-go 1.25.12
+go 1.26.5
 
 tool (
 	github.com/securego/gosec/v2/cmd/gosec


### PR DESCRIPTION
Sets the go version for all relevant locations to [1.26.5](https://go.dev/doc/go1.26). This has some nice features including an errors.AsType function which can replace some of our type switches while maintaining style.
