### PR TITLE
feat(scim): Add /ResourceTypes and /Schemas

### DIFF
--- a/internal/api/scim/protocol/list_response.go
+++ b/internal/api/scim/protocol/list_response.go
@@ -1,0 +1,25 @@
+package protocol
+
+const SchemaListResponse = "urn:ietf:params:scim:api:messages:2.0:ListResponse"
+
+type ListResponse[T any] struct {
+	Schemas      []string `json:"schemas"`
+	TotalResults int      `json:"totalResults"`
+	StartIndex   int      `json:"startIndex"`
+	ItemsPerPage int      `json:"itemsPerPage"`
+	Resources    []T      `json:"Resources"`
+}
+
+func NewListResponse[T any](resources []T) *ListResponse[T] {
+	if resources == nil {
+		resources = []T{}
+	}
+	n := len(resources)
+	return &ListResponse[T]{
+		Schemas:      []string{SchemaListResponse},
+		TotalResults: n,
+		StartIndex:   1,
+		ItemsPerPage: n,
+		Resources:    resources,
+	}
+}

--- a/internal/api/scim/protocol/list_response_test.go
+++ b/internal/api/scim/protocol/list_response_test.go
@@ -1,0 +1,53 @@
+package protocol
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+const emptyListResponse = `{
+	"schemas": ["urn:ietf:params:scim:api:messages:2.0:ListResponse"],
+	"totalResults": 0,
+	"startIndex": 1,
+	"itemsPerPage": 0,
+	"Resources": []
+}`
+
+func TestNewListResponse(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		resources []string
+		expected  string
+	}{
+		{
+			name:      "nil resources marshal to an empty array",
+			resources: nil,
+			expected:  emptyListResponse,
+		},
+		{
+			name:      "empty resources marshal to an empty array",
+			resources: []string{},
+			expected:  emptyListResponse,
+		},
+		{
+			name:      "populated resources are counted",
+			resources: []string{"a", "b"},
+			expected: `{
+				"schemas": ["urn:ietf:params:scim:api:messages:2.0:ListResponse"],
+				"totalResults": 2,
+				"startIndex": 1,
+				"itemsPerPage": 2,
+				"Resources": ["a", "b"]
+			}`,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			body, err := json.Marshal(NewListResponse(tc.resources))
+
+			require.NoError(t, err)
+			require.JSONEq(t, tc.expected, string(body))
+		})
+	}
+}

--- a/internal/api/scim/server.go
+++ b/internal/api/scim/server.go
@@ -29,17 +29,20 @@ func (srv *Server) ServiceProviderConfig(w http.ResponseWriter, r *http.Request)
 }
 
 func (srv *Server) ResourceTypes(w http.ResponseWriter, r *http.Request) error {
-	return srv.notImplemented(w)
+	return list(w, r, []any{})
 }
 
 func (srv *Server) Schemas(w http.ResponseWriter, r *http.Request) error {
-	return srv.notImplemented(w)
+	return list(w, r, []any{})
 }
 
 func (srv *Server) NotFound(w http.ResponseWriter, r *http.Request) error {
 	return protocol.SendError(w, http.StatusNotFound, "", "Endpoint or resource does not exist")
 }
 
-func (srv *Server) notImplemented(w http.ResponseWriter) error {
-	return protocol.SendError(w, http.StatusNotImplemented, "", "The request endpoint is not implemented")
+func list[T any](w http.ResponseWriter, r *http.Request, resources []T) error {
+	if r.URL.Query().Get("filter") != "" {
+		return protocol.SendError(w, http.StatusForbidden, "", "Filtering is not supported on this endpoint")
+	}
+	return protocol.Send(w, http.StatusOK, protocol.NewListResponse(resources))
 }

--- a/internal/api/scim/server.go
+++ b/internal/api/scim/server.go
@@ -41,7 +41,7 @@ func (srv *Server) NotFound(w http.ResponseWriter, r *http.Request) error {
 }
 
 func list[T any](w http.ResponseWriter, r *http.Request, resources []T) error {
-	if r.URL.Query().Get("filter") != "" {
+	if r.URL.Query().Has("filter") {
 		return protocol.SendError(w, http.StatusForbidden, "", "Filtering is not supported on this endpoint")
 	}
 	return protocol.Send(w, http.StatusOK, protocol.NewListResponse(resources))

--- a/internal/api/scim/server_test.go
+++ b/internal/api/scim/server_test.go
@@ -4,6 +4,7 @@ import (
 	"embed"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -59,9 +60,21 @@ func TestServer(t *testing.T) {
 			w := httptest.NewRecorder()
 
 			require.NoError(t, tc.handler(w, r))
-			require.Equal(t, http.StatusNotImplemented, w.Code)
-			require.Equal(t, "application/scim+json", w.Header().Get("Content-Type"))
-			require.JSONEq(t, testFixture(t, "not_implemented.json"), w.Body.String())
+
+			require.Equal(t, http.StatusOK, w.Code)
+			require.Equal(t, protocol.MediaType, w.Header().Get("Content-Type"))
+			require.JSONEq(t, testFixture(t, "empty_list_response.json"), w.Body.String())
+		})
+
+		t.Run(tc.path+" rejects filter query parameter", func(t *testing.T) {
+			filter := url.Values{"filter": {`name eq "User"`}}.Encode()
+			r := httptest.NewRequest(http.MethodGet, BasePath+"/"+tc.path+"?"+filter, nil)
+			w := httptest.NewRecorder()
+
+			require.NoError(t, tc.handler(w, r))
+
+			require.Equal(t, http.StatusForbidden, w.Code)
+			require.JSONEq(t, testFixture(t, "filter_forbidden.json"), w.Body.String())
 		})
 	}
 

--- a/internal/api/scim/testdata/empty_list_response.json
+++ b/internal/api/scim/testdata/empty_list_response.json
@@ -1,0 +1,9 @@
+{
+  "schemas": [
+    "urn:ietf:params:scim:api:messages:2.0:ListResponse"
+  ],
+  "totalResults": 0,
+  "startIndex": 1,
+  "itemsPerPage": 0,
+  "Resources": []
+}

--- a/internal/api/scim/testdata/filter_forbidden.json
+++ b/internal/api/scim/testdata/filter_forbidden.json
@@ -1,0 +1,7 @@
+{
+  "schemas": [
+    "urn:ietf:params:scim:api:messages:2.0:Error"
+  ],
+  "detail": "Filtering is not supported on this endpoint",
+  "status": "403"
+}

--- a/internal/api/scim_test.go
+++ b/internal/api/scim_test.go
@@ -3,6 +3,7 @@ package api
 import (
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -20,12 +21,6 @@ const (
 
 var scimPaths = []string{
 	scimServiceProviderConfigPath,
-	scimResourceTypesPath,
-	scimSchemasPath,
-}
-
-// scimNotImplementedPaths shrinks to empty as the endpoints land.
-var scimNotImplementedPaths = []string{
 	scimResourceTypesPath,
 	scimSchemasPath,
 }
@@ -80,14 +75,26 @@ func TestSCIM(t *testing.T) {
 			require.Contains(t, w.Body.String(), scimCore.SchemaServiceProviderConfig)
 		})
 
-		for _, path := range scimNotImplementedPaths {
+		for _, path := range []string{scimResourceTypesPath, scimSchemasPath} {
 			t.Run(path, func(t *testing.T) {
 				r := httptest.NewRequest(http.MethodGet, path, nil)
 				w := httptest.NewRecorder()
 
 				api.handler.ServeHTTP(w, r)
 
-				require.Equal(t, http.StatusNotImplemented, w.Code)
+				require.Equal(t, http.StatusOK, w.Code)
+				require.Equal(t, scimProtocol.MediaType, w.Header().Get("Content-Type"))
+				require.Contains(t, w.Body.String(), scimProtocol.SchemaListResponse)
+			})
+
+			t.Run(path+" rejects filter query parameter", func(t *testing.T) {
+				filter := url.Values{"filter": {`name eq "User"`}}.Encode()
+				r := httptest.NewRequest(http.MethodGet, path+"?"+filter, nil)
+				w := httptest.NewRecorder()
+
+				api.handler.ServeHTTP(w, r)
+
+				require.Equal(t, http.StatusForbidden, w.Code)
 				require.Equal(t, scimProtocol.MediaType, w.Header().Get("Content-Type"))
 				require.Contains(t, w.Body.String(), scimProtocol.SchemaError)
 			})


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature. `GET /scim/v2/ResourceTypes` and `GET /scim/v2/Schemas` return an empty `ListResponse`.

Extracted from https://github.com/supabase/auth/pull/2643

https://linear.app/supabase/issue/AUTH-1362/scim-discovery-endpoints

## What is the current behavior?

`ServiceProviderConfig` returns a real document, but `ResourceTypes` and `Schemas` still return 501 in the RFC 7644 error form.

## What is the new behavior?

Adds the query response form from RFC 7644, and both endpoints answer with an empty one. No resource types exist yet.

```bash
$ curl -s http://localhost:9999/scim/v2/Schemas | jq
{
  "schemas": [
    "urn:ietf:params:scim:api:messages:2.0:ListResponse"
  ],
  "totalResults": 0,
  "startIndex": 1,
  "itemsPerPage": 0,
  "Resources": []
}
```

Neither endpoint supports filtering. RFC 7644, Section 4:

> Query parameters described in Section 3.4.2, such as filtering, sorting, and
> pagination, SHALL be ignored. If a "filter" is provided, the service provider
> SHOULD respond with HTTP status code 403 (Forbidden) to ensure that clients
> cannot incorrectly assume that any matching conditions specified in a filter
> are true.

```bash
$ curl -s 'http://localhost:9999/scim/v2/Schemas?filter=name%20eq%20%22User%22' | jq
{
  "schemas": [
    "urn:ietf:params:scim:api:messages:2.0:Error"
  ],
  "detail": "Filtering is not supported on this endpoint",
  "status": "403"
}
```

## Additional context
