### PR TITLE
test: cover empty API external URL validation

### DIFF
--- a/internal/conf/configuration_test.go
+++ b/internal/conf/configuration_test.go
@@ -261,18 +261,16 @@ func TestValidate(t *testing.T) {
 	}
 	cases := []testCase{
 		{
+			val: &APIConfiguration{},
+			err: `parse "": empty url`,
+		},
+		{
 			val: &APIConfiguration{ExternalURL: "http://localhost"},
 		},
 		{
 			val: &APIConfiguration{ExternalURL: "invalid"},
 			err: `parse "invalid": invalid URI for request`,
 		},
-
-		{
-			val: &APIConfiguration{ExternalURL: "invalid"},
-			err: `parse "invalid": invalid URI for request`,
-		},
-
 		{
 			val: &CustomOAuthConfiguration{},
 		},


### PR DESCRIPTION
## What kind of change does this PR introduce?

Test improvement.

## What is the current behavior?

The test suite contains duplicate coverage for an invalid `APIConfiguration.ExternalURL` value but does not explicitly test the empty `ExternalURL` case.

## What is the new behavior?

Replaces the duplicate invalid URL test with a test that verifies an empty `ExternalURL` returns the expected validation error (`parse "": empty url`), while preserving coverage for valid and invalid URLs.

## Additional context

Verified with:

```sh
go test ./internal/conf -run '^TestValidate$'
```
