### PR TITLE
feat(scim): read-only Users (discovery, get-by-id, list)

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -457,7 +457,9 @@ func NewAPIWithVersion(globalConfig *conf.GlobalConfiguration, db *storage.Conne
 
 			r.Get("/ServiceProviderConfig", api.scim.ServiceProviderConfig)
 			r.Get("/ResourceTypes", api.scim.ResourceTypes)
+			r.Get("/ResourceTypes/{id}", api.scim.ResourceTypeByID)
 			r.Get("/Schemas", api.scim.Schemas)
+			r.Get("/Schemas/{id}", api.scim.SchemaByID)
 		})
 	})
 

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -48,6 +48,7 @@ type API struct {
 	hibpClient   *hibp.PwnedClient
 	oauthServer  *oauthserver.Server
 	scim         *scim.Server
+	scimUsers    scim.UserRepository
 	tokenService *tokens.Service
 	mailer       mailer.Mailer
 	oidcCache    *provider.OIDCProviderCache
@@ -129,6 +130,9 @@ func NewAPIWithVersion(globalConfig *conf.GlobalConfiguration, db *storage.Conne
 		tc := templatemailer.NewCache()
 		api.mailer = templatemailer.FromConfig(globalConfig, tc)
 	}
+	if api.scimUsers == nil {
+		api.scimUsers = scim.NewUserMemoryRepository()
+	}
 
 	// Connect token service to API's time function (supports test overrides)
 	api.tokenService.SetTimeFunc(api.Now)
@@ -138,7 +142,7 @@ func NewAPIWithVersion(globalConfig *conf.GlobalConfiguration, db *storage.Conne
 		api.oauthServer = oauthserver.NewServer(globalConfig, db, api.tokenService)
 	}
 
-	api.scim = scim.NewServer(globalConfig)
+	api.scim = scim.NewServer(globalConfig, db, api.scimUsers)
 
 	if api.config.Password.HIBP.Enabled {
 		httpClient := &http.Client{
@@ -460,6 +464,11 @@ func NewAPIWithVersion(globalConfig *conf.GlobalConfiguration, db *storage.Conne
 			r.Get("/ResourceTypes/{id}", api.scim.ResourceTypeByID)
 			r.Get("/Schemas", api.scim.Schemas)
 			r.Get("/Schemas/{id}", api.scim.SchemaByID)
+
+			// TEMPORARY: Use admin token and x-scim-provider-id header until SCIM tokens land
+			users := r.With(api.requireAdminCredentials).WithBypass(api.scim.Tenant)
+			users.Get("/Users", api.scim.Users)
+			users.Get("/Users/{id}", api.scim.UserByID)
 		})
 	})
 

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -43,7 +43,7 @@ func setupAPIForTest(opts ...Option) (*API, *conf.GlobalConfiguration, error) {
 	return NewAPIWithVersion(config, conn, apiTestVersion, opts...), config, nil
 }
 
-func setupAPIForTestWithCallback(cb func(*conf.GlobalConfiguration, *storage.Connection)) (*API, *conf.GlobalConfiguration, error) {
+func setupAPIForTestWithCallback(cb func(*conf.GlobalConfiguration, *storage.Connection), opts ...Option) (*API, *conf.GlobalConfiguration, error) {
 	config, err := confload.LoadGlobal(apiTestConfig)
 	if err != nil {
 		return nil, nil, err
@@ -63,7 +63,8 @@ func setupAPIForTestWithCallback(cb func(*conf.GlobalConfiguration, *storage.Con
 	}
 
 	limiterOpts := apilimiter.New(config)
-	return NewAPIWithVersion(config, conn, apiTestVersion, WithLimiter(limiterOpts)), config, nil
+	opts = append([]Option{WithLimiter(limiterOpts)}, opts...)
+	return NewAPIWithVersion(config, conn, apiTestVersion, opts...), config, nil
 }
 
 func TestEmailEnabledByDefault(t *testing.T) {

--- a/internal/api/options.go
+++ b/internal/api/options.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"github.com/supabase/auth/internal/api/apilimiter"
+	"github.com/supabase/auth/internal/api/scim"
 	"github.com/supabase/auth/internal/mailer"
 	"github.com/supabase/auth/internal/security"
 	"github.com/supabase/auth/internal/tokens"
@@ -36,5 +37,11 @@ func WithCaptchaVerifier(v security.CaptchaVerifier) Option {
 func WithLimiter(v *apilimiter.Limiter) Option {
 	return optionFunc(func(a *API) {
 		a.limiterOpts = v
+	})
+}
+
+func WithSCIMUserRepository(repo scim.UserRepository) Option {
+	return optionFunc(func(a *API) {
+		a.scimUsers = repo
 	})
 }

--- a/internal/api/scim/core/attribute.go
+++ b/internal/api/scim/core/attribute.go
@@ -1,0 +1,115 @@
+package core
+
+// AttributeType is the data type of an attribute, per RFC 7643, Section 7.
+type AttributeType string
+
+const (
+	TypeString    AttributeType = "string"
+	TypeBoolean   AttributeType = "boolean"
+	TypeDecimal   AttributeType = "decimal"
+	TypeInteger   AttributeType = "integer"
+	TypeDateTime  AttributeType = "dateTime"
+	TypeReference AttributeType = "reference"
+	TypeComplex   AttributeType = "complex"
+)
+
+// Mutability states when an attribute may be (re)defined.
+type Mutability string
+
+const (
+	MutabilityReadOnly  Mutability = "readOnly"
+	MutabilityReadWrite Mutability = "readWrite"
+	MutabilityImmutable Mutability = "immutable"
+	MutabilityWriteOnly Mutability = "writeOnly"
+)
+
+// Returned states when an attribute is included in a response.
+type Returned string
+
+const (
+	ReturnedAlways  Returned = "always"
+	ReturnedNever   Returned = "never"
+	ReturnedDefault Returned = "default"
+	ReturnedRequest Returned = "request"
+)
+
+// Uniqueness states how the service provider enforces uniqueness.
+type Uniqueness string
+
+const (
+	UniquenessNone   Uniqueness = "none"
+	UniquenessServer Uniqueness = "server"
+	UniquenessGlobal Uniqueness = "global"
+)
+
+// The reference types of RFC 7643, Section 7 that are not resource types.
+const (
+	ReferenceExternal = "external"
+	ReferenceURI      = "uri"
+)
+
+// Attribute describes one attribute of a schema, per RFC 7643, Section 7.
+type Attribute struct {
+	Name            string        `json:"name"`
+	Type            AttributeType `json:"type"`
+	MultiValued     bool          `json:"multiValued"`
+	Description     string        `json:"description"`
+	Required        bool          `json:"required"`
+	CanonicalValues []string      `json:"canonicalValues,omitempty"`
+	CaseExact       bool          `json:"caseExact"`
+	Mutability      Mutability    `json:"mutability"`
+	Returned        Returned      `json:"returned"`
+	Uniqueness      Uniqueness    `json:"uniqueness"`
+	ReferenceTypes  []string      `json:"referenceTypes,omitempty"`
+	SubAttributes   []*Attribute  `json:"subAttributes,omitempty"`
+}
+
+func NewAttribute(name string, attributeType AttributeType, description string) *Attribute {
+	return &Attribute{
+		Name:        name,
+		Type:        attributeType,
+		Description: description,
+		Mutability:  MutabilityReadWrite,
+		Returned:    ReturnedDefault,
+		Uniqueness:  UniquenessNone,
+	}
+}
+
+func (a *Attribute) AsRequired() *Attribute {
+	a.Required = true
+	return a
+}
+
+func (a *Attribute) AsMultiValued() *Attribute {
+	a.MultiValued = true
+	return a
+}
+
+func (a *Attribute) AsCaseExact() *Attribute {
+	a.CaseExact = true
+	return a
+}
+
+// Suggesting sets "canonicalValues", the values a client may send for this
+// attribute, e.g. "work" and "home".
+func (a *Attribute) Suggesting(values ...string) *Attribute {
+	a.CanonicalValues = values
+	return a
+}
+
+// Referencing sets "referenceTypes", the resource types a reference attribute
+// may point at, either by name or as ReferenceExternal or ReferenceURI.
+func (a *Attribute) Referencing(referenceTypes ...string) *Attribute {
+	a.ReferenceTypes = referenceTypes
+	return a
+}
+
+func (a *Attribute) UniqueOn(uniqueness Uniqueness) *Attribute {
+	a.Uniqueness = uniqueness
+	return a
+}
+
+func (a *Attribute) With(subAttributes ...*Attribute) *Attribute {
+	a.SubAttributes = subAttributes
+	return a
+}

--- a/internal/api/scim/core/attribute_test.go
+++ b/internal/api/scim/core/attribute_test.go
@@ -1,0 +1,20 @@
+package core
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAttribute(t *testing.T) {
+	t.Run("suggests the canonical values a client may send", func(t *testing.T) {
+		attribute := NewAttribute("type", TypeString, "A label indicating the attribute's function.").
+			Suggesting("work", "home", "other")
+
+		body, err := json.Marshal(attribute)
+
+		require.NoError(t, err)
+		require.Contains(t, string(body), `"canonicalValues":["work","home","other"]`)
+	})
+}

--- a/internal/api/scim/core/endpoints.go
+++ b/internal/api/scim/core/endpoints.go
@@ -1,6 +1,0 @@
-package core
-
-// The resource endpoints of RFC 7644, Section 3.2, relative to the base URL
-const (
-	EndpointServiceProviderConfig = "/ServiceProviderConfig"
-)

--- a/internal/api/scim/core/kind.go
+++ b/internal/api/scim/core/kind.go
@@ -1,0 +1,24 @@
+package core
+
+import "strings"
+
+type Kind struct {
+	Name     ResourceTypeName
+	Endpoint string
+}
+
+var (
+	KindGroup                 = Kind{Name: "Group", Endpoint: "/Groups"}
+	KindResourceType          = Kind{Name: "ResourceType", Endpoint: "/ResourceTypes"}
+	KindSchema                = Kind{Name: "Schema", Endpoint: "/Schemas"}
+	KindServiceProviderConfig = Kind{Name: "ServiceProviderConfig", Endpoint: "/ServiceProviderConfig"}
+	KindUser                  = Kind{Name: "User", Endpoint: "/Users"}
+)
+
+func (k Kind) Location(baseURL string) string {
+	return Join(baseURL, k.Endpoint)
+}
+
+func Join(base, segment string) string {
+	return strings.TrimSuffix(base, "/") + "/" + strings.TrimPrefix(segment, "/")
+}

--- a/internal/api/scim/core/kind_test.go
+++ b/internal/api/scim/core/kind_test.go
@@ -1,0 +1,19 @@
+package core
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestKindLocation(t *testing.T) {
+	baseURL := "http://localhost:9999/scim/v2"
+
+	t.Run("locates the collection under the base URL", func(t *testing.T) {
+		require.Equal(t, baseURL+"/Users", KindUser.Location(baseURL))
+	})
+
+	t.Run("does not double the separator when the base URL ends in a slash", func(t *testing.T) {
+		require.Equal(t, baseURL+"/Users", KindUser.Location(baseURL+"/"))
+	})
+}

--- a/internal/api/scim/core/meta.go
+++ b/internal/api/scim/core/meta.go
@@ -1,14 +1,32 @@
 package core
 
+import "time"
+
 // Meta is the resource metadata common attribute defined in RFC 7643, Section 3.1.
 type Meta struct {
 	ResourceType ResourceTypeName `json:"resourceType"`
+	Created      time.Time        `json:"created,omitzero"`
+	LastModified time.Time        `json:"lastModified,omitzero"`
 	Location     string           `json:"location,omitempty"`
+	Version      string           `json:"version,omitempty"`
 }
 
-func NewMeta(baseURL string, resourceType ResourceTypeName, endpoint string) Meta {
+func NewMeta(baseURL string, kind Kind) Meta {
 	return Meta{
-		ResourceType: resourceType,
-		Location:     baseURL + endpoint,
+		ResourceType: kind.Name,
+		Location:     kind.Location(baseURL),
 	}
+}
+
+func NewMetaFor(baseURL string, kind Kind, r Resource) Meta {
+	created, updated := r.Timestamps()
+	return NewMetaForID(baseURL, kind, r.ResourceID(), created, updated)
+}
+
+func NewMetaForID(baseURL string, kind Kind, id string, created, updated time.Time) Meta {
+	meta := NewMeta(baseURL, kind)
+	meta.Location = Join(meta.Location, id)
+	meta.Created, meta.LastModified = created.UTC(), updated.UTC()
+
+	return meta
 }

--- a/internal/api/scim/core/meta_test.go
+++ b/internal/api/scim/core/meta_test.go
@@ -3,37 +3,62 @@ package core
 import (
 	"encoding/json"
 	"testing"
+	"time"
 
+	"github.com/gofrs/uuid"
 	"github.com/stretchr/testify/require"
 )
 
-func TestNewMeta(t *testing.T) {
-	t.Run("locates the resource at its endpoint", func(t *testing.T) {
-		meta := NewMeta("http://localhost:9999/scim/v2", ResourceTypeServiceProviderConfig, EndpointServiceProviderConfig)
-
-		require.Equal(t, ResourceTypeServiceProviderConfig, meta.ResourceType)
-		require.Equal(t, "http://localhost:9999/scim/v2/ServiceProviderConfig", meta.Location)
-	})
+type exampleUser struct {
+	id               string
+	created, updated time.Time
 }
 
-func TestMeta(t *testing.T) {
-	t.Run("serializes to JSON correctly", func(t *testing.T) {
-		body, err := json.Marshal(Meta{
-			ResourceType: ResourceTypeServiceProviderConfig,
-			Location:     "http://localhost:9999/scim/v2/ServiceProviderConfig",
-		})
+func (s exampleUser) ResourceID() string                       { return s.id }
+func (s exampleUser) Timestamps() (created, updated time.Time) { return s.created, s.updated }
 
-		require.NoError(t, err)
-		require.JSONEq(t, `{
-			"resourceType": "ServiceProviderConfig",
-			"location": "http://localhost:9999/scim/v2/ServiceProviderConfig"
-		}`, string(body))
+func TestMeta(t *testing.T) {
+	baseURL := "http://localhost:9999/scim/v2"
+
+	t.Run("NewMeta", func(t *testing.T) {
+		meta := NewMeta(baseURL, KindServiceProviderConfig)
+
+		require.Equal(t, KindServiceProviderConfig.Name, meta.ResourceType)
+		require.Equal(t, baseURL+"/ServiceProviderConfig", meta.Location)
+		require.Zero(t, meta.Created)
+		require.Zero(t, meta.LastModified)
 	})
 
-	t.Run("omits the location when it is empty", func(t *testing.T) {
-		body, err := json.Marshal(Meta{ResourceType: ResourceTypeServiceProviderConfig})
+	t.Run("NewMetaFor", func(t *testing.T) {
+		resource := exampleUser{
+			id:      uuid.Must(uuid.NewV4()).String(),
+			created: time.Date(2026, 7, 21, 19, 41, 41, 0, time.UTC),
+			updated: time.Date(2026, 7, 22, 8, 12, 3, 0, time.UTC),
+		}
+		meta := NewMetaFor(baseURL, KindUser, resource)
 
-		require.NoError(t, err)
-		require.JSONEq(t, `{"resourceType": "ServiceProviderConfig"}`, string(body))
+		require.Equal(t, KindUser.Name, meta.ResourceType)
+		require.Equal(t, baseURL+"/Users/"+resource.id, meta.Location)
+		require.Equal(t, resource.created, meta.Created)
+		require.Equal(t, resource.updated, meta.LastModified)
+	})
+
+	t.Run("json.Marshal", func(t *testing.T) {
+		t.Run("serializes to JSON correctly", func(t *testing.T) {
+			body, err := json.Marshal(NewMeta(baseURL, KindServiceProviderConfig))
+
+			require.NoError(t, err)
+			require.JSONEq(t, `{
+				"resourceType": "ServiceProviderConfig",
+				"location": "http://localhost:9999/scim/v2/ServiceProviderConfig"
+			}`, string(body))
+		})
+
+		t.Run("omits the location when it is empty", func(t *testing.T) {
+			body, err := json.Marshal(Meta{ResourceType: "ServiceProviderConfig"})
+
+			require.NoError(t, err)
+			require.JSONEq(t, `{"resourceType": "ServiceProviderConfig"}`, string(body))
+		})
 	})
 }

--- a/internal/api/scim/core/resource.go
+++ b/internal/api/scim/core/resource.go
@@ -1,0 +1,8 @@
+package core
+
+import "time"
+
+type Resource interface {
+	ResourceID() string
+	Timestamps() (created, updated time.Time)
+}

--- a/internal/api/scim/core/resource_type.go
+++ b/internal/api/scim/core/resource_type.go
@@ -1,0 +1,48 @@
+package core
+
+import "time"
+
+// SchemaExtension is a schema that extends a resource type, per RFC 7643, Section 6.
+type SchemaExtension struct {
+	Schema   SchemaURI `json:"schema"`
+	Required bool      `json:"required"`
+}
+
+// ResourceType is the resource type metadata defined in RFC 7643, Section 6.
+type ResourceType struct {
+	Schemas          []SchemaURI       `json:"schemas,omitempty"`
+	ID               ResourceTypeName  `json:"id,omitempty"`
+	Name             ResourceTypeName  `json:"name"`
+	Description      string            `json:"description,omitempty"`
+	Endpoint         string            `json:"endpoint"`
+	Schema           SchemaURI         `json:"schema,omitempty"`
+	SchemaExtensions []SchemaExtension `json:"schemaExtensions,omitempty"`
+	Meta             Meta              `json:"meta,omitzero"`
+}
+
+func NewResourceType(baseURL string, kind Kind, schema *Schema) *ResourceType {
+	resourceType := &ResourceType{
+		Schemas:     []SchemaURI{SchemaResourceType},
+		ID:          kind.Name,
+		Name:        kind.Name,
+		Description: schema.Description,
+		Endpoint:    kind.Endpoint,
+		Schema:      schema.ID,
+	}
+	resourceType.Meta = NewMetaFor(baseURL, KindResourceType, resourceType)
+
+	return resourceType
+}
+
+func (r *ResourceType) Extend(extensions ...SchemaExtension) *ResourceType {
+	r.SchemaExtensions = append(r.SchemaExtensions, extensions...)
+	return r
+}
+
+func (r ResourceType) Kind() Kind {
+	return Kind{Name: r.Name, Endpoint: r.Endpoint}
+}
+
+func (r *ResourceType) ResourceID() string { return string(r.ID) }
+
+func (r *ResourceType) Timestamps() (created, updated time.Time) { return }

--- a/internal/api/scim/core/resource_type_test.go
+++ b/internal/api/scim/core/resource_type_test.go
@@ -1,0 +1,41 @@
+package core
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestResourceType(t *testing.T) {
+	baseURL := "http://localhost:9999/scim/v2"
+
+	t.Run("NewResourceType", func(t *testing.T) {
+		schema := NewSchema(baseURL, SchemaUser, KindUser.Name).Describe("User Account")
+
+		resourceType := NewResourceType(baseURL, KindUser, schema)
+
+		t.Run("takes its identity and description from the schema", func(t *testing.T) {
+			require.Equal(t, KindUser.Name, resourceType.ID)
+			require.Equal(t, KindUser.Name, resourceType.Name)
+			require.Equal(t, "User Account", resourceType.Description)
+			require.Equal(t, SchemaUser, resourceType.Schema)
+		})
+
+		t.Run("locates itself under the ResourceTypes endpoint", func(t *testing.T) {
+			require.Equal(t, KindResourceType.Name, resourceType.Meta.ResourceType)
+			require.Equal(t, baseURL+"/ResourceTypes/User", resourceType.Meta.Location)
+		})
+
+		t.Run("declares the schema extensions it was given", func(t *testing.T) {
+			extended := NewResourceType(baseURL, KindUser, schema).
+				Extend(SchemaExtension{Schema: SchemaEnterpriseUser, Required: true})
+
+			body, err := json.Marshal(extended)
+
+			require.NoError(t, err)
+			require.Contains(t, string(body),
+				`"schemaExtensions":[{"schema":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User","required":true}]`)
+		})
+	})
+}

--- a/internal/api/scim/core/schema.go
+++ b/internal/api/scim/core/schema.go
@@ -1,0 +1,38 @@
+package core
+
+import "time"
+
+// Schema is the schema definition resource of RFC 7643, Section 7.
+type Schema struct {
+	Schemas     []SchemaURI      `json:"schemas"`
+	ID          SchemaURI        `json:"id"`
+	Name        ResourceTypeName `json:"name"`
+	Description string           `json:"description"`
+	Attributes  []*Attribute     `json:"attributes"`
+	Meta        Meta             `json:"meta"`
+}
+
+func NewSchema(baseURL string, id SchemaURI, name ResourceTypeName) *Schema {
+	schema := &Schema{
+		Schemas: []SchemaURI{SchemaSchema},
+		ID:      id,
+		Name:    name,
+	}
+	schema.Meta = NewMetaFor(baseURL, KindSchema, schema)
+
+	return schema
+}
+
+func (s *Schema) Describe(description string) *Schema {
+	s.Description = description
+	return s
+}
+
+func (s *Schema) With(attributes ...*Attribute) *Schema {
+	s.Attributes = attributes
+	return s
+}
+
+func (s *Schema) ResourceID() string { return string(s.ID) }
+
+func (s *Schema) Timestamps() (created, updated time.Time) { return }

--- a/internal/api/scim/core/schemas.go
+++ b/internal/api/scim/core/schemas.go
@@ -2,12 +2,15 @@ package core
 
 // The schema URIs of RFC 7643
 const (
-	schemaRoot = "urn:ietf:params:scim:schemas"
-	schemaCore = schemaRoot + ":core:2.0"
+	schemaRoot      = "urn:ietf:params:scim:schemas"
+	schemaCore      = schemaRoot + ":core:2.0"
+	schemaExtension = schemaRoot + ":extension"
 
+	SchemaEnterpriseUser SchemaURI = schemaExtension + ":enterprise:2.0:User"
+
+	SchemaGroup                 SchemaURI = schemaCore + ":Group"
+	SchemaResourceType          SchemaURI = schemaCore + ":ResourceType"
+	SchemaSchema                SchemaURI = schemaCore + ":Schema"
 	SchemaServiceProviderConfig SchemaURI = schemaCore + ":ServiceProviderConfig"
-)
-
-const (
-	ResourceTypeServiceProviderConfig ResourceTypeName = "ServiceProviderConfig"
+	SchemaUser                  SchemaURI = schemaCore + ":User"
 )

--- a/internal/api/scim/core/service_provider_config.go
+++ b/internal/api/scim/core/service_provider_config.go
@@ -17,17 +17,22 @@ type FilterFeature struct {
 
 type AuthenticationSchemeType string
 
+// The authentication scheme types of RFC 7643, Section 5.
 const (
+	AuthenticationSchemeOAuth            AuthenticationSchemeType = "oauth"
+	AuthenticationSchemeOAuth2           AuthenticationSchemeType = "oauth2"
 	AuthenticationSchemeOAuthBearerToken AuthenticationSchemeType = "oauthbearertoken"
+	AuthenticationSchemeHTTPBasic        AuthenticationSchemeType = "httpbasic"
+	AuthenticationSchemeHTTPDigest       AuthenticationSchemeType = "httpdigest"
 )
 
-// AuthenticationScheme is the authentication scheme of RFC 7643, Section 5.
 type AuthenticationScheme struct {
-	Type        AuthenticationSchemeType `json:"type"`
-	Name        string                   `json:"name"`
-	Description string                   `json:"description"`
-	SpecURI     string                   `json:"specUri,omitempty"`
-	Primary     bool                     `json:"primary"`
+	Type             AuthenticationSchemeType `json:"type"`
+	Name             string                   `json:"name"`
+	Description      string                   `json:"description"`
+	SpecURI          string                   `json:"specUri,omitempty"`
+	DocumentationURI string                   `json:"documentationUri,omitempty"`
+	Primary          bool                     `json:"primary"`
 }
 
 func NewOAuthBearerToken() *AuthenticationScheme {
@@ -47,6 +52,7 @@ func (scheme *AuthenticationScheme) AsPrimary() *AuthenticationScheme {
 // ServiceProviderConfig is the schema defined in RFC 7643, Section 5.
 type ServiceProviderConfig struct {
 	Schemas               []SchemaURI             `json:"schemas"`
+	DocumentationURI      string                  `json:"documentationUri,omitempty"`
 	Patch                 SupportedFeature        `json:"patch"`
 	Bulk                  BulkFeature             `json:"bulk"`
 	Filter                FilterFeature           `json:"filter"`
@@ -61,10 +67,9 @@ func NewServiceProviderConfig(baseURL string, schemes ...*AuthenticationScheme) 
 	if schemes == nil {
 		schemes = []*AuthenticationScheme{}
 	}
-
 	return &ServiceProviderConfig{
 		Schemas:               []SchemaURI{SchemaServiceProviderConfig},
 		AuthenticationSchemes: schemes,
-		Meta:                  NewMeta(baseURL, ResourceTypeServiceProviderConfig, EndpointServiceProviderConfig),
+		Meta:                  NewMeta(baseURL, KindServiceProviderConfig),
 	}
 }

--- a/internal/api/scim/core/service_provider_config_test.go
+++ b/internal/api/scim/core/service_provider_config_test.go
@@ -23,8 +23,8 @@ func TestNewServiceProviderConfig(t *testing.T) {
 
 		config := NewServiceProviderConfig(baseURL)
 
-		require.Equal(t, ResourceTypeServiceProviderConfig, config.Meta.ResourceType)
-		require.Equal(t, baseURL+EndpointServiceProviderConfig, config.Meta.Location)
+		require.Equal(t, ResourceTypeName("ServiceProviderConfig"), config.Meta.ResourceType)
+		require.Equal(t, baseURL+"/ServiceProviderConfig", config.Meta.Location)
 	})
 
 	t.Run("supports none of the optional protocol features", func(t *testing.T) {

--- a/internal/api/scim/core/user.go
+++ b/internal/api/scim/core/user.go
@@ -1,0 +1,26 @@
+package core
+
+type Email struct {
+	Value   string `json:"value"`
+	Primary bool   `json:"primary"`
+}
+
+// Name holds the components of the user's name, per RFC 7643, Section 4.1.1.
+type Name struct {
+	Formatted  string `json:"formatted,omitempty"`
+	FamilyName string `json:"familyName,omitempty"`
+	GivenName  string `json:"givenName,omitempty"`
+	MiddleName string `json:"middleName,omitempty"`
+}
+
+// User is the core User resource defined in RFC 7643, Section 4.1.
+type User struct {
+	Schemas    []SchemaURI `json:"schemas"`
+	ID         string      `json:"id"`
+	ExternalID string      `json:"externalId,omitempty"`
+	UserName   string      `json:"userName"`
+	Name       Name        `json:"name,omitzero"`
+	Emails     []Email     `json:"emails,omitempty"`
+	Active     *bool       `json:"active,omitempty"`
+	Meta       Meta        `json:"meta"`
+}

--- a/internal/api/scim/core/user_test.go
+++ b/internal/api/scim/core/user_test.go
@@ -1,0 +1,61 @@
+package core
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestUser(t *testing.T) {
+	created := time.Date(2026, 7, 21, 19, 41, 41, 0, time.UTC)
+	lastModified := time.Date(2026, 7, 22, 8, 12, 3, 0, time.UTC)
+
+	user := User{
+		Schemas:    []SchemaURI{SchemaUser},
+		ID:         "2819c223-7f76-453a-919d-413861904646",
+		ExternalID: "701984",
+		UserName:   "bjensen@example.com",
+		Name:       Name{Formatted: "Ms. Barbara J Jensen", FamilyName: "Jensen", GivenName: "Barbara"},
+		Emails:     []Email{{Value: "bjensen@example.com", Primary: true}},
+		Active:     new(true),
+		Meta: Meta{
+			ResourceType: KindUser.Name,
+			Created:      created,
+			LastModified: lastModified,
+			Location:     "http://localhost:9999/scim/v2/Users/2819c223-7f76-453a-919d-413861904646",
+		},
+	}
+
+	t.Run("serializes to JSON correctly", func(t *testing.T) {
+		body, err := json.Marshal(user)
+
+		require.NoError(t, err)
+		require.JSONEq(t, `{
+			"schemas": ["urn:ietf:params:scim:schemas:core:2.0:User"],
+			"id": "2819c223-7f76-453a-919d-413861904646",
+			"externalId": "701984",
+			"userName": "bjensen@example.com",
+			"name": {"formatted": "Ms. Barbara J Jensen", "familyName": "Jensen", "givenName": "Barbara"},
+			"emails": [{"value": "bjensen@example.com", "primary": true}],
+			"active": true,
+			"meta": {
+				"resourceType": "User",
+				"created": "2026-07-21T19:41:41Z",
+				"lastModified": "2026-07-22T08:12:03Z",
+				"location": "http://localhost:9999/scim/v2/Users/2819c223-7f76-453a-919d-413861904646"
+			}
+		}`, string(body))
+	})
+
+	t.Run("round-trips a deactivated user", func(t *testing.T) {
+		var decoded User
+		require.NoError(t, json.Unmarshal([]byte(`{"userName":"bjensen","active":false}`), &decoded))
+
+		body, err := json.Marshal(decoded)
+
+		require.NoError(t, err)
+		require.Contains(t, string(body), `"active":false`)
+	})
+}

--- a/internal/api/scim/memory_repository.go
+++ b/internal/api/scim/memory_repository.go
@@ -1,0 +1,71 @@
+package scim
+
+import (
+	"context"
+	"maps"
+	"slices"
+	"sync"
+)
+
+type MemoryRepository[T any] struct {
+	mu       sync.RWMutex
+	byTenant map[string]map[string]T
+	idOf     func(T) string
+}
+
+func NewMemoryRepository[T any](idOf func(T) string) *MemoryRepository[T] {
+	return &MemoryRepository[T]{
+		byTenant: make(map[string]map[string]T),
+		idOf:     idOf,
+	}
+}
+
+func (r *MemoryRepository[T]) Put(tenant string, item T) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	items, ok := r.byTenant[tenant]
+	if !ok {
+		items = make(map[string]T)
+		r.byTenant[tenant] = items
+	}
+	items[r.idOf(item)] = item
+}
+
+func (r *MemoryRepository[T]) Get(ctx context.Context, tenant, id string) (T, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	if item, ok := r.byTenant[tenant][id]; ok {
+		return item, nil
+	}
+
+	var zero T
+	return zero, ErrNotFound
+}
+
+func (r *MemoryRepository[T]) List(ctx context.Context, tenant string, count, offset int) ([]T, int, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	items := r.byTenant[tenant]
+	total := len(items)
+	if count <= 0 {
+		return nil, total, nil
+	}
+
+	if offset < 0 {
+		offset = 0
+	}
+	if offset >= total {
+		return nil, total, nil
+	}
+
+	ids := slices.Sorted(maps.Keys(items))
+	end := min(offset+count, total)
+	page := make([]T, 0, end-offset)
+	for _, id := range ids[offset:end] {
+		page = append(page, items[id])
+	}
+	return page, total, nil
+}

--- a/internal/api/scim/memory_repository_test.go
+++ b/internal/api/scim/memory_repository_test.go
@@ -1,0 +1,80 @@
+package scim
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/supabase/auth/internal/api/scim/core"
+)
+
+func user(id string) *core.User {
+	return &core.User{ID: id, UserName: id + "@example.com"}
+}
+
+func TestMemoryRepositoryGet(t *testing.T) {
+	ctx := context.Background()
+	repo := NewUserMemoryRepository()
+	repo.Put("tenant-a", user("1"))
+
+	t.Run("returns a stored resource", func(t *testing.T) {
+		got, err := repo.Get(ctx, "tenant-a", "1")
+		require.NoError(t, err)
+		require.Equal(t, "1", got.ID)
+	})
+
+	t.Run("reports an unknown id as not found", func(t *testing.T) {
+		got, err := repo.Get(ctx, "tenant-a", "missing")
+		require.Nil(t, got)
+		require.True(t, errors.Is(err, ErrNotFound))
+	})
+
+	t.Run("does not reach across tenants", func(t *testing.T) {
+		got, err := repo.Get(ctx, "tenant-b", "1")
+		require.Nil(t, got)
+		require.True(t, errors.Is(err, ErrNotFound))
+	})
+}
+
+func TestMemoryRepositoryList(t *testing.T) {
+	ctx := context.Background()
+	repo := NewUserMemoryRepository()
+	for _, id := range []string{"3", "1", "2"} {
+		repo.Put("tenant-a", user(id))
+	}
+	repo.Put("tenant-b", user("9"))
+
+	ids := func(users []*core.User) []string {
+		out := make([]string, 0, len(users))
+		for _, u := range users {
+			out = append(out, u.ID)
+		}
+		return out
+	}
+
+	t.Run("returns every resource with the total", func(t *testing.T) {
+		users, total, err := repo.List(ctx, "tenant-a", 100, 0)
+		require.NoError(t, err)
+		require.Equal(t, 3, total)
+		require.Equal(t, []string{"1", "2", "3"}, ids(users))
+	})
+
+	t.Run("walks the collection in a stable order", func(t *testing.T) {
+		first, _, err := repo.List(ctx, "tenant-a", 2, 0)
+		require.NoError(t, err)
+		second, total, err := repo.List(ctx, "tenant-a", 2, 2)
+		require.NoError(t, err)
+
+		require.Equal(t, 3, total)
+		require.Equal(t, []string{"1", "2"}, ids(first))
+		require.Equal(t, []string{"3"}, ids(second))
+	})
+
+	t.Run("scopes the collection to one tenant", func(t *testing.T) {
+		users, total, err := repo.List(ctx, "tenant-b", 100, 0)
+		require.NoError(t, err)
+		require.Equal(t, 1, total)
+		require.Equal(t, []string{"9"}, ids(users))
+	})
+}

--- a/internal/api/scim/middleware.go
+++ b/internal/api/scim/middleware.go
@@ -1,0 +1,55 @@
+package scim
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/gofrs/uuid"
+	"github.com/supabase/auth/internal/api/shared"
+	"github.com/supabase/auth/internal/models"
+)
+
+// TEMPORARY: this header stands in for the per-provider SCIM token
+const ProviderHeaderName = "x-scim-provider-id"
+
+func (srv *Server) Tenant(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx, ok := srv.tenant(w, r)
+		if !ok {
+			return
+		}
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}
+
+func (srv *Server) tenant(w http.ResponseWriter, r *http.Request) (context.Context, bool) {
+	ctx := r.Context()
+
+	id := providerID(r)
+	if id == uuid.Nil {
+		_ = srv.NotFound(w, r)
+		return nil, false
+	}
+
+	provider, err := models.FindSSOProviderByID(srv.db.WithContext(ctx), id)
+	if err != nil {
+		if models.IsNotFoundError(err) {
+			_ = srv.NotFound(w, r)
+			return nil, false
+		}
+		_ = srv.internalError(w, r, err)
+		return nil, false
+	}
+
+	return shared.WithSSOProvider(ctx, provider), true
+}
+
+func providerID(r *http.Request) uuid.UUID {
+	// TEMPORARY: reads the provider id from the "x-scim-provider-id" header until SCIM Tokens ship
+	id, err := uuid.FromString(r.Header.Get(ProviderHeaderName))
+	if err != nil {
+		return uuid.Nil
+	}
+
+	return id
+}

--- a/internal/api/scim/protocol/error.go
+++ b/internal/api/scim/protocol/error.go
@@ -2,21 +2,37 @@ package protocol
 
 import (
 	"strconv"
+
+	"github.com/supabase/auth/internal/api/scim/core"
 )
 
-const SchemaError = "urn:ietf:params:scim:api:messages:2.0:Error"
+// ScimType is a detail error keyword from RFC 7644, Table 9.
+type ScimType string
+
+const (
+	ScimTypeInvalidFilter ScimType = "invalidFilter"
+	ScimTypeInvalidPath   ScimType = "invalidPath"
+	ScimTypeInvalidSyntax ScimType = "invalidSyntax"
+	ScimTypeInvalidValue  ScimType = "invalidValue"
+	ScimTypeInvalidVers   ScimType = "invalidVers"
+	ScimTypeMutability    ScimType = "mutability"
+	ScimTypeNoTarget      ScimType = "noTarget"
+	ScimTypeSensitive     ScimType = "sensitive"
+	ScimTypeTooMany       ScimType = "tooMany"
+	ScimTypeUniqueness    ScimType = "uniqueness"
+)
 
 // Error is the error message form defined in RFC 7644, Section 3.12.
 type Error struct {
-	Schemas  []string `json:"schemas"`
-	ScimType string   `json:"scimType,omitempty"`
-	Detail   string   `json:"detail,omitempty"`
-	Status   string   `json:"status"`
+	Schemas  []core.SchemaURI `json:"schemas"`
+	ScimType ScimType         `json:"scimType,omitempty"`
+	Detail   string           `json:"detail,omitempty"`
+	Status   string           `json:"status"`
 }
 
-func NewError(status int, scimType string, detail string) *Error {
+func NewError(status int, scimType ScimType, detail string) *Error {
 	return &Error{
-		Schemas:  []string{SchemaError},
+		Schemas:  []core.SchemaURI{SchemaError},
 		ScimType: scimType,
 		Detail:   detail,
 		Status:   strconv.Itoa(status),

--- a/internal/api/scim/protocol/error_test.go
+++ b/internal/api/scim/protocol/error_test.go
@@ -15,9 +15,7 @@ func TestNewError(t *testing.T) {
 
 		require.NoError(t, err)
 		assert.JSONEq(t, `{
-			"schemas": [
-				"urn:ietf:params:scim:api:messages:2.0:Error"
-			],
+			"schemas": ["urn:ietf:params:scim:api:messages:2.0:Error"],
 			"status": "404",
 			"detail": "Endpoint or resource does not exist"
 		}`, string(body))

--- a/internal/api/scim/protocol/list_response.go
+++ b/internal/api/scim/protocol/list_response.go
@@ -1,25 +1,28 @@
 package protocol
 
-const SchemaListResponse = "urn:ietf:params:scim:api:messages:2.0:ListResponse"
+import "github.com/supabase/auth/internal/api/scim/core"
 
 type ListResponse[T any] struct {
-	Schemas      []string `json:"schemas"`
-	TotalResults int      `json:"totalResults"`
-	StartIndex   int      `json:"startIndex"`
-	ItemsPerPage int      `json:"itemsPerPage"`
-	Resources    []T      `json:"Resources"`
+	Schemas      []core.SchemaURI `json:"schemas"`
+	TotalResults int              `json:"totalResults"`
+	StartIndex   int              `json:"startIndex"`
+	ItemsPerPage int              `json:"itemsPerPage"`
+	Resources    []T              `json:"Resources"`
 }
 
-func NewListResponse[T any](resources []T) *ListResponse[T] {
+func NewPage[T any](resources []T, startIndex, totalResults int) *ListResponse[T] {
 	if resources == nil {
 		resources = []T{}
 	}
-	n := len(resources)
 	return &ListResponse[T]{
-		Schemas:      []string{SchemaListResponse},
-		TotalResults: n,
-		StartIndex:   1,
-		ItemsPerPage: n,
+		Schemas:      []core.SchemaURI{SchemaListResponse},
+		TotalResults: totalResults,
+		StartIndex:   startIndex,
+		ItemsPerPage: len(resources),
 		Resources:    resources,
 	}
+}
+
+func NewListResponse[T any](resources []T) *ListResponse[T] {
+	return NewPage(resources, 1, len(resources))
 }

--- a/internal/api/scim/protocol/list_response_test.go
+++ b/internal/api/scim/protocol/list_response_test.go
@@ -45,9 +45,23 @@ func TestNewListResponse(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			body, err := json.Marshal(NewListResponse(tc.resources))
-
 			require.NoError(t, err)
 			require.JSONEq(t, tc.expected, string(body))
 		})
 	}
+}
+
+func TestNewPage(t *testing.T) {
+	t.Run("counts every match, not just the resources on the page", func(t *testing.T) {
+		body, err := json.Marshal(NewPage([]string{"c", "d"}, 3, 9))
+
+		require.NoError(t, err)
+		require.JSONEq(t, `{
+			"schemas": ["urn:ietf:params:scim:api:messages:2.0:ListResponse"],
+			"totalResults": 9,
+			"startIndex": 3,
+			"itemsPerPage": 2,
+			"Resources": ["c", "d"]
+		}`, string(body))
+	})
 }

--- a/internal/api/scim/protocol/messages.go
+++ b/internal/api/scim/protocol/messages.go
@@ -1,0 +1,15 @@
+package protocol
+
+import "github.com/supabase/auth/internal/api/scim/core"
+
+// The message URIs of RFC 7644
+const (
+	messagesRoot = "urn:ietf:params:scim:api:messages:2.0"
+
+	SchemaBulkRequest   core.SchemaURI = messagesRoot + ":BulkRequest"
+	SchemaBulkResponse  core.SchemaURI = messagesRoot + ":BulkResponse"
+	SchemaError         core.SchemaURI = messagesRoot + ":Error"
+	SchemaListResponse  core.SchemaURI = messagesRoot + ":ListResponse"
+	SchemaPatchOp       core.SchemaURI = messagesRoot + ":PatchOp"
+	SchemaSearchRequest core.SchemaURI = messagesRoot + ":SearchRequest"
+)

--- a/internal/api/scim/protocol/page.go
+++ b/internal/api/scim/protocol/page.go
@@ -1,0 +1,58 @@
+package protocol
+
+import (
+	"fmt"
+	"net/url"
+	"strconv"
+)
+
+const (
+	// DefaultCount is the page size used when a client asks for no particular
+	// one. RFC 7644, Section 3.4.2.4 leaves that maximum to the provider.
+	DefaultCount = 100
+
+	// MaxCount is the largest page this provider will return. Asking for more
+	// is allowed; the RFC only forbids returning more than was asked for.
+	MaxCount = 100
+)
+
+// Page is the window of a collection a client asked for, per RFC 7644,
+// Section 3.4.2.4. StartIndex counts resources from 1, not pages.
+type Page struct {
+	StartIndex int
+	Count      int
+}
+
+func ParsePage(values url.Values) (Page, error) {
+	startIndex, err := intParam(values, "startIndex", 1)
+	if err != nil {
+		return Page{}, err
+	}
+
+	count, err := intParam(values, "count", DefaultCount)
+	if err != nil {
+		return Page{}, err
+	}
+
+	return Page{
+		StartIndex: max(startIndex, 1),
+		Count:      min(max(count, 0), MaxCount),
+	}, nil
+}
+
+func (p Page) Offset() int {
+	return p.StartIndex - 1
+}
+
+func intParam(values url.Values, name string, fallback int) (int, error) {
+	raw := values.Get(name)
+	if raw == "" {
+		return fallback, nil
+	}
+
+	value, err := strconv.Atoi(raw)
+	if err != nil {
+		return 0, fmt.Errorf("%q must be an integer", name)
+	}
+	return value, nil
+}

--- a/internal/api/scim/protocol/page_test.go
+++ b/internal/api/scim/protocol/page_test.go
@@ -1,0 +1,55 @@
+package protocol
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParsePage(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		query      string
+		startIndex int
+		count      int
+	}{
+		{
+			name:       "defaults to the whole first page when the client asks for nothing",
+			query:      "",
+			startIndex: 1,
+			count:      DefaultCount,
+		},
+		{
+			name:       "honours the window the client asked for",
+			query:      "startIndex=11&count=10",
+			startIndex: 11,
+			count:      10,
+		},
+		{
+			name:       "caps a count larger than the provider is willing to return",
+			query:      "count=5000",
+			startIndex: 1,
+			count:      MaxCount,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			values, err := url.ParseQuery(tc.query)
+			require.NoError(t, err)
+
+			page, err := ParsePage(values)
+
+			require.NoError(t, err)
+			assert.Equal(t, tc.startIndex, page.StartIndex)
+			assert.Equal(t, tc.count, page.Count)
+		})
+	}
+}
+
+func TestPageOffset(t *testing.T) {
+	t.Run("converts the 1-based start index into a 0-based offset", func(t *testing.T) {
+		require.Equal(t, 0, Page{StartIndex: 1}.Offset())
+		require.Equal(t, 10, Page{StartIndex: 11}.Offset())
+	})
+}

--- a/internal/api/scim/protocol/protocol.go
+++ b/internal/api/scim/protocol/protocol.go
@@ -13,6 +13,6 @@ func Send(w http.ResponseWriter, status int, obj any) error {
 	return shared.JSON(w).ContentType(MediaType).Status(status).Send(obj)
 }
 
-func SendError(w http.ResponseWriter, status int, scimType string, detail string) error {
+func SendError(w http.ResponseWriter, status int, scimType ScimType, detail string) error {
 	return Send(w, status, NewError(status, scimType, detail))
 }

--- a/internal/api/scim/repository.go
+++ b/internal/api/scim/repository.go
@@ -1,0 +1,21 @@
+package scim
+
+import (
+	"context"
+	"errors"
+
+	"github.com/supabase/auth/internal/api/scim/core"
+)
+
+var ErrNotFound = errors.New("scim: resource not found")
+
+type Repository[T any] interface {
+	Get(ctx context.Context, tenant, id string) (T, error)
+	List(ctx context.Context, tenant string, count, offset int) (items []T, total int, err error)
+}
+
+type UserRepository = Repository[*core.User]
+
+func NewUserMemoryRepository() *MemoryRepository[*core.User] {
+	return NewMemoryRepository(func(u *core.User) string { return u.ID })
+}

--- a/internal/api/scim/server.go
+++ b/internal/api/scim/server.go
@@ -8,23 +8,29 @@ import (
 	"github.com/supabase/auth/internal/api/scim/core"
 	"github.com/supabase/auth/internal/api/scim/protocol"
 	"github.com/supabase/auth/internal/conf"
+	"github.com/supabase/auth/internal/observability"
+	"github.com/supabase/auth/internal/storage"
 )
 
 const BasePath = "/scim/v2"
 
 type Server struct {
 	baseURL               string
+	db                    *storage.Connection
+	users                 UserRepository
 	serviceProviderConfig *core.ServiceProviderConfig
 	resourceTypes         []*core.ResourceType
 	schemas               []*core.Schema
 }
 
-func NewServer(config *conf.GlobalConfiguration) *Server {
+func NewServer(config *conf.GlobalConfiguration, db *storage.Connection, users UserRepository) *Server {
 	baseURL := core.Join(config.API.ExternalURL, BasePath)
 	userSchema := newUserSchema(baseURL)
 
 	return &Server{
 		baseURL: baseURL,
+		db:      db,
+		users:   users,
 		serviceProviderConfig: core.NewServiceProviderConfig(
 			baseURL,
 			core.NewOAuthBearerToken().AsPrimary(),
@@ -76,6 +82,18 @@ func urlParam(r *http.Request, key string) string {
 
 func (srv *Server) NotFound(w http.ResponseWriter, r *http.Request) error {
 	return protocol.SendError(w, http.StatusNotFound, "", "Endpoint or resource does not exist")
+}
+
+func (srv *Server) internalError(w http.ResponseWriter, r *http.Request, err error) error {
+	observability.LogEntrySetField(r, "error", err.Error())
+	return protocol.SendError(w, http.StatusInternalServerError, "", "Internal server error")
+}
+
+func rejectFilter(w http.ResponseWriter, r *http.Request, status int, scimType protocol.ScimType) (bool, error) {
+	if !r.URL.Query().Has("filter") {
+		return false, nil
+	}
+	return true, protocol.SendError(w, status, scimType, "Filtering is not supported on this endpoint")
 }
 
 func list[T any](w http.ResponseWriter, r *http.Request, resources []T) error {

--- a/internal/api/scim/server.go
+++ b/internal/api/scim/server.go
@@ -2,8 +2,9 @@ package scim
 
 import (
 	"net/http"
-	"strings"
+	"net/url"
 
+	"github.com/go-chi/chi/v5"
 	"github.com/supabase/auth/internal/api/scim/core"
 	"github.com/supabase/auth/internal/api/scim/protocol"
 	"github.com/supabase/auth/internal/conf"
@@ -12,15 +13,24 @@ import (
 const BasePath = "/scim/v2"
 
 type Server struct {
+	baseURL               string
 	serviceProviderConfig *core.ServiceProviderConfig
+	resourceTypes         []*core.ResourceType
+	schemas               []*core.Schema
 }
 
 func NewServer(config *conf.GlobalConfiguration) *Server {
+	baseURL := core.Join(config.API.ExternalURL, BasePath)
+	userSchema := newUserSchema(baseURL)
+
 	return &Server{
+		baseURL: baseURL,
 		serviceProviderConfig: core.NewServiceProviderConfig(
-			strings.TrimRight(config.API.ExternalURL, "/")+BasePath,
+			baseURL,
 			core.NewOAuthBearerToken().AsPrimary(),
 		),
+		resourceTypes: []*core.ResourceType{core.NewResourceType(baseURL, core.KindUser, userSchema)},
+		schemas:       []*core.Schema{userSchema},
 	}
 }
 
@@ -29,11 +39,39 @@ func (srv *Server) ServiceProviderConfig(w http.ResponseWriter, r *http.Request)
 }
 
 func (srv *Server) ResourceTypes(w http.ResponseWriter, r *http.Request) error {
-	return list(w, r, []any{})
+	return list(w, r, srv.resourceTypes)
+}
+
+func (srv *Server) ResourceTypeByID(w http.ResponseWriter, r *http.Request) error {
+	return byID(srv, w, r, srv.resourceTypes)
 }
 
 func (srv *Server) Schemas(w http.ResponseWriter, r *http.Request) error {
-	return list(w, r, []any{})
+	return list(w, r, srv.schemas)
+}
+
+func (srv *Server) SchemaByID(w http.ResponseWriter, r *http.Request) error {
+	return byID(srv, w, r, srv.schemas)
+}
+
+func newUserSchema(baseURL string) *core.Schema {
+	return core.
+		NewSchema(baseURL, core.SchemaUser, core.KindUser.Name).
+		Describe("User Account").
+		With(
+			core.NewAttribute("userName", core.TypeString, "Unique identifier for the User.").
+				AsRequired().
+				UniqueOn(core.UniquenessServer),
+		)
+}
+
+func urlParam(r *http.Request, key string) string {
+	value := chi.URLParam(r, key)
+
+	if decoded, err := url.PathUnescape(value); err == nil {
+		return decoded
+	}
+	return value
 }
 
 func (srv *Server) NotFound(w http.ResponseWriter, r *http.Request) error {
@@ -44,5 +82,17 @@ func list[T any](w http.ResponseWriter, r *http.Request, resources []T) error {
 	if r.URL.Query().Has("filter") {
 		return protocol.SendError(w, http.StatusForbidden, "", "Filtering is not supported on this endpoint")
 	}
+
 	return protocol.Send(w, http.StatusOK, protocol.NewListResponse(resources))
+}
+
+func byID[T core.Resource](srv *Server, w http.ResponseWriter, r *http.Request, resources []T) error {
+	id := urlParam(r, "id")
+
+	for _, resource := range resources {
+		if resource.ResourceID() == id {
+			return protocol.Send(w, http.StatusOK, resource)
+		}
+	}
+	return srv.NotFound(w, r)
 }

--- a/internal/api/scim/server_test.go
+++ b/internal/api/scim/server_test.go
@@ -1,13 +1,17 @@
 package scim
 
 import (
+	"context"
 	"embed"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"testing"
 
+	"github.com/go-chi/chi/v5"
 	"github.com/stretchr/testify/require"
+	"github.com/supabase/auth/internal/api/scim/core"
 	"github.com/supabase/auth/internal/api/scim/protocol"
 	"github.com/supabase/auth/internal/conf"
 )
@@ -49,21 +53,28 @@ func TestServer(t *testing.T) {
 	})
 
 	for _, tc := range []struct {
-		path    string
-		handler func(http.ResponseWriter, *http.Request) error
+		path, fixture string
+		id            string
+		list, byID    func(http.ResponseWriter, *http.Request) error
 	}{
-		{"ResourceTypes", srv.ResourceTypes},
-		{"Schemas", srv.Schemas},
+		{"ResourceTypes", "resource_type_user.json", string(core.KindUser.Name), srv.ResourceTypes, srv.ResourceTypeByID},
+		{"Schemas", "schema_user.json", string(core.SchemaUser), srv.Schemas, srv.SchemaByID},
 	} {
 		t.Run(tc.path, func(t *testing.T) {
 			r := httptest.NewRequest(http.MethodGet, BasePath+"/"+tc.path, nil)
 			w := httptest.NewRecorder()
 
-			require.NoError(t, tc.handler(w, r))
+			require.NoError(t, tc.list(w, r))
 
 			require.Equal(t, http.StatusOK, w.Code)
 			require.Equal(t, protocol.MediaType, w.Header().Get("Content-Type"))
-			require.JSONEq(t, testFixture(t, "empty_list_response.json"), w.Body.String())
+
+			var body protocol.ListResponse[json.RawMessage]
+			require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+
+			require.Equal(t, 1, body.TotalResults)
+			require.Len(t, body.Resources, 1)
+			require.JSONEq(t, testFixture(t, tc.fixture), string(body.Resources[0]))
 		})
 
 		t.Run(tc.path+" rejects filter query parameter", func(t *testing.T) {
@@ -71,10 +82,32 @@ func TestServer(t *testing.T) {
 			r := httptest.NewRequest(http.MethodGet, BasePath+"/"+tc.path+"?"+filter, nil)
 			w := httptest.NewRecorder()
 
-			require.NoError(t, tc.handler(w, r))
+			require.NoError(t, tc.list(w, r))
 
 			require.Equal(t, http.StatusForbidden, w.Code)
 			require.JSONEq(t, testFixture(t, "filter_forbidden.json"), w.Body.String())
+		})
+
+		t.Run(tc.path+"/"+tc.id, func(t *testing.T) {
+			r := requestWithURLParam(tc.path+"/"+tc.id, "id", tc.id)
+			w := httptest.NewRecorder()
+
+			require.NoError(t, tc.byID(w, r))
+
+			require.Equal(t, http.StatusOK, w.Code)
+			require.Equal(t, protocol.MediaType, w.Header().Get("Content-Type"))
+			require.JSONEq(t, testFixture(t, tc.fixture), w.Body.String())
+		})
+
+		t.Run(tc.path+" returns a SCIM 404 for an unknown id", func(t *testing.T) {
+			r := requestWithURLParam(tc.path+"/Unknown", "id", "Unknown")
+			w := httptest.NewRecorder()
+
+			require.NoError(t, tc.byID(w, r))
+
+			require.Equal(t, http.StatusNotFound, w.Code)
+			require.Equal(t, protocol.MediaType, w.Header().Get("Content-Type"))
+			require.JSONEq(t, testFixture(t, "not_found.json"), w.Body.String())
 		})
 	}
 
@@ -85,7 +118,16 @@ func TestServer(t *testing.T) {
 		require.NoError(t, srv.NotFound(w, r))
 
 		require.Equal(t, http.StatusNotFound, w.Code)
-		require.Equal(t, "application/scim+json", w.Header().Get("Content-Type"))
+		require.Equal(t, protocol.MediaType, w.Header().Get("Content-Type"))
 		require.JSONEq(t, testFixture(t, "not_found.json"), w.Body.String())
 	})
+}
+
+func requestWithURLParam(path, key, value string) *http.Request {
+	r := httptest.NewRequest(http.MethodGet, BasePath+"/"+path, nil)
+
+	routeCtx := chi.NewRouteContext()
+	routeCtx.URLParams.Add(key, value)
+
+	return r.WithContext(context.WithValue(r.Context(), chi.RouteCtxKey, routeCtx))
 }

--- a/internal/api/scim/server_test.go
+++ b/internal/api/scim/server_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/gofrs/uuid"
 	"github.com/stretchr/testify/require"
 	"github.com/supabase/auth/internal/api/scim/core"
 	"github.com/supabase/auth/internal/api/scim/protocol"
@@ -19,16 +20,16 @@ import (
 //go:embed testdata/*
 var fixtures embed.FS
 
+func newServerFor(externalURL string) *Server {
+	return NewServer(&conf.GlobalConfiguration{
+		API: conf.APIConfiguration{ExternalURL: externalURL},
+	}, nil, NewUserMemoryRepository())
+}
+
 func testFixture(t *testing.T, file string) string {
 	data, err := fixtures.ReadFile("testdata/" + file)
 	require.NoError(t, err)
 	return string(data)
-}
-
-func newServerFor(externalURL string) *Server {
-	return NewServer(&conf.GlobalConfiguration{
-		API: conf.APIConfiguration{ExternalURL: externalURL},
-	})
 }
 
 func TestServer(t *testing.T) {
@@ -120,6 +121,54 @@ func TestServer(t *testing.T) {
 		require.Equal(t, http.StatusNotFound, w.Code)
 		require.Equal(t, protocol.MediaType, w.Header().Get("Content-Type"))
 		require.JSONEq(t, testFixture(t, "not_found.json"), w.Body.String())
+	})
+
+	t.Run("Users rejects a filter it cannot honour", func(t *testing.T) {
+		filter := url.Values{"filter": {`userName eq "user@example.com"`}}.Encode()
+		r := httptest.NewRequest(http.MethodGet, BasePath+"/Users?"+filter, nil)
+		w := httptest.NewRecorder()
+
+		require.NoError(t, srv.Users(w, r))
+
+		require.Equal(t, http.StatusBadRequest, w.Code)
+		require.Equal(t, protocol.MediaType, w.Header().Get("Content-Type"))
+		require.JSONEq(t, testFixture(t, "filter_invalid.json"), w.Body.String())
+	})
+
+	t.Run("Users rejects pagination parameters that are not integers", func(t *testing.T) {
+		for _, query := range []string{"startIndex=first", "count=all"} {
+			t.Run(query, func(t *testing.T) {
+				r := httptest.NewRequest(http.MethodGet, BasePath+"/Users?"+query, nil)
+				w := httptest.NewRecorder()
+
+				require.NoError(t, srv.Users(w, r))
+
+				require.Equal(t, http.StatusBadRequest, w.Code)
+				require.Equal(t, protocol.MediaType, w.Header().Get("Content-Type"))
+				require.Contains(t, w.Body.String(), string(protocol.ScimTypeInvalidValue))
+			})
+		}
+	})
+
+	t.Run("Users without a tenant on the context is a server error", func(t *testing.T) {
+		r := httptest.NewRequest(http.MethodGet, BasePath+"/Users", nil)
+		w := httptest.NewRecorder()
+
+		require.NoError(t, srv.Users(w, r))
+
+		require.Equal(t, http.StatusNotFound, w.Code)
+		require.Equal(t, protocol.MediaType, w.Header().Get("Content-Type"))
+	})
+
+	t.Run("UserByID without a tenant on the context is a server error", func(t *testing.T) {
+		id := uuid.Must(uuid.NewV4()).String()
+		r := requestWithURLParam("Users/"+id, "id", id)
+		w := httptest.NewRecorder()
+
+		require.NoError(t, srv.UserByID(w, r))
+
+		require.Equal(t, http.StatusNotFound, w.Code)
+		require.Equal(t, protocol.MediaType, w.Header().Get("Content-Type"))
 	})
 }
 

--- a/internal/api/scim/testdata/empty_list_response.json
+++ b/internal/api/scim/testdata/empty_list_response.json
@@ -1,9 +1,0 @@
-{
-  "schemas": [
-    "urn:ietf:params:scim:api:messages:2.0:ListResponse"
-  ],
-  "totalResults": 0,
-  "startIndex": 1,
-  "itemsPerPage": 0,
-  "Resources": []
-}

--- a/internal/api/scim/testdata/filter_invalid.json
+++ b/internal/api/scim/testdata/filter_invalid.json
@@ -1,0 +1,8 @@
+{
+  "schemas": [
+    "urn:ietf:params:scim:api:messages:2.0:Error"
+  ],
+  "scimType": "invalidFilter",
+  "detail": "Filtering is not supported on this endpoint",
+  "status": "400"
+}

--- a/internal/api/scim/testdata/resource_type_user.json
+++ b/internal/api/scim/testdata/resource_type_user.json
@@ -1,0 +1,14 @@
+{
+  "schemas": [
+    "urn:ietf:params:scim:schemas:core:2.0:ResourceType"
+  ],
+  "id": "User",
+  "name": "User",
+  "description": "User Account",
+  "endpoint": "/Users",
+  "schema": "urn:ietf:params:scim:schemas:core:2.0:User",
+  "meta": {
+    "resourceType": "ResourceType",
+    "location": "http://localhost:9999/scim/v2/ResourceTypes/User"
+  }
+}

--- a/internal/api/scim/testdata/schema_user.json
+++ b/internal/api/scim/testdata/schema_user.json
@@ -1,0 +1,25 @@
+{
+  "schemas": [
+    "urn:ietf:params:scim:schemas:core:2.0:Schema"
+  ],
+  "id": "urn:ietf:params:scim:schemas:core:2.0:User",
+  "name": "User",
+  "description": "User Account",
+  "attributes": [
+    {
+      "name": "userName",
+      "type": "string",
+      "multiValued": false,
+      "description": "Unique identifier for the User.",
+      "required": true,
+      "caseExact": false,
+      "mutability": "readWrite",
+      "returned": "default",
+      "uniqueness": "server"
+    }
+  ],
+  "meta": {
+    "resourceType": "Schema",
+    "location": "http://localhost:9999/scim/v2/Schemas/urn:ietf:params:scim:schemas:core:2.0:User"
+  }
+}

--- a/internal/api/scim/users.go
+++ b/internal/api/scim/users.go
@@ -1,0 +1,59 @@
+package scim
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/gofrs/uuid"
+	"github.com/supabase/auth/internal/api/scim/protocol"
+	"github.com/supabase/auth/internal/api/shared"
+)
+
+func (srv *Server) UserByID(w http.ResponseWriter, r *http.Request) error {
+	ctx := r.Context()
+
+	id, err := uuid.FromString(urlParam(r, "id"))
+	if err != nil {
+		return srv.NotFound(w, r)
+	}
+
+	provider := shared.GetSSOProvider(ctx)
+	if provider == nil {
+		return srv.NotFound(w, r)
+	}
+
+	user, err := srv.users.Get(ctx, provider.ID.String(), id.String())
+	if err != nil {
+		if errors.Is(err, ErrNotFound) {
+			return srv.NotFound(w, r)
+		}
+		return srv.internalError(w, r, err)
+	}
+
+	return protocol.Send(w, http.StatusOK, user)
+}
+
+func (srv *Server) Users(w http.ResponseWriter, r *http.Request) error {
+	ctx := r.Context()
+
+	if rejected, err := rejectFilter(w, r, http.StatusBadRequest, protocol.ScimTypeInvalidFilter); rejected {
+		return err
+	}
+
+	page, err := protocol.ParsePage(r.URL.Query())
+	if err != nil {
+		return protocol.SendError(w, http.StatusBadRequest, protocol.ScimTypeInvalidValue, err.Error())
+	}
+
+	provider := shared.GetSSOProvider(ctx)
+	if provider == nil {
+		return srv.NotFound(w, r)
+	}
+
+	users, total, err := srv.users.List(ctx, provider.ID.String(), page.Count, page.Offset())
+	if err != nil {
+		return srv.internalError(w, r, err)
+	}
+
+	return protocol.Send(w, http.StatusOK, protocol.NewPage(users, page.StartIndex, total))
+}

--- a/internal/api/scim_test.go
+++ b/internal/api/scim_test.go
@@ -18,12 +18,18 @@ const (
 	scimServiceProviderConfigPath = "/scim/v2/ServiceProviderConfig"
 	scimResourceTypesPath         = "/scim/v2/ResourceTypes"
 	scimSchemasPath               = "/scim/v2/Schemas"
+	scimUsersPath                 = "/scim/v2/Users"
 )
 
 var scimPaths = []string{
 	scimServiceProviderConfigPath,
 	scimResourceTypesPath,
 	scimSchemasPath,
+	// /Users is admin-gated, but chi resolves 405 and the disabled-feature 404
+	// before any per-route middleware runs, so both loops below reach it
+	// without credentials. It stays out of the enabled-200 loop, which asserts
+	// the 403 that only the metadata endpoints return for a filter.
+	scimUsersPath,
 }
 
 func TestSCIM(t *testing.T) {

--- a/internal/api/scim_test.go
+++ b/internal/api/scim_test.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -72,7 +73,7 @@ func TestSCIM(t *testing.T) {
 
 			require.Equal(t, http.StatusOK, w.Code)
 			require.Equal(t, scimProtocol.MediaType, w.Header().Get("Content-Type"))
-			require.Contains(t, w.Body.String(), scimCore.SchemaServiceProviderConfig)
+			require.Contains(t, w.Body.String(), string(scimCore.SchemaServiceProviderConfig))
 		})
 
 		for _, path := range []string{scimResourceTypesPath, scimSchemasPath} {
@@ -97,6 +98,28 @@ func TestSCIM(t *testing.T) {
 				require.Equal(t, http.StatusForbidden, w.Code)
 				require.Equal(t, scimProtocol.MediaType, w.Header().Get("Content-Type"))
 				require.Contains(t, w.Body.String(), scimProtocol.SchemaError)
+			})
+		}
+
+		for _, tc := range []struct {
+			path   string
+			schema string
+		}{
+			{scimResourceTypesPath + "/User", string(scimCore.SchemaResourceType)},
+			{scimSchemasPath + "/" + string(scimCore.SchemaUser), string(scimCore.SchemaSchema)},
+			// A URN's colons are legal to percent-encode in a path segment, and
+			// some clients do, so both spellings must reach the same schema.
+			{scimSchemasPath + "/" + strings.ReplaceAll(string(scimCore.SchemaUser), ":", "%3A"), string(scimCore.SchemaSchema)},
+		} {
+			t.Run(tc.path, func(t *testing.T) {
+				r := httptest.NewRequest(http.MethodGet, tc.path, nil)
+				w := httptest.NewRecorder()
+
+				api.handler.ServeHTTP(w, r)
+
+				require.Equal(t, http.StatusOK, w.Code)
+				require.Equal(t, scimProtocol.MediaType, w.Header().Get("Content-Type"))
+				require.Contains(t, w.Body.String(), tc.schema)
 			})
 		}
 

--- a/internal/api/scim_users_test.go
+++ b/internal/api/scim_users_test.go
@@ -1,0 +1,234 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gofrs/uuid"
+	jwt "github.com/golang-jwt/jwt/v5"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	"github.com/supabase/auth/internal/api/scim"
+	"github.com/supabase/auth/internal/api/scim/core"
+	"github.com/supabase/auth/internal/api/scim/protocol"
+	"github.com/supabase/auth/internal/conf"
+	"github.com/supabase/auth/internal/models"
+	"github.com/supabase/auth/internal/storage"
+)
+
+type tenant struct {
+	handler  http.Handler
+	provider *models.SSOProvider
+	users    []*core.User
+	domain   string
+	token    string
+}
+
+func (t *tenant) get(id string) *httptest.ResponseRecorder {
+	return t.do("/scim/v2/Users/" + id)
+}
+
+func (t *tenant) list(query string) *httptest.ResponseRecorder {
+	if query != "" {
+		query = "?" + query
+	}
+	return t.do("/scim/v2/Users" + query)
+}
+
+func (t *tenant) do(path string) *httptest.ResponseRecorder {
+	r := httptest.NewRequest(http.MethodGet, path, nil)
+	w := httptest.NewRecorder()
+
+	r.Header.Set("Authorization", "Bearer "+t.token)
+	r.Header.Set(scim.ProviderHeaderName, t.provider.ID.String())
+	t.handler.ServeHTTP(w, r)
+	return w
+}
+
+func (t *tenant) userIDs() []string {
+	ids := make([]string, 0, len(t.users))
+	for _, user := range t.users {
+		ids = append(ids, user.ID)
+	}
+	return ids
+}
+
+type SCIMUsersTestSuite struct {
+	suite.Suite
+	API     *API
+	Config  *conf.GlobalConfiguration
+	Users   *scim.MemoryRepository[*core.User]
+	TenantA *tenant
+	TenantB *tenant
+}
+
+func TestSCIMUsers(t *testing.T) {
+	users := scim.NewUserMemoryRepository()
+	api, config, err := setupAPIForTestWithCallback(func(cfg *conf.GlobalConfiguration, _ *storage.Connection) {
+		if cfg != nil {
+			cfg.Experimental.ScimEnabled = true
+		}
+	}, WithSCIMUserRepository(users))
+	require.NoError(t, err)
+	defer api.db.Close()
+
+	suite.Run(t, &SCIMUsersTestSuite{API: api, Config: config, Users: users})
+}
+
+func (ts *SCIMUsersTestSuite) SetupTest() {
+	require.NoError(ts.T(), models.TruncateAll(ts.API.db))
+
+	ts.TenantA = ts.buildTenant("example.com", 3)
+	ts.TenantB = ts.buildTenant("example.org", 3)
+}
+
+func (ts *SCIMUsersTestSuite) TestGetUser() {
+	ts.Run("returns the user that belongs to the requested provider", func() {
+		user := ts.TenantA.users[0]
+
+		w := ts.TenantA.get(user.ID)
+
+		require.Equal(ts.T(), http.StatusOK, w.Code)
+		require.Equal(ts.T(), protocol.MediaType, w.Header().Get("Content-Type"))
+		require.JSONEq(ts.T(), fmt.Sprintf(`{
+			"schemas": [%q],
+			"id": %q,
+			"userName": %q,
+			"meta": {
+				"resourceType": "User",
+				"created": %q,
+				"lastModified": %q,
+				"location": "%s/scim/v2/Users/%s"
+			}
+		}`,
+			core.SchemaUser,
+			user.ID,
+			user.UserName,
+			user.Meta.Created.Format(time.RFC3339Nano),
+			user.Meta.LastModified.Format(time.RFC3339Nano),
+			ts.Config.API.ExternalURL, user.ID,
+		), w.Body.String())
+	})
+
+	ts.Run("scopes each provider to its own users", func() {
+		require.Equal(ts.T(), http.StatusOK, ts.TenantA.get(ts.TenantA.users[0].ID).Code)
+		require.Equal(ts.T(), http.StatusNotFound, ts.TenantB.get(ts.TenantA.users[0].ID).Code)
+
+		require.Equal(ts.T(), http.StatusOK, ts.TenantB.get(ts.TenantB.users[0].ID).Code)
+		require.Equal(ts.T(), http.StatusNotFound, ts.TenantA.get(ts.TenantB.users[0].ID).Code)
+	})
+}
+
+func (ts *SCIMUsersTestSuite) TestListUsers() {
+	ts.Run("returns every user the provider has provisioned", func() {
+		w := ts.TenantA.list("")
+
+		require.Equal(ts.T(), http.StatusOK, w.Code)
+		require.Equal(ts.T(), protocol.MediaType, w.Header().Get("Content-Type"))
+
+		body := ts.decode(w)
+		require.Equal(ts.T(), []core.SchemaURI{protocol.SchemaListResponse}, body.Schemas)
+		require.Equal(ts.T(), 3, body.TotalResults)
+		require.Equal(ts.T(), 1, body.StartIndex)
+		require.Equal(ts.T(), 3, body.ItemsPerPage)
+		require.ElementsMatch(ts.T(), ts.TenantA.userIDs(), resourceIDs(body))
+	})
+
+	ts.Run("scopes the collection to the requesting provider", func() {
+		require.ElementsMatch(ts.T(), ts.TenantA.userIDs(), resourceIDs(ts.decode(ts.TenantA.list(""))))
+		require.ElementsMatch(ts.T(), ts.TenantB.userIDs(), resourceIDs(ts.decode(ts.TenantB.list(""))))
+	})
+
+	ts.Run("refuses a request without credentials", func() {
+		r := httptest.NewRequest(http.MethodGet, "/scim/v2/Users", nil)
+		w := httptest.NewRecorder()
+
+		ts.API.handler.ServeHTTP(w, r)
+
+		require.Equal(ts.T(), http.StatusUnauthorized, w.Code)
+	})
+
+	ts.Run("refuses a request for a provider that does not exist", func() {
+		r := httptest.NewRequest(http.MethodGet, "/scim/v2/Users", nil)
+		w := httptest.NewRecorder()
+
+		r.Header.Set("Authorization", "Bearer "+ts.TenantA.token)
+		r.Header.Set(scim.ProviderHeaderName, uuid.Must(uuid.NewV4()).String())
+		ts.API.handler.ServeHTTP(w, r)
+
+		require.Equal(ts.T(), http.StatusNotFound, w.Code)
+		require.Equal(ts.T(), protocol.MediaType, w.Header().Get("Content-Type"))
+	})
+}
+
+func resourceIDs(body *protocol.ListResponse[core.User]) []string {
+	ids := make([]string, 0, len(body.Resources))
+	for _, resource := range body.Resources {
+		ids = append(ids, resource.ID)
+	}
+	return ids
+}
+
+func (ts *SCIMUsersTestSuite) decode(w *httptest.ResponseRecorder) *protocol.ListResponse[core.User] {
+	ts.T().Helper()
+
+	body := &protocol.ListResponse[core.User]{}
+	require.NoError(ts.T(), json.Unmarshal(w.Body.Bytes(), body))
+	return body
+}
+
+func (ts *SCIMUsersTestSuite) buildTenant(domain string, users int) *tenant {
+	ts.T().Helper()
+
+	id := uuid.Must(uuid.NewV4()).String()
+	provider := &models.SSOProvider{
+		SAMLProvider: models.SAMLProvider{
+			EntityID:    "https://example.com/saml/metadata/" + id,
+			MetadataXML: "<example />",
+		},
+		SSODomains: []models.SSODomain{{Domain: domain}},
+	}
+	require.NoError(ts.T(), ts.API.db.Eager().Create(provider))
+
+	tn := &tenant{
+		handler:  ts.API.handler,
+		provider: provider,
+		domain:   domain,
+		token:    ts.signClaims(&AccessTokenClaims{Role: "supabase_admin"}),
+	}
+	for range users {
+		tn.users = append(tn.users, ts.buildUser(tn, uuid.Must(uuid.NewV4()).String()))
+	}
+
+	return tn
+}
+
+func (ts *SCIMUsersTestSuite) buildUser(t *tenant, username string) *core.User {
+	ts.T().Helper()
+
+	id := uuid.Must(uuid.NewV4()).String()
+	now := time.Now()
+	user := &core.User{
+		Schemas:  []core.SchemaURI{core.SchemaUser},
+		ID:       id,
+		UserName: username + "@" + t.domain,
+		Meta:     core.NewMetaForID(ts.baseURL(), core.KindUser, id, now, now),
+	}
+	ts.Users.Put(t.provider.ID.String(), user)
+
+	return user
+}
+
+func (ts *SCIMUsersTestSuite) baseURL() string {
+	return core.Join(ts.Config.API.ExternalURL, scim.BasePath)
+}
+
+func (ts *SCIMUsersTestSuite) signClaims(claims *AccessTokenClaims) string {
+	token, err := jwt.NewWithClaims(jwt.SigningMethodHS256, claims).SignedString([]byte(ts.Config.JWT.Secret))
+	require.NoError(ts.T(), err)
+	return token
+}

--- a/internal/api/shared/context.go
+++ b/internal/api/shared/context.go
@@ -18,6 +18,7 @@ const (
 	UserKey              ContextKey = "user"
 	SessionKey           ContextKey = "session"
 	OAuthServerClientKey ContextKey = "oauth_server_client"
+	SSOProviderKey       ContextKey = "sso_provider"
 )
 
 // GetUser reads the user from the context - shared implementation
@@ -69,4 +70,21 @@ func GetOAuthServerClient(ctx context.Context) *models.OAuthServerClient {
 		return nil
 	}
 	return obj.(*models.OAuthServerClient)
+}
+
+// GetSSOProvider reads the SSO provider from the context - shared implementation
+func GetSSOProvider(ctx context.Context) *models.SSOProvider {
+	if ctx == nil {
+		return nil
+	}
+	obj := ctx.Value(SSOProviderKey)
+	if obj == nil {
+		return nil
+	}
+	return obj.(*models.SSOProvider)
+}
+
+// WithSSOProvider adds the SSO provider to the context - shared implementation
+func WithSSOProvider(ctx context.Context, provider *models.SSOProvider) context.Context {
+	return context.WithValue(ctx, SSOProviderKey, provider)
 }


### PR DESCRIPTION
Combines the SCIM read-only Users surface into one PR:

* `GET /ResourceTypes/User`, `GET /Schemas/urn:ietf:params:scim:schemas:core:2.0:User` (RFC 7643 discovery/reflection)
* `GET /Users/{id}` (scoped to the requesting SSO provider)
* `GET /Users` with `startIndex`/`count` pagination (RFC 7644 §3.4.2.4), scoped to the requesting SSO provider

Users are served from an in-memory `Repository[T]`; a Postgres adapter lands once the schema (AUTH-1460) is settled.

Closes AUTH-1369, AUTH-1368, AUTH-1367.