### PR TITLE
feat(scim): serve Users via an in-memory repository

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -48,6 +48,7 @@ type API struct {
 	hibpClient   *hibp.PwnedClient
 	oauthServer  *oauthserver.Server
 	scim         *scim.Server
+	scimUsers    scim.UserRepository
 	tokenService *tokens.Service
 	mailer       mailer.Mailer
 	oidcCache    *provider.OIDCProviderCache
@@ -129,6 +130,9 @@ func NewAPIWithVersion(globalConfig *conf.GlobalConfiguration, db *storage.Conne
 		tc := templatemailer.NewCache()
 		api.mailer = templatemailer.FromConfig(globalConfig, tc)
 	}
+	if api.scimUsers == nil {
+		api.scimUsers = scim.NewUserMemoryRepository()
+	}
 
 	// Connect token service to API's time function (supports test overrides)
 	api.tokenService.SetTimeFunc(api.Now)
@@ -138,7 +142,7 @@ func NewAPIWithVersion(globalConfig *conf.GlobalConfiguration, db *storage.Conne
 		api.oauthServer = oauthserver.NewServer(globalConfig, db, api.tokenService)
 	}
 
-	api.scim = scim.NewServer(globalConfig)
+	api.scim = scim.NewServer(globalConfig, db, api.scimUsers)
 
 	if api.config.Password.HIBP.Enabled {
 		httpClient := &http.Client{
@@ -460,6 +464,11 @@ func NewAPIWithVersion(globalConfig *conf.GlobalConfiguration, db *storage.Conne
 			r.Get("/ResourceTypes/{id}", api.scim.ResourceTypeByID)
 			r.Get("/Schemas", api.scim.Schemas)
 			r.Get("/Schemas/{id}", api.scim.SchemaByID)
+
+			// TEMPORARY: Use admin token and x-scim-provider-id header until SCIM tokens land
+			users := r.With(api.requireAdminCredentials).WithBypass(api.scim.Tenant)
+			users.Get("/Users", api.scim.Users)
+			users.Get("/Users/{id}", api.scim.UserByID)
 		})
 	})
 

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -43,7 +43,7 @@ func setupAPIForTest(opts ...Option) (*API, *conf.GlobalConfiguration, error) {
 	return NewAPIWithVersion(config, conn, apiTestVersion, opts...), config, nil
 }
 
-func setupAPIForTestWithCallback(cb func(*conf.GlobalConfiguration, *storage.Connection)) (*API, *conf.GlobalConfiguration, error) {
+func setupAPIForTestWithCallback(cb func(*conf.GlobalConfiguration, *storage.Connection), opts ...Option) (*API, *conf.GlobalConfiguration, error) {
 	config, err := confload.LoadGlobal(apiTestConfig)
 	if err != nil {
 		return nil, nil, err
@@ -63,7 +63,8 @@ func setupAPIForTestWithCallback(cb func(*conf.GlobalConfiguration, *storage.Con
 	}
 
 	limiterOpts := apilimiter.New(config)
-	return NewAPIWithVersion(config, conn, apiTestVersion, WithLimiter(limiterOpts)), config, nil
+	opts = append([]Option{WithLimiter(limiterOpts)}, opts...)
+	return NewAPIWithVersion(config, conn, apiTestVersion, opts...), config, nil
 }
 
 func TestEmailEnabledByDefault(t *testing.T) {

--- a/internal/api/options.go
+++ b/internal/api/options.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"github.com/supabase/auth/internal/api/apilimiter"
+	"github.com/supabase/auth/internal/api/scim"
 	"github.com/supabase/auth/internal/mailer"
 	"github.com/supabase/auth/internal/security"
 	"github.com/supabase/auth/internal/tokens"
@@ -36,5 +37,11 @@ func WithCaptchaVerifier(v security.CaptchaVerifier) Option {
 func WithLimiter(v *apilimiter.Limiter) Option {
 	return optionFunc(func(a *API) {
 		a.limiterOpts = v
+	})
+}
+
+func WithSCIMUserRepository(repo scim.UserRepository) Option {
+	return optionFunc(func(a *API) {
+		a.scimUsers = repo
 	})
 }

--- a/internal/api/scim/memory_repository.go
+++ b/internal/api/scim/memory_repository.go
@@ -1,0 +1,71 @@
+package scim
+
+import (
+	"context"
+	"maps"
+	"slices"
+	"sync"
+)
+
+type MemoryRepository[T any] struct {
+	mu       sync.RWMutex
+	byTenant map[string]map[string]T
+	idOf     func(T) string
+}
+
+func NewMemoryRepository[T any](idOf func(T) string) *MemoryRepository[T] {
+	return &MemoryRepository[T]{
+		byTenant: make(map[string]map[string]T),
+		idOf:     idOf,
+	}
+}
+
+func (r *MemoryRepository[T]) Put(tenant string, item T) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	items, ok := r.byTenant[tenant]
+	if !ok {
+		items = make(map[string]T)
+		r.byTenant[tenant] = items
+	}
+	items[r.idOf(item)] = item
+}
+
+func (r *MemoryRepository[T]) Get(ctx context.Context, tenant, id string) (T, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	if item, ok := r.byTenant[tenant][id]; ok {
+		return item, nil
+	}
+
+	var zero T
+	return zero, ErrNotFound
+}
+
+func (r *MemoryRepository[T]) List(ctx context.Context, tenant string, count, offset int) ([]T, int, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	items := r.byTenant[tenant]
+	total := len(items)
+	if count <= 0 {
+		return nil, total, nil
+	}
+
+	if offset < 0 {
+		offset = 0
+	}
+	if offset >= total {
+		return nil, total, nil
+	}
+
+	ids := slices.Sorted(maps.Keys(items))
+	end := min(offset+count, total)
+	page := make([]T, 0, end-offset)
+	for _, id := range ids[offset:end] {
+		page = append(page, items[id])
+	}
+	return page, total, nil
+}

--- a/internal/api/scim/memory_repository_test.go
+++ b/internal/api/scim/memory_repository_test.go
@@ -1,0 +1,80 @@
+package scim
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/supabase/auth/internal/api/scim/core"
+)
+
+func user(id string) *core.User {
+	return &core.User{ID: id, UserName: id + "@example.com"}
+}
+
+func TestMemoryRepositoryGet(t *testing.T) {
+	ctx := context.Background()
+	repo := NewUserMemoryRepository()
+	repo.Put("tenant-a", user("1"))
+
+	t.Run("returns a stored resource", func(t *testing.T) {
+		got, err := repo.Get(ctx, "tenant-a", "1")
+		require.NoError(t, err)
+		require.Equal(t, "1", got.ID)
+	})
+
+	t.Run("reports an unknown id as not found", func(t *testing.T) {
+		got, err := repo.Get(ctx, "tenant-a", "missing")
+		require.Nil(t, got)
+		require.True(t, errors.Is(err, ErrNotFound))
+	})
+
+	t.Run("does not reach across tenants", func(t *testing.T) {
+		got, err := repo.Get(ctx, "tenant-b", "1")
+		require.Nil(t, got)
+		require.True(t, errors.Is(err, ErrNotFound))
+	})
+}
+
+func TestMemoryRepositoryList(t *testing.T) {
+	ctx := context.Background()
+	repo := NewUserMemoryRepository()
+	for _, id := range []string{"3", "1", "2"} {
+		repo.Put("tenant-a", user(id))
+	}
+	repo.Put("tenant-b", user("9"))
+
+	ids := func(users []*core.User) []string {
+		out := make([]string, 0, len(users))
+		for _, u := range users {
+			out = append(out, u.ID)
+		}
+		return out
+	}
+
+	t.Run("returns every resource with the total", func(t *testing.T) {
+		users, total, err := repo.List(ctx, "tenant-a", 100, 0)
+		require.NoError(t, err)
+		require.Equal(t, 3, total)
+		require.Equal(t, []string{"1", "2", "3"}, ids(users))
+	})
+
+	t.Run("walks the collection in a stable order", func(t *testing.T) {
+		first, _, err := repo.List(ctx, "tenant-a", 2, 0)
+		require.NoError(t, err)
+		second, total, err := repo.List(ctx, "tenant-a", 2, 2)
+		require.NoError(t, err)
+
+		require.Equal(t, 3, total)
+		require.Equal(t, []string{"1", "2"}, ids(first))
+		require.Equal(t, []string{"3"}, ids(second))
+	})
+
+	t.Run("scopes the collection to one tenant", func(t *testing.T) {
+		users, total, err := repo.List(ctx, "tenant-b", 100, 0)
+		require.NoError(t, err)
+		require.Equal(t, 1, total)
+		require.Equal(t, []string{"9"}, ids(users))
+	})
+}

--- a/internal/api/scim/middleware.go
+++ b/internal/api/scim/middleware.go
@@ -1,0 +1,55 @@
+package scim
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/gofrs/uuid"
+	"github.com/supabase/auth/internal/api/shared"
+	"github.com/supabase/auth/internal/models"
+)
+
+// TEMPORARY: this header stands in for the per-provider SCIM token
+const ProviderHeaderName = "x-scim-provider-id"
+
+func (srv *Server) Tenant(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx, ok := srv.tenant(w, r)
+		if !ok {
+			return
+		}
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}
+
+func (srv *Server) tenant(w http.ResponseWriter, r *http.Request) (context.Context, bool) {
+	ctx := r.Context()
+
+	id := providerID(r)
+	if id == uuid.Nil {
+		_ = srv.NotFound(w, r)
+		return nil, false
+	}
+
+	provider, err := models.FindSSOProviderByID(srv.db.WithContext(ctx), id)
+	if err != nil {
+		if models.IsNotFoundError(err) {
+			_ = srv.NotFound(w, r)
+			return nil, false
+		}
+		_ = srv.internalError(w, r, err)
+		return nil, false
+	}
+
+	return shared.WithSSOProvider(ctx, provider), true
+}
+
+func providerID(r *http.Request) uuid.UUID {
+	// TEMPORARY: reads the provider id from the "x-scim-provider-id" header until SCIM Tokens ship
+	id, err := uuid.FromString(r.Header.Get(ProviderHeaderName))
+	if err != nil {
+		return uuid.Nil
+	}
+
+	return id
+}

--- a/internal/api/scim/repository.go
+++ b/internal/api/scim/repository.go
@@ -1,0 +1,21 @@
+package scim
+
+import (
+	"context"
+	"errors"
+
+	"github.com/supabase/auth/internal/api/scim/core"
+)
+
+var ErrNotFound = errors.New("scim: resource not found")
+
+type Repository[T any] interface {
+	Get(ctx context.Context, tenant, id string) (T, error)
+	List(ctx context.Context, tenant string, count, offset int) (items []T, total int, err error)
+}
+
+type UserRepository = Repository[*core.User]
+
+func NewUserMemoryRepository() *MemoryRepository[*core.User] {
+	return NewMemoryRepository(func(u *core.User) string { return u.ID })
+}

--- a/internal/api/scim/server.go
+++ b/internal/api/scim/server.go
@@ -8,23 +8,29 @@ import (
 	"github.com/supabase/auth/internal/api/scim/core"
 	"github.com/supabase/auth/internal/api/scim/protocol"
 	"github.com/supabase/auth/internal/conf"
+	"github.com/supabase/auth/internal/observability"
+	"github.com/supabase/auth/internal/storage"
 )
 
 const BasePath = "/scim/v2"
 
 type Server struct {
 	baseURL               string
+	db                    *storage.Connection
+	users                 UserRepository
 	serviceProviderConfig *core.ServiceProviderConfig
 	resourceTypes         []*core.ResourceType
 	schemas               []*core.Schema
 }
 
-func NewServer(config *conf.GlobalConfiguration) *Server {
+func NewServer(config *conf.GlobalConfiguration, db *storage.Connection, users UserRepository) *Server {
 	baseURL := core.Join(config.API.ExternalURL, BasePath)
 	userSchema := newUserSchema(baseURL)
 
 	return &Server{
 		baseURL: baseURL,
+		db:      db,
+		users:   users,
 		serviceProviderConfig: core.NewServiceProviderConfig(
 			baseURL,
 			core.NewOAuthBearerToken().AsPrimary(),
@@ -76,6 +82,18 @@ func urlParam(r *http.Request, key string) string {
 
 func (srv *Server) NotFound(w http.ResponseWriter, r *http.Request) error {
 	return protocol.SendError(w, http.StatusNotFound, "", "Endpoint or resource does not exist")
+}
+
+func (srv *Server) internalError(w http.ResponseWriter, r *http.Request, err error) error {
+	observability.LogEntrySetField(r, "error", err.Error())
+	return protocol.SendError(w, http.StatusInternalServerError, "", "Internal server error")
+}
+
+func rejectFilter(w http.ResponseWriter, r *http.Request, status int, scimType protocol.ScimType) (bool, error) {
+	if !r.URL.Query().Has("filter") {
+		return false, nil
+	}
+	return true, protocol.SendError(w, status, scimType, "Filtering is not supported on this endpoint")
 }
 
 func list[T any](w http.ResponseWriter, r *http.Request, resources []T) error {

--- a/internal/api/scim/server_test.go
+++ b/internal/api/scim/server_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/gofrs/uuid"
 	"github.com/stretchr/testify/require"
 	"github.com/supabase/auth/internal/api/scim/core"
 	"github.com/supabase/auth/internal/api/scim/protocol"
@@ -19,16 +20,16 @@ import (
 //go:embed testdata/*
 var fixtures embed.FS
 
+func newServerFor(externalURL string) *Server {
+	return NewServer(&conf.GlobalConfiguration{
+		API: conf.APIConfiguration{ExternalURL: externalURL},
+	}, nil, NewUserMemoryRepository())
+}
+
 func testFixture(t *testing.T, file string) string {
 	data, err := fixtures.ReadFile("testdata/" + file)
 	require.NoError(t, err)
 	return string(data)
-}
-
-func newServerFor(externalURL string) *Server {
-	return NewServer(&conf.GlobalConfiguration{
-		API: conf.APIConfiguration{ExternalURL: externalURL},
-	})
 }
 
 func TestServer(t *testing.T) {
@@ -120,6 +121,54 @@ func TestServer(t *testing.T) {
 		require.Equal(t, http.StatusNotFound, w.Code)
 		require.Equal(t, protocol.MediaType, w.Header().Get("Content-Type"))
 		require.JSONEq(t, testFixture(t, "not_found.json"), w.Body.String())
+	})
+
+	t.Run("Users rejects a filter it cannot honour", func(t *testing.T) {
+		filter := url.Values{"filter": {`userName eq "user@example.com"`}}.Encode()
+		r := httptest.NewRequest(http.MethodGet, BasePath+"/Users?"+filter, nil)
+		w := httptest.NewRecorder()
+
+		require.NoError(t, srv.Users(w, r))
+
+		require.Equal(t, http.StatusBadRequest, w.Code)
+		require.Equal(t, protocol.MediaType, w.Header().Get("Content-Type"))
+		require.JSONEq(t, testFixture(t, "filter_invalid.json"), w.Body.String())
+	})
+
+	t.Run("Users rejects pagination parameters that are not integers", func(t *testing.T) {
+		for _, query := range []string{"startIndex=first", "count=all"} {
+			t.Run(query, func(t *testing.T) {
+				r := httptest.NewRequest(http.MethodGet, BasePath+"/Users?"+query, nil)
+				w := httptest.NewRecorder()
+
+				require.NoError(t, srv.Users(w, r))
+
+				require.Equal(t, http.StatusBadRequest, w.Code)
+				require.Equal(t, protocol.MediaType, w.Header().Get("Content-Type"))
+				require.Contains(t, w.Body.String(), string(protocol.ScimTypeInvalidValue))
+			})
+		}
+	})
+
+	t.Run("Users without a tenant on the context is a server error", func(t *testing.T) {
+		r := httptest.NewRequest(http.MethodGet, BasePath+"/Users", nil)
+		w := httptest.NewRecorder()
+
+		require.NoError(t, srv.Users(w, r))
+
+		require.Equal(t, http.StatusNotFound, w.Code)
+		require.Equal(t, protocol.MediaType, w.Header().Get("Content-Type"))
+	})
+
+	t.Run("UserByID without a tenant on the context is a server error", func(t *testing.T) {
+		id := uuid.Must(uuid.NewV4()).String()
+		r := requestWithURLParam("Users/"+id, "id", id)
+		w := httptest.NewRecorder()
+
+		require.NoError(t, srv.UserByID(w, r))
+
+		require.Equal(t, http.StatusNotFound, w.Code)
+		require.Equal(t, protocol.MediaType, w.Header().Get("Content-Type"))
 	})
 }
 

--- a/internal/api/scim/testdata/filter_invalid.json
+++ b/internal/api/scim/testdata/filter_invalid.json
@@ -1,0 +1,8 @@
+{
+  "schemas": [
+    "urn:ietf:params:scim:api:messages:2.0:Error"
+  ],
+  "scimType": "invalidFilter",
+  "detail": "Filtering is not supported on this endpoint",
+  "status": "400"
+}

--- a/internal/api/scim/users.go
+++ b/internal/api/scim/users.go
@@ -1,0 +1,59 @@
+package scim
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/gofrs/uuid"
+	"github.com/supabase/auth/internal/api/scim/protocol"
+	"github.com/supabase/auth/internal/api/shared"
+)
+
+func (srv *Server) UserByID(w http.ResponseWriter, r *http.Request) error {
+	ctx := r.Context()
+
+	id, err := uuid.FromString(urlParam(r, "id"))
+	if err != nil {
+		return srv.NotFound(w, r)
+	}
+
+	provider := shared.GetSSOProvider(ctx)
+	if provider == nil {
+		return srv.NotFound(w, r)
+	}
+
+	user, err := srv.users.Get(ctx, provider.ID.String(), id.String())
+	if err != nil {
+		if errors.Is(err, ErrNotFound) {
+			return srv.NotFound(w, r)
+		}
+		return srv.internalError(w, r, err)
+	}
+
+	return protocol.Send(w, http.StatusOK, user)
+}
+
+func (srv *Server) Users(w http.ResponseWriter, r *http.Request) error {
+	ctx := r.Context()
+
+	if rejected, err := rejectFilter(w, r, http.StatusBadRequest, protocol.ScimTypeInvalidFilter); rejected {
+		return err
+	}
+
+	page, err := protocol.ParsePage(r.URL.Query())
+	if err != nil {
+		return protocol.SendError(w, http.StatusBadRequest, protocol.ScimTypeInvalidValue, err.Error())
+	}
+
+	provider := shared.GetSSOProvider(ctx)
+	if provider == nil {
+		return srv.NotFound(w, r)
+	}
+
+	users, total, err := srv.users.List(ctx, provider.ID.String(), page.Count, page.Offset())
+	if err != nil {
+		return srv.internalError(w, r, err)
+	}
+
+	return protocol.Send(w, http.StatusOK, protocol.NewPage(users, page.StartIndex, total))
+}

--- a/internal/api/scim_test.go
+++ b/internal/api/scim_test.go
@@ -18,12 +18,18 @@ const (
 	scimServiceProviderConfigPath = "/scim/v2/ServiceProviderConfig"
 	scimResourceTypesPath         = "/scim/v2/ResourceTypes"
 	scimSchemasPath               = "/scim/v2/Schemas"
+	scimUsersPath                 = "/scim/v2/Users"
 )
 
 var scimPaths = []string{
 	scimServiceProviderConfigPath,
 	scimResourceTypesPath,
 	scimSchemasPath,
+	// /Users is admin-gated, but chi resolves 405 and the disabled-feature 404
+	// before any per-route middleware runs, so both loops below reach it
+	// without credentials. It stays out of the enabled-200 loop, which asserts
+	// the 403 that only the metadata endpoints return for a filter.
+	scimUsersPath,
 }
 
 func TestSCIM(t *testing.T) {

--- a/internal/api/scim_users_test.go
+++ b/internal/api/scim_users_test.go
@@ -1,0 +1,234 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gofrs/uuid"
+	jwt "github.com/golang-jwt/jwt/v5"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	"github.com/supabase/auth/internal/api/scim"
+	"github.com/supabase/auth/internal/api/scim/core"
+	"github.com/supabase/auth/internal/api/scim/protocol"
+	"github.com/supabase/auth/internal/conf"
+	"github.com/supabase/auth/internal/models"
+	"github.com/supabase/auth/internal/storage"
+)
+
+type tenant struct {
+	handler  http.Handler
+	provider *models.SSOProvider
+	users    []*core.User
+	domain   string
+	token    string
+}
+
+func (t *tenant) get(id string) *httptest.ResponseRecorder {
+	return t.do("/scim/v2/Users/" + id)
+}
+
+func (t *tenant) list(query string) *httptest.ResponseRecorder {
+	if query != "" {
+		query = "?" + query
+	}
+	return t.do("/scim/v2/Users" + query)
+}
+
+func (t *tenant) do(path string) *httptest.ResponseRecorder {
+	r := httptest.NewRequest(http.MethodGet, path, nil)
+	w := httptest.NewRecorder()
+
+	r.Header.Set("Authorization", "Bearer "+t.token)
+	r.Header.Set(scim.ProviderHeaderName, t.provider.ID.String())
+	t.handler.ServeHTTP(w, r)
+	return w
+}
+
+func (t *tenant) userIDs() []string {
+	ids := make([]string, 0, len(t.users))
+	for _, user := range t.users {
+		ids = append(ids, user.ID)
+	}
+	return ids
+}
+
+type SCIMUsersTestSuite struct {
+	suite.Suite
+	API     *API
+	Config  *conf.GlobalConfiguration
+	Users   *scim.MemoryRepository[*core.User]
+	TenantA *tenant
+	TenantB *tenant
+}
+
+func TestSCIMUsers(t *testing.T) {
+	users := scim.NewUserMemoryRepository()
+	api, config, err := setupAPIForTestWithCallback(func(cfg *conf.GlobalConfiguration, _ *storage.Connection) {
+		if cfg != nil {
+			cfg.Experimental.ScimEnabled = true
+		}
+	}, WithSCIMUserRepository(users))
+	require.NoError(t, err)
+	defer api.db.Close()
+
+	suite.Run(t, &SCIMUsersTestSuite{API: api, Config: config, Users: users})
+}
+
+func (ts *SCIMUsersTestSuite) SetupTest() {
+	require.NoError(ts.T(), models.TruncateAll(ts.API.db))
+
+	ts.TenantA = ts.buildTenant("example.com", 3)
+	ts.TenantB = ts.buildTenant("example.org", 3)
+}
+
+func (ts *SCIMUsersTestSuite) TestGetUser() {
+	ts.Run("returns the user that belongs to the requested provider", func() {
+		user := ts.TenantA.users[0]
+
+		w := ts.TenantA.get(user.ID)
+
+		require.Equal(ts.T(), http.StatusOK, w.Code)
+		require.Equal(ts.T(), protocol.MediaType, w.Header().Get("Content-Type"))
+		require.JSONEq(ts.T(), fmt.Sprintf(`{
+			"schemas": [%q],
+			"id": %q,
+			"userName": %q,
+			"meta": {
+				"resourceType": "User",
+				"created": %q,
+				"lastModified": %q,
+				"location": "%s/scim/v2/Users/%s"
+			}
+		}`,
+			core.SchemaUser,
+			user.ID,
+			user.UserName,
+			user.Meta.Created.Format(time.RFC3339Nano),
+			user.Meta.LastModified.Format(time.RFC3339Nano),
+			ts.Config.API.ExternalURL, user.ID,
+		), w.Body.String())
+	})
+
+	ts.Run("scopes each provider to its own users", func() {
+		require.Equal(ts.T(), http.StatusOK, ts.TenantA.get(ts.TenantA.users[0].ID).Code)
+		require.Equal(ts.T(), http.StatusNotFound, ts.TenantB.get(ts.TenantA.users[0].ID).Code)
+
+		require.Equal(ts.T(), http.StatusOK, ts.TenantB.get(ts.TenantB.users[0].ID).Code)
+		require.Equal(ts.T(), http.StatusNotFound, ts.TenantA.get(ts.TenantB.users[0].ID).Code)
+	})
+}
+
+func (ts *SCIMUsersTestSuite) TestListUsers() {
+	ts.Run("returns every user the provider has provisioned", func() {
+		w := ts.TenantA.list("")
+
+		require.Equal(ts.T(), http.StatusOK, w.Code)
+		require.Equal(ts.T(), protocol.MediaType, w.Header().Get("Content-Type"))
+
+		body := ts.decode(w)
+		require.Equal(ts.T(), []core.SchemaURI{protocol.SchemaListResponse}, body.Schemas)
+		require.Equal(ts.T(), 3, body.TotalResults)
+		require.Equal(ts.T(), 1, body.StartIndex)
+		require.Equal(ts.T(), 3, body.ItemsPerPage)
+		require.ElementsMatch(ts.T(), ts.TenantA.userIDs(), resourceIDs(body))
+	})
+
+	ts.Run("scopes the collection to the requesting provider", func() {
+		require.ElementsMatch(ts.T(), ts.TenantA.userIDs(), resourceIDs(ts.decode(ts.TenantA.list(""))))
+		require.ElementsMatch(ts.T(), ts.TenantB.userIDs(), resourceIDs(ts.decode(ts.TenantB.list(""))))
+	})
+
+	ts.Run("refuses a request without credentials", func() {
+		r := httptest.NewRequest(http.MethodGet, "/scim/v2/Users", nil)
+		w := httptest.NewRecorder()
+
+		ts.API.handler.ServeHTTP(w, r)
+
+		require.Equal(ts.T(), http.StatusUnauthorized, w.Code)
+	})
+
+	ts.Run("refuses a request for a provider that does not exist", func() {
+		r := httptest.NewRequest(http.MethodGet, "/scim/v2/Users", nil)
+		w := httptest.NewRecorder()
+
+		r.Header.Set("Authorization", "Bearer "+ts.TenantA.token)
+		r.Header.Set(scim.ProviderHeaderName, uuid.Must(uuid.NewV4()).String())
+		ts.API.handler.ServeHTTP(w, r)
+
+		require.Equal(ts.T(), http.StatusNotFound, w.Code)
+		require.Equal(ts.T(), protocol.MediaType, w.Header().Get("Content-Type"))
+	})
+}
+
+func resourceIDs(body *protocol.ListResponse[core.User]) []string {
+	ids := make([]string, 0, len(body.Resources))
+	for _, resource := range body.Resources {
+		ids = append(ids, resource.ID)
+	}
+	return ids
+}
+
+func (ts *SCIMUsersTestSuite) decode(w *httptest.ResponseRecorder) *protocol.ListResponse[core.User] {
+	ts.T().Helper()
+
+	body := &protocol.ListResponse[core.User]{}
+	require.NoError(ts.T(), json.Unmarshal(w.Body.Bytes(), body))
+	return body
+}
+
+func (ts *SCIMUsersTestSuite) buildTenant(domain string, users int) *tenant {
+	ts.T().Helper()
+
+	id := uuid.Must(uuid.NewV4()).String()
+	provider := &models.SSOProvider{
+		SAMLProvider: models.SAMLProvider{
+			EntityID:    "https://example.com/saml/metadata/" + id,
+			MetadataXML: "<example />",
+		},
+		SSODomains: []models.SSODomain{{Domain: domain}},
+	}
+	require.NoError(ts.T(), ts.API.db.Eager().Create(provider))
+
+	tn := &tenant{
+		handler:  ts.API.handler,
+		provider: provider,
+		domain:   domain,
+		token:    ts.signClaims(&AccessTokenClaims{Role: "supabase_admin"}),
+	}
+	for range users {
+		tn.users = append(tn.users, ts.buildUser(tn, uuid.Must(uuid.NewV4()).String()))
+	}
+
+	return tn
+}
+
+func (ts *SCIMUsersTestSuite) buildUser(t *tenant, username string) *core.User {
+	ts.T().Helper()
+
+	id := uuid.Must(uuid.NewV4()).String()
+	now := time.Now()
+	user := &core.User{
+		Schemas:  []core.SchemaURI{core.SchemaUser},
+		ID:       id,
+		UserName: username + "@" + t.domain,
+		Meta:     core.NewMetaForID(ts.baseURL(), core.KindUser, id, now, now),
+	}
+	ts.Users.Put(t.provider.ID.String(), user)
+
+	return user
+}
+
+func (ts *SCIMUsersTestSuite) baseURL() string {
+	return core.Join(ts.Config.API.ExternalURL, scim.BasePath)
+}
+
+func (ts *SCIMUsersTestSuite) signClaims(claims *AccessTokenClaims) string {
+	token, err := jwt.NewWithClaims(jwt.SigningMethodHS256, claims).SignedString([]byte(ts.Config.JWT.Secret))
+	require.NoError(ts.T(), err)
+	return token
+}

--- a/internal/api/shared/context.go
+++ b/internal/api/shared/context.go
@@ -18,6 +18,7 @@ const (
 	UserKey              ContextKey = "user"
 	SessionKey           ContextKey = "session"
 	OAuthServerClientKey ContextKey = "oauth_server_client"
+	SSOProviderKey       ContextKey = "sso_provider"
 )
 
 // GetUser reads the user from the context - shared implementation
@@ -69,4 +70,21 @@ func GetOAuthServerClient(ctx context.Context) *models.OAuthServerClient {
 		return nil
 	}
 	return obj.(*models.OAuthServerClient)
+}
+
+// GetSSOProvider reads the SSO provider from the context - shared implementation
+func GetSSOProvider(ctx context.Context) *models.SSOProvider {
+	if ctx == nil {
+		return nil
+	}
+	obj := ctx.Value(SSOProviderKey)
+	if obj == nil {
+		return nil
+	}
+	return obj.(*models.SSOProvider)
+}
+
+// WithSSOProvider adds the SSO provider to the context - shared implementation
+func WithSSOProvider(ctx context.Context, provider *models.SSOProvider) context.Context {
+	return context.WithValue(ctx, SSOProviderKey, provider)
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature. Adds `GET /scim/v2/Users/{id}`, the first SCIM resource endpoint.

https://linear.app/supabase/issue/AUTH-1368/scim-users-get-by-id

## What is the current behavior?

`/scim/v2` serves the three discovery endpoints and nothing else.

Before:

```bash
curl -H "Authorization: Bearer $TOKEN" http://localhost:9999/scim/v2/Users/64db64f9-15e5-4da2-a06f-0627c9c76baa | jq
{
  "schemas": [
    "urn:ietf:params:scim:api:messages:2.0:Error"
  ],
  "detail": "A valid SCIM bearer token is required",
  "status": "401"
}
```

## What is the new behavior?

`scim.Server.Authenticate` resolves the SSO provider that owns the presented bearer token and puts it on the request context. `UserByID` then returns that provider's user:

| case | response |
|---|---|
| user belongs to the token's provider | `200` + User resource, `application/scim+json` |
| missing, malformed, or unknown token | `401` + `WWW-Authenticate: Bearer` |
| token resolves but the provider is disabled | `403` |
| unknown id, another provider's user, soft deleted user, malformed id | `404`, identical body |

Discovery stays unauthenticated. `Authenticate` is scoped to the `/Users` route so a deployment with no provisioned tenant still serves `/Schemas`.

After:

```bash
モ curl -H "Authorization: Bearer $TOKEN" http://localhost:9999/scim/v2/Users/64db64f9-15e5-4da2-a06f-0627c9c76baa | jq
{
  "schemas": [
    "urn:ietf:params:scim:schemas:core:2.0:User"
  ],
  "id": "64db64f9-15e5-4da2-a06f-0627c9c76baa",
  "userName": "mo@example.com",
  "emails": [
    {
      "value": "mo@example.com",
      "primary": true
    }
  ],
  "meta": {
    "resourceType": "User",
    "created": "2026-08-07T23:34:38.055886Z",
    "lastModified": "2026-08-07T23:34:38.064015Z",
    "location": "https://example.ngrok-free.dev/scim/v2/Users/64db64f9-15e5-4da2-a06f-0627c9c76baa"
  }
}
```

## Additional context
