### PR TITLE
fix: correctly update email confirmation when an identity is unlinked

### DIFF
--- a/internal/api/identity_test.go
+++ b/internal/api/identity_test.go
@@ -220,6 +220,132 @@ func (ts *IdentityTestSuite) TestUnlinkIdentity() {
 
 }
 
+func (ts *IdentityTestSuite) TestUnlinkIdentityEmailVerification() {
+	ts.Config.Security.ManualLinkingEnabled = true
+
+	boolPtr := func(b bool) *bool { return &b }
+	cases := []struct {
+		desc string
+		// value of email_verified on the remaining identity; nil means
+		// the key is absent from identity_data
+		emailVerified     *bool
+		expectedConfirmed bool
+	}{
+		{
+			desc:              "Promoting an unverified identity email unconfirms the user",
+			emailVerified:     boolPtr(false),
+			expectedConfirmed: false,
+		},
+		{
+			desc:              "Promoting a verified identity email keeps the user confirmed",
+			emailVerified:     boolPtr(true),
+			expectedConfirmed: true,
+		},
+		{
+			desc:              "Promoting an identity without email_verified unconfirms the user",
+			emailVerified:     nil,
+			expectedConfirmed: false,
+		},
+	}
+
+	for _, c := range cases {
+		ts.Run(c.desc, func() {
+			ts.SetupTest()
+			u, err := models.NewUser("", "primary@example.com", "password", ts.Config.JWT.Aud, nil)
+			require.NoError(ts.T(), err)
+			require.NoError(ts.T(), ts.API.db.Create(u))
+			require.NoError(ts.T(), u.Confirm(ts.API.db))
+
+			emailIdentity, err := models.NewIdentity(u, "email", map[string]any{
+				"sub":            u.ID.String(),
+				"email":          u.GetEmail(),
+				"email_verified": true,
+			})
+			require.NoError(ts.T(), err)
+			require.NoError(ts.T(), ts.API.db.Create(emailIdentity))
+
+			googleData := map[string]any{
+				"sub":   u.ID.String(),
+				"email": "other@example.com",
+			}
+			if c.emailVerified != nil {
+				googleData["email_verified"] = *c.emailVerified
+			}
+			googleIdentity, err := models.NewIdentity(u, "google", googleData)
+			require.NoError(ts.T(), err)
+			require.NoError(ts.T(), ts.API.db.Create(googleIdentity))
+
+			token := ts.generateAccessTokenAndSession(u)
+			req, err := http.NewRequest(http.MethodDelete, fmt.Sprintf("/user/identities/%s", emailIdentity.ID), nil)
+			require.NoError(ts.T(), err)
+			req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
+			w := httptest.NewRecorder()
+			ts.API.handler.ServeHTTP(w, req)
+			require.Equal(ts.T(), http.StatusOK, w.Code)
+
+			u, err = models.FindUserByID(ts.API.db, u.ID)
+			require.NoError(ts.T(), err)
+			require.Equal(ts.T(), "other@example.com", u.GetEmail())
+			if c.expectedConfirmed {
+				require.NotNil(ts.T(), u.EmailConfirmedAt)
+				require.NotNil(ts.T(), u.ConfirmedAt)
+			} else {
+				require.Nil(ts.T(), u.EmailConfirmedAt)
+				require.Nil(ts.T(), u.ConfirmedAt)
+				require.Equal(ts.T(), false, u.UserMetaData["email_verified"])
+			}
+		})
+	}
+}
+
+func (ts *IdentityTestSuite) TestUnlinkIdentityPrefersVerifiedEmail() {
+	ts.Config.Security.ManualLinkingEnabled = true
+
+	u, err := models.NewUser("", "primary@example.com", "password", ts.Config.JWT.Aud, nil)
+	require.NoError(ts.T(), err)
+	require.NoError(ts.T(), ts.API.db.Create(u))
+	require.NoError(ts.T(), u.Confirm(ts.API.db))
+
+	emailIdentity, err := models.NewIdentity(u, "email", map[string]any{
+		"sub":            u.ID.String(),
+		"email":          u.GetEmail(),
+		"email_verified": true,
+	})
+	require.NoError(ts.T(), err)
+	require.NoError(ts.T(), ts.API.db.Create(emailIdentity))
+
+	unverifiedIdentity, err := models.NewIdentity(u, "google", map[string]any{
+		"sub":            u.ID.String(),
+		"email":          "unverified@example.com",
+		"email_verified": false,
+	})
+	require.NoError(ts.T(), err)
+	require.NoError(ts.T(), ts.API.db.Create(unverifiedIdentity))
+
+	verifiedIdentity, err := models.NewIdentity(u, "github", map[string]any{
+		"sub":            u.ID.String(),
+		"email":          "verified@example.com",
+		"email_verified": true,
+	})
+	require.NoError(ts.T(), err)
+	require.NoError(ts.T(), ts.API.db.Create(verifiedIdentity))
+
+	token := ts.generateAccessTokenAndSession(u)
+	req, err := http.NewRequest(http.MethodDelete, fmt.Sprintf("/user/identities/%s", emailIdentity.ID), nil)
+	require.NoError(ts.T(), err)
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
+	w := httptest.NewRecorder()
+	ts.API.handler.ServeHTTP(w, req)
+	require.Equal(ts.T(), http.StatusOK, w.Code)
+
+	// the verified identity's email should be promoted even though the
+	// unverified identity was created first, keeping the user confirmed
+	u, err = models.FindUserByID(ts.API.db, u.ID)
+	require.NoError(ts.T(), err)
+	require.Equal(ts.T(), "verified@example.com", u.GetEmail())
+	require.NotNil(ts.T(), u.EmailConfirmedAt)
+}
+
 func (ts *IdentityTestSuite) generateAccessTokenAndSession(u *models.User) string {
 	s, err := models.NewSession(u.ID, nil)
 	require.NoError(ts.T(), err)

--- a/internal/models/identity.go
+++ b/internal/models/identity.go
@@ -37,6 +37,13 @@ func (i *Identity) GetEmail() string {
 	return string(i.Email)
 }
 
+// IsEmailVerified returns true only when identity_data contains
+// "email_verified": true. A missing key is treated as unverified.
+func (i *Identity) IsEmailVerified() bool {
+	verified, ok := i.IdentityData["email_verified"].(bool)
+	return ok && verified
+}
+
 // NewIdentity returns an identity associated to the user's id.
 func NewIdentity(user *User, provider string, identityData map[string]interface{}) (*Identity, error) {
 	providerId, ok := identityData["sub"]

--- a/internal/models/user.go
+++ b/internal/models/user.go
@@ -328,9 +328,44 @@ func (u *User) UpdateUserEmailFromIdentities(tx *storage.Connection) error {
 	if primaryIdentity == nil {
 		return UserEmailUniqueConflictError{}
 	}
+	previousEmail := u.GetEmail()
 	// default to the first identity's email
 	if terr := u.SetEmail(tx, primaryIdentity.GetEmail()); terr != nil {
 		return terr
+	}
+	if previousEmail != "" {
+		// outstanding tokens were sent to the previous email which is no
+		// longer linked to the user so they can't be trusted anymore
+		u.ConfirmationToken = ""
+		u.ConfirmationSentAt = nil
+		u.RecoveryToken = ""
+		u.RecoverySentAt = nil
+		u.EmailChange = ""
+		u.EmailChangeTokenCurrent = ""
+		u.EmailChangeTokenNew = ""
+		u.EmailChangeSentAt = nil
+		u.EmailChangeConfirmStatus = 0
+		u.ReauthenticationToken = ""
+		u.ReauthenticationSentAt = nil
+		if terr := tx.UpdateOnly(
+			u,
+			"confirmation_token",
+			"confirmation_sent_at",
+			"recovery_token",
+			"recovery_sent_at",
+			"email_change",
+			"email_change_token_current",
+			"email_change_token_new",
+			"email_change_sent_at",
+			"email_change_confirm_status",
+			"reauthentication_token",
+			"reauthentication_sent_at",
+		); terr != nil {
+			return terr
+		}
+		if terr := ClearAllOneTimeTokensForUser(tx, u.ID); terr != nil {
+			return terr
+		}
 	}
 	if primaryIdentity.GetEmail() == "" || !primaryIdentity.IsEmailVerified() {
 		// the promoted email was never verified by the IdP or ourselves,

--- a/internal/models/user.go
+++ b/internal/models/user.go
@@ -7,6 +7,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"math"
+	"sort"
 	"strings"
 	"time"
 
@@ -287,6 +288,31 @@ func (u *User) UpdateUserEmailFromIdentities(tx *storage.Connection) error {
 		}
 	}
 
+	// We select identities in the following order of priority:
+	// 	1. identities whose email was verified by the identity provider
+	// 	2. identities with an unverified email
+	// 	3. identities without an email (e.g. phone)
+	identityRank := func(i *Identity) int {
+		switch {
+		case i.GetEmail() == "":
+			return 2
+		case !i.IsEmailVerified():
+			return 1
+		default:
+			return 0
+		}
+	}
+	sort.SliceStable(identities, func(a, b int) bool {
+		ia, ib := identities[a], identities[b]
+		if ra, rb := identityRank(ia), identityRank(ib); ra != rb {
+			return ra < rb
+		}
+		if !ia.CreatedAt.Equal(ib.CreatedAt) {
+			return ia.CreatedAt.Before(ib.CreatedAt)
+		}
+		return ia.ID.String() < ib.ID.String()
+	})
+
 	var primaryIdentity *Identity
 	for _, i := range identities {
 		if _, terr := FindUserByEmailAndAudience(tx, i.GetEmail(), u.Aud); terr != nil {
@@ -306,9 +332,16 @@ func (u *User) UpdateUserEmailFromIdentities(tx *storage.Connection) error {
 	if terr := u.SetEmail(tx, primaryIdentity.GetEmail()); terr != nil {
 		return terr
 	}
-	if primaryIdentity.GetEmail() == "" {
+	if primaryIdentity.GetEmail() == "" || !primaryIdentity.IsEmailVerified() {
+		// the promoted email was never verified by the IdP or ourselves,
+		// so the user's email can no longer be considered confirmed
 		u.EmailConfirmedAt = nil
 		if terr := tx.UpdateOnly(u, "email_confirmed_at"); terr != nil {
+			return terr
+		}
+		if terr := u.UpdateUserMetaData(tx, map[string]any{
+			"email_verified": false,
+		}); terr != nil {
 			return terr
 		}
 	}

--- a/internal/models/user.go
+++ b/internal/models/user.go
@@ -328,44 +328,14 @@ func (u *User) UpdateUserEmailFromIdentities(tx *storage.Connection) error {
 	if primaryIdentity == nil {
 		return UserEmailUniqueConflictError{}
 	}
-	previousEmail := u.GetEmail()
 	// default to the first identity's email
 	if terr := u.SetEmail(tx, primaryIdentity.GetEmail()); terr != nil {
 		return terr
 	}
-	if previousEmail != "" {
-		// outstanding tokens were sent to the previous email which is no
-		// longer linked to the user so they can't be trusted anymore
-		u.ConfirmationToken = ""
-		u.ConfirmationSentAt = nil
-		u.RecoveryToken = ""
-		u.RecoverySentAt = nil
-		u.EmailChange = ""
-		u.EmailChangeTokenCurrent = ""
-		u.EmailChangeTokenNew = ""
-		u.EmailChangeSentAt = nil
-		u.EmailChangeConfirmStatus = 0
-		u.ReauthenticationToken = ""
-		u.ReauthenticationSentAt = nil
-		if terr := tx.UpdateOnly(
-			u,
-			"confirmation_token",
-			"confirmation_sent_at",
-			"recovery_token",
-			"recovery_sent_at",
-			"email_change",
-			"email_change_token_current",
-			"email_change_token_new",
-			"email_change_sent_at",
-			"email_change_confirm_status",
-			"reauthentication_token",
-			"reauthentication_sent_at",
-		); terr != nil {
-			return terr
-		}
-		if terr := ClearAllOneTimeTokensForUser(tx, u.ID); terr != nil {
-			return terr
-		}
+	// outstanding tokens and pending account changes were issued before the
+	// primary email transition so they can't be trusted anymore
+	if terr := u.ClearAllPendingTokens(tx); terr != nil {
+		return terr
 	}
 	if primaryIdentity.GetEmail() == "" || !primaryIdentity.IsEmailVerified() {
 		// the promoted email was never verified by the IdP or ourselves,
@@ -381,6 +351,46 @@ func (u *User) UpdateUserEmailFromIdentities(tx *storage.Connection) error {
 		}
 	}
 	return nil
+}
+
+// ClearAllPendingTokens revokes all outstanding confirmation, recovery,
+// email change, phone change and reauthentication tokens issued for the
+// user, together with their one-time token rows.
+func (u *User) ClearAllPendingTokens(tx *storage.Connection) error {
+	u.ConfirmationToken = ""
+	u.ConfirmationSentAt = nil
+	u.RecoveryToken = ""
+	u.RecoverySentAt = nil
+	u.EmailChange = ""
+	u.EmailChangeTokenCurrent = ""
+	u.EmailChangeTokenNew = ""
+	u.EmailChangeSentAt = nil
+	u.EmailChangeConfirmStatus = 0
+	u.PhoneChange = ""
+	u.PhoneChangeToken = ""
+	u.PhoneChangeSentAt = nil
+	u.ReauthenticationToken = ""
+	u.ReauthenticationSentAt = nil
+	if terr := tx.UpdateOnly(
+		u,
+		"confirmation_token",
+		"confirmation_sent_at",
+		"recovery_token",
+		"recovery_sent_at",
+		"email_change",
+		"email_change_token_current",
+		"email_change_token_new",
+		"email_change_sent_at",
+		"email_change_confirm_status",
+		"phone_change",
+		"phone_change_token",
+		"phone_change_sent_at",
+		"reauthentication_token",
+		"reauthentication_sent_at",
+	); terr != nil {
+		return terr
+	}
+	return ClearAllOneTimeTokensForUser(tx, u.ID)
 }
 
 // SetEmail sets the user's email

--- a/internal/models/user_test.go
+++ b/internal/models/user_test.go
@@ -469,15 +469,17 @@ func (ts *UserTestSuite) TestUpdateUserEmailSuccess() {
 	userA, err := NewUser("", "foo@example.com", "", "authenticated", nil)
 	require.NoError(ts.T(), err)
 	require.NoError(ts.T(), ts.db.Create(userA))
+	require.NoError(ts.T(), userA.Confirm(ts.db))
 
-	primaryIdentity, err := NewIdentity(userA, "email", map[string]interface{}{
+	primaryIdentity, err := NewIdentity(userA, "email", map[string]any{
 		"sub":   userA.ID.String(),
 		"email": "foo@example.com",
 	})
 	require.NoError(ts.T(), err)
 	require.NoError(ts.T(), ts.db.Create(primaryIdentity))
 
-	secondaryIdentity, err := NewIdentity(userA, "google", map[string]interface{}{
+	// secondary identity without an email_verified key, must be treated as unverified
+	secondaryIdentity, err := NewIdentity(userA, "google", map[string]any{
 		"sub":   userA.ID.String(),
 		"email": "bar@example.com",
 	})
@@ -487,13 +489,123 @@ func (ts *UserTestSuite) TestUpdateUserEmailSuccess() {
 	// UpdateUserEmail should not do anything and the user's email should still use the primaryIdentity
 	require.NoError(ts.T(), userA.UpdateUserEmailFromIdentities(ts.db))
 	require.Equal(ts.T(), primaryIdentity.GetEmail(), userA.GetEmail())
+	require.NotNil(ts.T(), userA.EmailConfirmedAt)
 
 	// remove primary identity
 	require.NoError(ts.T(), ts.db.Destroy(primaryIdentity))
 
 	// UpdateUserEmail should update the user to use the secondary identity's email
+	// and clear the confirmation state since the promoted email was never verified
 	require.NoError(ts.T(), userA.UpdateUserEmailFromIdentities(ts.db))
 	require.Equal(ts.T(), secondaryIdentity.GetEmail(), userA.GetEmail())
+	require.Nil(ts.T(), userA.EmailConfirmedAt)
+	require.Equal(ts.T(), false, userA.UserMetaData["email_verified"])
+}
+
+func (ts *UserTestSuite) TestUpdateUserEmailFromVerifiedIdentity() {
+	userA, err := NewUser("", "foo@example.com", "", "authenticated", nil)
+	require.NoError(ts.T(), err)
+	require.NoError(ts.T(), ts.db.Create(userA))
+	require.NoError(ts.T(), userA.Confirm(ts.db))
+
+	secondaryIdentity, err := NewIdentity(userA, "google", map[string]any{
+		"sub":            userA.ID.String(),
+		"email":          "bar@example.com",
+		"email_verified": true,
+	})
+	require.NoError(ts.T(), err)
+	require.NoError(ts.T(), ts.db.Create(secondaryIdentity))
+
+	// the promoted email was verified by the identity provider so the
+	// user's confirmation state should be kept
+	require.NoError(ts.T(), userA.UpdateUserEmailFromIdentities(ts.db))
+	require.Equal(ts.T(), secondaryIdentity.GetEmail(), userA.GetEmail())
+	require.NotNil(ts.T(), userA.EmailConfirmedAt)
+}
+
+func (ts *UserTestSuite) TestUpdateUserEmailFromUnverifiedIdentity() {
+	userA, err := NewUser("", "foo@example.com", "", "authenticated", nil)
+	require.NoError(ts.T(), err)
+	require.NoError(ts.T(), ts.db.Create(userA))
+	require.NoError(ts.T(), userA.Confirm(ts.db))
+
+	secondaryIdentity, err := NewIdentity(userA, "google", map[string]any{
+		"sub":            userA.ID.String(),
+		"email":          "bar@example.com",
+		"email_verified": false,
+	})
+	require.NoError(ts.T(), err)
+	require.NoError(ts.T(), ts.db.Create(secondaryIdentity))
+
+	// the promoted email was never verified so the user should no longer
+	// be considered confirmed
+	require.NoError(ts.T(), userA.UpdateUserEmailFromIdentities(ts.db))
+	require.Equal(ts.T(), secondaryIdentity.GetEmail(), userA.GetEmail())
+	require.Nil(ts.T(), userA.EmailConfirmedAt)
+	require.Equal(ts.T(), false, userA.UserMetaData["email_verified"])
+}
+
+func (ts *UserTestSuite) TestUpdateUserEmailPrefersVerifiedIdentity() {
+	userA, err := NewUser("", "foo@example.com", "", "authenticated", nil)
+	require.NoError(ts.T(), err)
+	require.NoError(ts.T(), ts.db.Create(userA))
+	require.NoError(ts.T(), userA.Confirm(ts.db))
+
+	unverifiedIdentity, err := NewIdentity(userA, "google", map[string]any{
+		"sub":            userA.ID.String(),
+		"email":          "unverified@example.com",
+		"email_verified": false,
+	})
+	require.NoError(ts.T(), err)
+	require.NoError(ts.T(), ts.db.Create(unverifiedIdentity))
+
+	verifiedIdentity, err := NewIdentity(userA, "github", map[string]any{
+		"sub":            userA.ID.String(),
+		"email":          "verified@example.com",
+		"email_verified": true,
+	})
+	require.NoError(ts.T(), err)
+	require.NoError(ts.T(), ts.db.Create(verifiedIdentity))
+
+	// the verified identity should be promoted even though the unverified
+	// identity was created first
+	require.NoError(ts.T(), userA.UpdateUserEmailFromIdentities(ts.db))
+	require.Equal(ts.T(), verifiedIdentity.GetEmail(), userA.GetEmail())
+	require.NotNil(ts.T(), userA.EmailConfirmedAt)
+}
+
+func (ts *UserTestSuite) TestUpdateUserEmailVerifiedConflictFallsBack() {
+	userA, err := NewUser("", "foo@example.com", "", "authenticated", nil)
+	require.NoError(ts.T(), err)
+	require.NoError(ts.T(), ts.db.Create(userA))
+	require.NoError(ts.T(), userA.Confirm(ts.db))
+
+	verifiedIdentity, err := NewIdentity(userA, "google", map[string]any{
+		"sub":            userA.ID.String(),
+		"email":          "bar@example.com",
+		"email_verified": true,
+	})
+	require.NoError(ts.T(), err)
+	require.NoError(ts.T(), ts.db.Create(verifiedIdentity))
+
+	unverifiedIdentity, err := NewIdentity(userA, "github", map[string]any{
+		"sub":            userA.ID.String(),
+		"email":          "baz@example.com",
+		"email_verified": false,
+	})
+	require.NoError(ts.T(), err)
+	require.NoError(ts.T(), ts.db.Create(unverifiedIdentity))
+
+	userB, err := NewUser("", "bar@example.com", "", "authenticated", nil)
+	require.NoError(ts.T(), err)
+	require.NoError(ts.T(), ts.db.Create(userB))
+
+	// the verified identity's email is taken by userB so the unverified
+	// identity is promoted instead, which unconfirms the user
+	require.NoError(ts.T(), userA.UpdateUserEmailFromIdentities(ts.db))
+	require.Equal(ts.T(), unverifiedIdentity.GetEmail(), userA.GetEmail())
+	require.Nil(ts.T(), userA.EmailConfirmedAt)
+	require.Equal(ts.T(), false, userA.UserMetaData["email_verified"])
 }
 
 func (ts *UserTestSuite) TestUpdateUserEmailFailure() {

--- a/internal/models/user_test.go
+++ b/internal/models/user_test.go
@@ -633,6 +633,9 @@ func (ts *UserTestSuite) TestUpdateUserEmailClearsStaleTokens() {
 	userA.EmailChangeTokenNew = "email-change-new-hash"
 	userA.EmailChangeSentAt = &now
 	userA.EmailChangeConfirmStatus = 1
+	userA.PhoneChange = "123456789"
+	userA.PhoneChangeToken = "phone-change-token-hash"
+	userA.PhoneChangeSentAt = &now
 	userA.ReauthenticationToken = "reauthentication-token-hash"
 	userA.ReauthenticationSentAt = &now
 	require.NoError(ts.T(), ts.db.UpdateOnly(
@@ -646,6 +649,9 @@ func (ts *UserTestSuite) TestUpdateUserEmailClearsStaleTokens() {
 		"email_change_token_new",
 		"email_change_sent_at",
 		"email_change_confirm_status",
+		"phone_change",
+		"phone_change_token",
+		"phone_change_sent_at",
 		"reauthentication_token",
 		"reauthentication_sent_at",
 	))
@@ -667,12 +673,58 @@ func (ts *UserTestSuite) TestUpdateUserEmailClearsStaleTokens() {
 	require.Empty(ts.T(), userA.EmailChangeTokenNew)
 	require.Nil(ts.T(), userA.EmailChangeSentAt)
 	require.Equal(ts.T(), 0, userA.EmailChangeConfirmStatus)
+	require.Empty(ts.T(), userA.PhoneChange)
+	require.Empty(ts.T(), userA.PhoneChangeToken)
+	require.Nil(ts.T(), userA.PhoneChangeSentAt)
 	require.Empty(ts.T(), userA.ReauthenticationToken)
 	require.Nil(ts.T(), userA.ReauthenticationSentAt)
 
 	// the one-time token must no longer be redeemable
 	_, err = FindUserByConfirmationToken(ts.db, "confirmation-token-hash")
 	require.Error(ts.T(), err)
+}
+
+func (ts *UserTestSuite) TestUpdateUserEmailFromEmptyClearsStaleTokens() {
+	// a user without an email or identities, e.g. an anonymous user
+	userA, err := NewUser("", "", "", "authenticated", nil)
+	require.NoError(ts.T(), err)
+	require.NoError(ts.T(), ts.db.Create(userA))
+
+	identity, err := NewIdentity(userA, "google", map[string]any{
+		"sub":            userA.ID.String(),
+		"email":          "bar@example.com",
+		"email_verified": true,
+	})
+	require.NoError(ts.T(), err)
+	require.NoError(ts.T(), ts.db.Create(identity))
+
+	// simulate a phone change requested before the identity was linked
+	now := time.Now()
+	userA.PhoneChange = "123456789"
+	userA.PhoneChangeToken = "phone-change-token-hash"
+	userA.PhoneChangeSentAt = &now
+	require.NoError(ts.T(), ts.db.UpdateOnly(
+		userA,
+		"phone_change",
+		"phone_change_token",
+		"phone_change_sent_at",
+	))
+	require.NoError(ts.T(), CreateOneTimeToken(ts.db, userA.ID, userA.PhoneChange, userA.PhoneChangeToken, PhoneChangeToken))
+
+	// promoting an identity's email over an empty one is still a primary
+	// email transition, so outstanding tokens must be revoked
+	require.NoError(ts.T(), userA.UpdateUserEmailFromIdentities(ts.db))
+	require.Equal(ts.T(), identity.GetEmail(), userA.GetEmail())
+
+	userA, err = FindUserByID(ts.db, userA.ID)
+	require.NoError(ts.T(), err)
+	require.Empty(ts.T(), userA.PhoneChange)
+	require.Empty(ts.T(), userA.PhoneChangeToken)
+	require.Nil(ts.T(), userA.PhoneChangeSentAt)
+
+	_, err = FindOneTimeToken(ts.db, "phone-change-token-hash", PhoneChangeToken)
+	require.Error(ts.T(), err)
+	require.True(ts.T(), IsNotFoundError(err))
 }
 
 func (ts *UserTestSuite) TestUpdateUserEmailFailure() {

--- a/internal/models/user_test.go
+++ b/internal/models/user_test.go
@@ -608,6 +608,73 @@ func (ts *UserTestSuite) TestUpdateUserEmailVerifiedConflictFallsBack() {
 	require.Equal(ts.T(), false, userA.UserMetaData["email_verified"])
 }
 
+func (ts *UserTestSuite) TestUpdateUserEmailClearsStaleTokens() {
+	userA, err := NewUser("", "foo@example.com", "", "authenticated", nil)
+	require.NoError(ts.T(), err)
+	require.NoError(ts.T(), ts.db.Create(userA))
+	require.NoError(ts.T(), userA.Confirm(ts.db))
+
+	secondaryIdentity, err := NewIdentity(userA, "google", map[string]interface{}{
+		"sub":            userA.ID.String(),
+		"email":          "bar@example.com",
+		"email_verified": true,
+	})
+	require.NoError(ts.T(), err)
+	require.NoError(ts.T(), ts.db.Create(secondaryIdentity))
+
+	// simulate outstanding tokens sent to the previous email
+	now := time.Now()
+	userA.ConfirmationToken = "confirmation-token-hash"
+	userA.ConfirmationSentAt = &now
+	userA.RecoveryToken = "recovery-token-hash"
+	userA.RecoverySentAt = &now
+	userA.EmailChange = "baz@example.com"
+	userA.EmailChangeTokenCurrent = "email-change-current-hash"
+	userA.EmailChangeTokenNew = "email-change-new-hash"
+	userA.EmailChangeSentAt = &now
+	userA.EmailChangeConfirmStatus = 1
+	userA.ReauthenticationToken = "reauthentication-token-hash"
+	userA.ReauthenticationSentAt = &now
+	require.NoError(ts.T(), ts.db.UpdateOnly(
+		userA,
+		"confirmation_token",
+		"confirmation_sent_at",
+		"recovery_token",
+		"recovery_sent_at",
+		"email_change",
+		"email_change_token_current",
+		"email_change_token_new",
+		"email_change_sent_at",
+		"email_change_confirm_status",
+		"reauthentication_token",
+		"reauthentication_sent_at",
+	))
+	require.NoError(ts.T(), CreateOneTimeToken(ts.db, userA.ID, userA.GetEmail(), userA.ConfirmationToken, ConfirmationToken))
+
+	// promoting another identity's email must revoke every outstanding
+	// token addressed to the previous email
+	require.NoError(ts.T(), userA.UpdateUserEmailFromIdentities(ts.db))
+	require.Equal(ts.T(), secondaryIdentity.GetEmail(), userA.GetEmail())
+
+	userA, err = FindUserByID(ts.db, userA.ID)
+	require.NoError(ts.T(), err)
+	require.Empty(ts.T(), userA.ConfirmationToken)
+	require.Nil(ts.T(), userA.ConfirmationSentAt)
+	require.Empty(ts.T(), userA.RecoveryToken)
+	require.Nil(ts.T(), userA.RecoverySentAt)
+	require.Empty(ts.T(), userA.EmailChange)
+	require.Empty(ts.T(), userA.EmailChangeTokenCurrent)
+	require.Empty(ts.T(), userA.EmailChangeTokenNew)
+	require.Nil(ts.T(), userA.EmailChangeSentAt)
+	require.Equal(ts.T(), 0, userA.EmailChangeConfirmStatus)
+	require.Empty(ts.T(), userA.ReauthenticationToken)
+	require.Nil(ts.T(), userA.ReauthenticationSentAt)
+
+	// the one-time token must no longer be redeemable
+	_, err = FindUserByConfirmationToken(ts.db, "confirmation-token-hash")
+	require.Error(ts.T(), err)
+}
+
 func (ts *UserTestSuite) TestUpdateUserEmailFailure() {
 	userA, err := NewUser("", "foo@example.com", "", "authenticated", nil)
 	require.NoError(ts.T(), err)


### PR DESCRIPTION
When unlinking an identity, `UpdateUserEmailFromIdentities` could promote another identity's email into `users.email` while keeping the previous `email_confirmed_at`, so an unverified address inherited verified status.

The identity that will be promoted is selected in the following order:

1. identities whose email was verified by the identity provider
2. identities with an unverified email
3. identities without an email (e.g. phone)

This PR also clears the tokens and state when the email has changed on the user.