### PR TITLE
fix(web3): always bind SIWE/SIWS Domain to URI host

### DIFF
--- a/internal/api/web3.go
+++ b/internal/api/web3.go
@@ -88,7 +88,12 @@ func (a *API) web3GrantSolana(ctx context.Context, w http.ResponseWriter, r *htt
 		return apierrors.NewOAuthError("invalid_grant", "Signed Solana message is using URI which is not allowed on this server, message was signed for another app")
 	}
 
-	if parsedMessage.URI.Hostname() != "localhost" && (parsedMessage.URI.Host != parsedMessage.Domain || !utilities.IsRedirectURLValid(config, "https://"+parsedMessage.Domain+"/")) {
+	// Domain must always match URI authority (incl. localhost). Skipping this
+	// for localhost previously allowed Domain=attacker.com with URI=http://localhost...
+	if parsedMessage.URI.Host != parsedMessage.Domain {
+		return apierrors.NewOAuthError("invalid_grant", "Signed Solana message is using a Domain that does not match the one in URI which is not allowed on this server")
+	}
+	if parsedMessage.URI.Hostname() != "localhost" && !utilities.IsRedirectURLValid(config, "https://"+parsedMessage.Domain+"/") {
 		return apierrors.NewOAuthError("invalid_grant", "Signed Solana message is using a Domain that does not match the one in URI which is not allowed on this server")
 	}
 
@@ -234,7 +239,12 @@ func (a *API) web3GrantEthereum(ctx context.Context, w http.ResponseWriter, r *h
 		return apierrors.NewOAuthError("invalid_grant", "Signed Ethereum message is using URI which is not allowed on this server, message was signed for another app")
 	}
 
-	if parsedMessage.URI.Hostname() != "localhost" && (parsedMessage.URI.Host != parsedMessage.Domain || !utilities.IsRedirectURLValid(config, "https://"+parsedMessage.Domain+"/")) {
+	// Domain must always match URI authority (incl. localhost). Skipping this
+	// for localhost previously allowed Domain=attacker.com with URI=http://localhost...
+	if parsedMessage.URI.Host != parsedMessage.Domain {
+		return apierrors.NewOAuthError("invalid_grant", "Signed Ethereum message is using a Domain that does not match the one in URI which is not allowed on this server")
+	}
+	if parsedMessage.URI.Hostname() != "localhost" && !utilities.IsRedirectURLValid(config, "https://"+parsedMessage.Domain+"/") {
 		return apierrors.NewOAuthError("invalid_grant", "Signed Ethereum message is using a Domain that does not match the one in URI which is not allowed on this server")
 	}
 


### PR DESCRIPTION
## Summary

Domain matching for Web3 SIWE/SIWS grants was skipped when `URI.Hostname() == "localhost"`. That let a signed message with `Domain=attacker.example` and an allowlisted `URI=http://localhost:5173/` skip the domain bind while still passing the URI allowlist.

This change always requires `URI.Host == Domain`. The existing `https://{Domain}/` allowlist check remains for non-localhost hosts so legitimate localhost happy-path fixtures keep working.

## Test plan

- [ ] CI green
- [x] Local: Solana mismatched-domain path still returns `invalid_grant` (domain bind)
- [ ] Confirm localhost happy-path messages with matching `Domain`/`URI` still succeed in full suite


Made with [Cursor](https://cursor.com)