### PR TITLE
feat(auditlogs): emit identity linked action

### DIFF
--- a/client/admin/client.go
+++ b/client/admin/client.go
@@ -1396,6 +1396,7 @@ type GetAdminAuditResponse struct {
 			// - verification_attempted
 			// - factor_deleted
 			// - factor_updated
+			// - identity_linked
 			// - identity_unlinked
 			// - passkey_created
 			// - passkey_updated
@@ -2023,6 +2024,7 @@ func ParseGetAdminAuditResponse(rsp *http.Response) (*GetAdminAuditResponse, err
 				// - verification_attempted
 				// - factor_deleted
 				// - factor_updated
+				// - identity_linked
 				// - identity_unlinked
 				// - passkey_created
 				// - passkey_updated

--- a/internal/api/external.go
+++ b/internal/api/external.go
@@ -322,6 +322,14 @@ func (a *API) createAccountFromExternalIdentity(tx *storage.Connection, r *http.
 			return 0, nil, terr
 		}
 
+		if terr = models.NewAuditLogEntry(config.AuditLog, r, tx, user, models.IdentityLinkAction, utilities.GetIPAddress(r), map[string]any{
+			"identity_id": identity.ID,
+			"provider":    identity.Provider,
+			"provider_id": identity.ProviderID,
+		}); terr != nil {
+			return 0, nil, terr
+		}
+
 	case models.CreateAccount:
 		if config.DisableSignup {
 			return 0, nil, apierrors.NewUnprocessableEntityError(apierrors.ErrorCodeSignupDisabled, "Signups not allowed for this instance")

--- a/internal/api/external_test.go
+++ b/internal/api/external_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gofrs/uuid"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+	"github.com/supabase/auth/internal/api/provider"
 	"github.com/supabase/auth/internal/conf"
 	"github.com/supabase/auth/internal/models"
 )
@@ -40,6 +41,54 @@ func (ts *ExternalTestSuite) SetupTest() {
 	ts.Config.Mailer.Autoconfirm = false
 
 	models.TruncateAll(ts.API.db)
+}
+
+func (ts *ExternalTestSuite) TestAutomaticLinkIdentityWritesAuditLog() {
+	existingUser, err := ts.createUser("", "automatic-link@example.com", "", "", "")
+	require.NoError(ts.T(), err)
+	require.NoError(ts.T(), existingUser.Confirm(ts.API.db))
+
+	userData := &provider.UserProvidedData{
+		Metadata: &provider.Claims{
+			Subject:       "automatic-link-subject",
+			Email:         existingUser.GetEmail(),
+			EmailVerified: true,
+		},
+		Emails: []provider.Email{{
+			Email:    existingUser.GetEmail(),
+			Primary:  true,
+			Verified: true,
+		}},
+	}
+	r := httptest.NewRequest(http.MethodGet, "/callback", nil)
+	r.RemoteAddr = "192.0.2.1:1234"
+
+	decision, user, err := ts.API.createAccountFromExternalIdentity(ts.API.db, r, userData, "google", false)
+	require.NoError(ts.T(), err)
+	require.Equal(ts.T(), models.LinkAccount, decision)
+	require.Equal(ts.T(), existingUser.ID, user.ID)
+
+	identity, err := models.FindIdentityByIdAndProvider(ts.API.db, userData.Metadata.Subject, "google")
+	require.NoError(ts.T(), err)
+	logs, err := models.FindAuditLogEntries(ts.API.db, []string{"action"}, string(models.IdentityLinkAction), nil)
+	require.NoError(ts.T(), err)
+	require.Len(ts.T(), logs, 1)
+	require.Equal(ts.T(), string(models.IdentityLinkAction), logs[0].Payload["action"])
+	require.Equal(ts.T(), "user", logs[0].Payload["log_type"])
+	traits, ok := logs[0].Payload["traits"].(map[string]any)
+	require.True(ts.T(), ok)
+	require.Equal(ts.T(), identity.ID.String(), traits["identity_id"])
+	require.Equal(ts.T(), "google", traits["provider"])
+	require.Equal(ts.T(), userData.Metadata.Subject, traits["provider_id"])
+	require.Equal(ts.T(), "192.0.2.1", logs[0].IPAddress)
+
+	decision, _, err = ts.API.createAccountFromExternalIdentity(ts.API.db, r, userData, "google", false)
+	require.NoError(ts.T(), err)
+	require.Equal(ts.T(), models.AccountExists, decision)
+
+	logs, err = models.FindAuditLogEntries(ts.API.db, []string{"action"}, string(models.IdentityLinkAction), nil)
+	require.NoError(ts.T(), err)
+	require.Len(ts.T(), logs, 1, "signing in with an existing identity must not emit another audit log")
 }
 
 func (ts *ExternalTestSuite) createUser(providerId string, email string, name string, avatar string, confirmationToken string) (*models.User, error) {

--- a/internal/api/identity.go
+++ b/internal/api/identity.go
@@ -184,8 +184,16 @@ func (a *API) linkIdentityToUser(r *http.Request, ctx context.Context, tx *stora
 		}
 		return nil, apierrors.NewUnprocessableEntityError(apierrors.ErrorCodeIdentityAlreadyExists, "Identity is already linked to another user")
 	}
-	if _, terr := a.createNewIdentity(tx, targetUser, providerType, structs.Map(userData.Metadata)); terr != nil {
+	identity, terr = a.createNewIdentity(tx, targetUser, providerType, structs.Map(userData.Metadata))
+	if terr != nil {
 		return nil, terr
+	}
+	if terr := models.NewAuditLogEntry(a.config.AuditLog, r, tx, targetUser, models.IdentityLinkAction, utilities.GetIPAddress(r), map[string]any{
+		"identity_id": identity.ID,
+		"provider":    identity.Provider,
+		"provider_id": identity.ProviderID,
+	}); terr != nil {
+		return nil, apierrors.NewInternalServerError("Error recording audit log entry").WithInternalError(terr)
 	}
 
 	if targetUser.GetEmail() == "" {

--- a/internal/api/identity.go
+++ b/internal/api/identity.go
@@ -12,6 +12,7 @@ import (
 	"github.com/supabase/auth/internal/api/provider"
 	"github.com/supabase/auth/internal/models"
 	"github.com/supabase/auth/internal/storage"
+	"github.com/supabase/auth/internal/utilities"
 )
 
 func (a *API) DeleteIdentity(w http.ResponseWriter, r *http.Request) error {
@@ -54,7 +55,7 @@ func (a *API) DeleteIdentity(w http.ResponseWriter, r *http.Request) error {
 	provider := identityToBeDeleted.Provider
 	recipientEmail := user.GetEmail()
 	err = db.Transaction(func(tx *storage.Connection) error {
-		if terr := models.NewAuditLogEntry(config.AuditLog, r, tx, user, models.IdentityUnlinkAction, "", map[string]interface{}{
+		if terr := models.NewAuditLogEntry(config.AuditLog, r, tx, user, models.IdentityUnlinkAction, utilities.GetIPAddress(r), map[string]any{
 			"identity_id": identityToBeDeleted.ID,
 			"provider":    identityToBeDeleted.Provider,
 			"provider_id": identityToBeDeleted.ProviderID,

--- a/internal/api/identity_test.go
+++ b/internal/api/identity_test.go
@@ -198,6 +198,7 @@ func (ts *IdentityTestSuite) TestUnlinkIdentity() {
 			req, err := http.NewRequest(http.MethodDelete, fmt.Sprintf("/user/identities/%s", identity.ID), nil)
 			require.NoError(ts.T(), err)
 			req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
+			req.RemoteAddr = "192.0.2.1:1234"
 			w := httptest.NewRecorder()
 			ts.API.handler.ServeHTTP(w, req)
 			require.Equal(ts.T(), http.StatusOK, w.Code)
@@ -207,6 +208,18 @@ func (ts *IdentityTestSuite) TestUnlinkIdentity() {
 			require.NoError(ts.T(), err)
 			require.Len(ts.T(), u.Identities, 1)
 			require.Equal(ts.T(), u.Identities[0].Provider, c.providerRemaining)
+
+			// an audit log entry should be recorded for the unlinked identity
+			logs, err := models.FindAuditLogEntries(ts.API.db, []string{"action"}, string(models.IdentityUnlinkAction), nil)
+			require.NoError(ts.T(), err)
+			require.Len(ts.T(), logs, 1)
+			require.Equal(ts.T(), string(models.IdentityUnlinkAction), logs[0].Payload["action"])
+			require.Equal(ts.T(), "user", logs[0].Payload["log_type"])
+			traits, ok := logs[0].Payload["traits"].(map[string]any)
+			require.True(ts.T(), ok)
+			require.Equal(ts.T(), identity.ID.String(), traits["identity_id"])
+			require.Equal(ts.T(), c.provider, traits["provider"])
+			require.Equal(ts.T(), "192.0.2.1", logs[0].IPAddress)
 
 			// conditional checks depending on the provider that was unlinked
 			switch c.provider {

--- a/internal/api/identity_test.go
+++ b/internal/api/identity_test.go
@@ -91,6 +91,7 @@ func (ts *IdentityTestSuite) TestLinkIdentityToUser() {
 	}
 	// request is just used as a placeholder in the function
 	r := httptest.NewRequest(http.MethodGet, "/identities", nil)
+	r.RemoteAddr = "192.0.2.1:1234"
 	u, err = ts.API.linkIdentityToUser(r, ctx, ts.API.db, testValidUserData, "test")
 	require.NoError(ts.T(), err)
 
@@ -99,6 +100,20 @@ func (ts *IdentityTestSuite) TestLinkIdentityToUser() {
 	require.Len(ts.T(), u.Identities, 2)
 	require.Equal(ts.T(), u.AppMetaData["provider"], "email")
 	require.Equal(ts.T(), u.AppMetaData["providers"], []string{"email", "test"})
+
+	identity, err := models.FindIdentityByIdAndProvider(ts.API.db, testValidUserData.Metadata.Subject, "test")
+	require.NoError(ts.T(), err)
+	logs, err := models.FindAuditLogEntries(ts.API.db, []string{"action"}, string(models.IdentityLinkAction), nil)
+	require.NoError(ts.T(), err)
+	require.Len(ts.T(), logs, 1)
+	require.Equal(ts.T(), string(models.IdentityLinkAction), logs[0].Payload["action"])
+	require.Equal(ts.T(), "user", logs[0].Payload["log_type"])
+	traits, ok := logs[0].Payload["traits"].(map[string]any)
+	require.True(ts.T(), ok)
+	require.Equal(ts.T(), identity.ID.String(), traits["identity_id"])
+	require.Equal(ts.T(), "test", traits["provider"])
+	require.Equal(ts.T(), testValidUserData.Metadata.Subject, traits["provider_id"])
+	require.Equal(ts.T(), "192.0.2.1", logs[0].IPAddress)
 
 	// link an already existing identity
 	testExistingUserData := &provider.UserProvidedData{
@@ -109,6 +124,10 @@ func (ts *IdentityTestSuite) TestLinkIdentityToUser() {
 	u, err = ts.API.linkIdentityToUser(r, ctx, ts.API.db, testExistingUserData, "email")
 	require.ErrorIs(ts.T(), err, apierrors.NewUnprocessableEntityError(apierrors.ErrorCodeIdentityAlreadyExists, "Identity is already linked"))
 	require.Nil(ts.T(), u)
+
+	logs, err = models.FindAuditLogEntries(ts.API.db, []string{"action"}, string(models.IdentityLinkAction), nil)
+	require.NoError(ts.T(), err)
+	require.Len(ts.T(), logs, 1, "an already-linked identity must not emit another audit log")
 }
 
 func (ts *IdentityTestSuite) TestUnlinkIdentityError() {

--- a/internal/models/audit_log_entry.go
+++ b/internal/models/audit_log_entry.go
@@ -41,6 +41,7 @@ const (
 	VerifyFactorAction              AuditAction = "verification_attempted"
 	DeleteFactorAction              AuditAction = "factor_deleted"
 	UpdateFactorAction              AuditAction = "factor_updated"
+	IdentityLinkAction              AuditAction = "identity_linked"
 	IdentityUnlinkAction            AuditAction = "identity_unlinked"
 	PasskeyCreatedAction            AuditAction = "passkey_created"
 	PasskeyUpdatedAction            AuditAction = "passkey_updated"
@@ -68,6 +69,7 @@ var ActionLogTypeMap = map[AuditAction]auditLogType{
 	UserConfirmationRequestedAction: user,
 	UserRepeatedSignUpAction:        user,
 	UserUpdatePasswordAction:        user,
+	IdentityLinkAction:              user,
 	IdentityUnlinkAction:            user,
 	EnrollFactorAction:              factor,
 	UnenrollFactorAction:            factor,

--- a/internal/models/audit_log_entry.go
+++ b/internal/models/audit_log_entry.go
@@ -64,6 +64,7 @@ var ActionLogTypeMap = map[AuditAction]auditLogType{
 	TokenRefreshedAction:            token,
 	UserModifiedAction:              user,
 	UserRecoveryRequestedAction:     user,
+	UserReauthenticateAction:        user,
 	UserConfirmationRequestedAction: user,
 	UserRepeatedSignUpAction:        user,
 	UserUpdatePasswordAction:        user,

--- a/internal/models/audit_log_entry.go
+++ b/internal/models/audit_log_entry.go
@@ -68,6 +68,7 @@ var ActionLogTypeMap = map[AuditAction]auditLogType{
 	UserConfirmationRequestedAction: user,
 	UserRepeatedSignUpAction:        user,
 	UserUpdatePasswordAction:        user,
+	IdentityUnlinkAction:            user,
 	EnrollFactorAction:              factor,
 	UnenrollFactorAction:            factor,
 	CreateChallengeAction:           factor,

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1495,6 +1495,7 @@ paths:
                             - verification_attempted
                             - factor_deleted
                             - factor_updated
+                            - identity_linked
                             - identity_unlinked
                             - passkey_created
                             - passkey_updated


### PR DESCRIPTION
This PR fixes a few issues with out audit logs, namely:

- The `UserReauthenticationAction` and the `IdentityUnlinkAction` were not mapped so they had an empty log_type
- The IP address was missing from the `IdentityUnlinkAction`
- A complimentary `IdentityLinkAction` did not exist

Note: the identity linked action is emitted only during explicit manual account linking or when an identity is automatically linked. It is **not** emitted when an identity is created for a new account.

