### PR TITLE
fix(identity): link an email-optional identity to a phone-only user

### DIFF
--- a/internal/api/identity.go
+++ b/internal/api/identity.go
@@ -203,14 +203,23 @@ func (a *API) linkIdentityToUser(r *http.Request, ctx context.Context, tx *stora
 			}
 			return nil, terr
 		}
-		if !userData.Metadata.EmailVerified {
-			if terr := a.sendConfirmation(r, tx, targetUser, models.ImplicitFlow); terr != nil {
+		// Only require email confirmation when the linked identity actually
+		// contributed an email address. An email-optional identity (for
+		// example an OIDC provider whose claim carries no email) leaves the
+		// primary email empty after UpdateUserEmailFromIdentities, so there is
+		// nothing to confirm and no confirmation email must be sent. Guarding
+		// on the resulting email keeps a confirmed phone-only user linkable to
+		// such an identity instead of failing with EmailNotConfirmed.
+		if targetUser.GetEmail() != "" {
+			if !userData.Metadata.EmailVerified {
+				if terr := a.sendConfirmation(r, tx, targetUser, models.ImplicitFlow); terr != nil {
+					return nil, terr
+				}
+				return nil, storage.NewCommitWithError(apierrors.NewUnprocessableEntityError(apierrors.ErrorCodeEmailNotConfirmed, "Unverified email with %v. A confirmation email has been sent to your %v email", providerType, providerType))
+			}
+			if terr := targetUser.Confirm(tx); terr != nil {
 				return nil, terr
 			}
-			return nil, storage.NewCommitWithError(apierrors.NewUnprocessableEntityError(apierrors.ErrorCodeEmailNotConfirmed, "Unverified email with %v. A confirmation email has been sent to your %v email", providerType, providerType))
-		}
-		if terr := targetUser.Confirm(tx); terr != nil {
-			return nil, terr
 		}
 
 		if targetUser.IsAnonymous {

--- a/internal/api/identity_test.go
+++ b/internal/api/identity_test.go
@@ -130,6 +130,81 @@ func (ts *IdentityTestSuite) TestLinkIdentityToUser() {
 	require.Len(ts.T(), logs, 1, "an already-linked identity must not emit another audit log")
 }
 
+// TestLinkIdentityToUserEmailOptional covers linking an email-optional
+// identity (e.g. an OIDC provider whose claim carries no email) to a confirmed
+// phone-only user. UpdateUserEmailFromIdentities leaves the primary email empty
+// in that case, so no email confirmation must be attempted and linking must
+// succeed. The unverified-email case is kept as a control to show the
+// confirmation path is still exercised when an email is actually present.
+func (ts *IdentityTestSuite) TestLinkIdentityToUserEmailOptional() {
+	newPhoneOnlyUser := func(phone string) *models.User {
+		u, err := models.NewUser(phone, "", "", ts.Config.JWT.Aud, nil)
+		require.NoError(ts.T(), err)
+		require.NoError(ts.T(), ts.API.db.Create(u))
+		require.NoError(ts.T(), u.ConfirmPhone(ts.API.db))
+
+		i, err := models.NewIdentity(u, "phone", map[string]interface{}{
+			"sub":   u.ID.String(),
+			"phone": u.GetPhone(),
+		})
+		require.NoError(ts.T(), err)
+		require.NoError(ts.T(), ts.API.db.Create(i))
+		return u
+	}
+
+	r := httptest.NewRequest(http.MethodGet, "/identities", nil)
+
+	ts.Run("no email in the identity links without confirmation", func() {
+		u := newPhoneOnlyUser("15551230001")
+		ctx := withTargetUser(context.Background(), u)
+
+		data := &provider.UserProvidedData{
+			Metadata: &provider.Claims{
+				Subject:       "oidc_no_email_subject",
+				Email:         "",
+				EmailVerified: false,
+			},
+		}
+		linked, err := ts.API.linkIdentityToUser(r, ctx, ts.API.db, data, "custom_oidc")
+		require.NoError(ts.T(), err)
+		require.NotNil(ts.T(), linked)
+		require.Equal(ts.T(), "", linked.GetEmail(), "email must stay empty when the linked identity has none")
+		require.Equal(ts.T(), "15551230001", linked.GetPhone(), "the confirmed phone must be preserved")
+
+		_, err = models.FindIdentityByIdAndProvider(ts.API.db, "oidc_no_email_subject", "custom_oidc")
+		require.NoError(ts.T(), err, "the email-optional identity must be linked")
+	})
+
+	ts.Run("unverified email in the identity still requires confirmation", func() {
+		// A user with no email and no email-less identity: linking an
+		// identity that DOES carry an unverified email promotes that email,
+		// so confirmation must still be required. This is the control that
+		// shows the fix does not suppress confirmation whenever an email is
+		// actually adopted. (A phone-only user is unsuitable here: its
+		// empty-email phone identity makes UpdateUserEmailFromIdentities keep
+		// the empty email, so no email is ever promoted.)
+		u, err := models.NewUser("", "", "", ts.Config.JWT.Aud, nil)
+		require.NoError(ts.T(), err)
+		u.IsAnonymous = true
+		require.NoError(ts.T(), ts.API.db.Create(u))
+		ctx := withTargetUser(context.Background(), u)
+
+		data := &provider.UserProvidedData{
+			Metadata: &provider.Claims{
+				Subject:       "oidc_unverified_email_subject",
+				Email:         "unverified@example.com",
+				EmailVerified: false,
+			},
+		}
+		_, err = ts.API.linkIdentityToUser(r, ctx, ts.API.db, data, "custom_oidc")
+		require.Error(ts.T(), err)
+		// The confirmation path returns the HTTPError wrapped in a
+		// storage.CommitWithError (which exposes Cause, not Unwrap), so assert
+		// on the stable user-facing message rather than unwrapping.
+		require.Contains(ts.T(), err.Error(), "Unverified email")
+	})
+}
+
 func (ts *IdentityTestSuite) TestUnlinkIdentityError() {
 	manualLinkingEnabled := ts.Config.Security.ManualLinkingEnabled
 	ts.Config.Security.ManualLinkingEnabled = true


### PR DESCRIPTION
## What

Linking an email-optional identity (for example an OIDC provider whose claim
carries no email) to a confirmed phone-only user currently fails with
`422 email_not_confirmed`, even though there is no email to confirm.

Fixes #2640.

## Why it happens

In `linkIdentityToUser` (`internal/api/identity.go`), when the target user has
no primary email the code does:

```go
if targetUser.GetEmail() == "" {
    targetUser.UpdateUserEmailFromIdentities(tx, autoconfirm) // may leave email empty
    if !userData.Metadata.EmailVerified {
        a.sendConfirmation(...)                 // <- sends a confirmation for a non-existent email
        return ..., ErrorCodeEmailNotConfirmed  // <- 422 to the caller
    }
    ...
}
```

`UpdateUserEmailFromIdentities` picks the highest-ranked identity's email, and an
email-optional identity contributes none — so the primary email is still empty
after the call. Because the OIDC claim also has `email_verified = false`, the
`!EmailVerified` branch runs and a confirmation email is "sent" for an address
that does not exist, and the link is rejected with `email_not_confirmed`.

`#634` added support for providers without an email, but this linking path still
assumes an unverified email is always present.

## The fix

Only run the email-confirmation logic when an email is actually present after
`UpdateUserEmailFromIdentities`:

```go
if targetUser.GetEmail() != "" {
    if !userData.Metadata.EmailVerified {
        a.sendConfirmation(...)
        return ..., ErrorCodeEmailNotConfirmed
    }
    targetUser.Confirm(tx)
}
```

The anonymous→permanent transition stays outside that guard, so an anonymous
user that links a no-email identity is still de-anonymized. Behaviour is
unchanged whenever the linked identity does carry an email:

| linked identity | before | after |
|---|---|---|
| verified email | user email set + confirmed | unchanged |
| unverified email | `email_not_confirmed` (confirmation sent) | unchanged |
| **no email (email-optional)** | **`email_not_confirmed` (spurious)** | **linked, email stays empty** |

## Tests

`TestLinkIdentityToUserEmailOptional` in `internal/api/identity_test.go`, two sub-cases:

1. **no email in the identity links without confirmation** — the regression:
   a confirmed phone-only user links an email-less OIDC identity; asserts success,
   the phone is preserved, the email stays empty, and the identity is created.
2. **unverified email in the identity still requires confirmation** — a control
   case proving the fix does not over-broaden: an identity that *does* carry an
   unverified email still returns `email_not_confirmed`.

### Verification
- `go vet ./internal/api/` clean, `go test -c ./internal/api/` (compiles the full
  suite incl. these tests) clean, `gofmt` clean.
- **Local run gap, disclosed honestly:** `internal/api` tests are Postgres-backed
  (`-p 1 -race`) and this dev machine has no Docker/Postgres/cgo, so I could not
  execute the suite locally. The tests are written to the suite's existing
  patterns and are intended to run on CI's Postgres matrix. Expected result there:
  sub-case 1 passes with the fix and fails (`422 email_not_confirmed`) if
  `identity.go` is reverted — i.e. genuine regression coverage — and sub-case 2
  passes unchanged.
- The control sub-case deliberately uses an email-less (anonymous) user rather
  than a phone-only one, because a phone-only user's empty-email phone identity
  makes `UpdateUserEmailFromIdentities` keep the empty email (its "an identity
  already uses this email" early-return matches `"" == ""`), so no email is
  promoted and there would be nothing to confirm — which is exactly the mechanism
  behind the bug this PR fixes.

---

