### PR TITLE
feat(api): allow signup without creating a session (#2586)

### DIFF
--- a/cmd/listen_other.go
+++ b/cmd/listen_other.go
@@ -1,0 +1,9 @@
+//go:build !unix && !linux && !darwin && !dragonfly && !freebsd && !netbsd && !openbsd && !solaris && !aix
+
+package cmd
+
+import "syscall"
+
+func setReusePort(c syscall.RawConn) error {
+	return nil
+}

--- a/cmd/listen_unix.go
+++ b/cmd/listen_unix.go
@@ -1,0 +1,19 @@
+//go:build unix || linux || darwin || dragonfly || freebsd || netbsd || openbsd || solaris || aix
+
+package cmd
+
+import (
+	"syscall"
+
+	"golang.org/x/sys/unix"
+)
+
+func setReusePort(c syscall.RawConn) error {
+	var serr error
+	if err := c.Control(func(fd uintptr) {
+		serr = unix.SetsockoptInt(int(fd), unix.SOL_SOCKET, unix.SO_REUSEPORT, 1) // #nosec G115
+	}); err != nil {
+		return err
+	}
+	return serr
+}

--- a/cmd/serve_cmd.go
+++ b/cmd/serve_cmd.go
@@ -8,8 +8,6 @@ import (
 	"syscall"
 	"time"
 
-	"golang.org/x/sys/unix"
-
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -185,13 +183,7 @@ func serve(ctx context.Context) {
 
 	lc := net.ListenConfig{
 		Control: func(network, address string, c syscall.RawConn) error {
-			var serr error
-			if err := c.Control(func(fd uintptr) {
-				serr = unix.SetsockoptInt(int(fd), unix.SOL_SOCKET, unix.SO_REUSEPORT, 1) // #nosec G115
-			}); err != nil {
-				return err
-			}
-			return serr
+			return setReusePort(c)
 		},
 	}
 	listener, err := lc.Listen(ctx, "tcp", addr)

--- a/internal/api/signup.go
+++ b/internal/api/signup.go
@@ -27,6 +27,14 @@ type SignupParams struct {
 	Channel             string                 `json:"channel"`
 	CodeChallengeMethod string                 `json:"code_challenge_method"`
 	CodeChallenge       string                 `json:"code_challenge"`
+	CreateSession       *bool                  `json:"create_session,omitempty"`
+}
+
+func (p *SignupParams) ShouldCreateSession() bool {
+	if p.CreateSession == nil {
+		return true
+	}
+	return *p.CreateSession
 }
 
 func (a *API) validateSignupParams(ctx context.Context, p *SignupParams) error {
@@ -69,6 +77,11 @@ func (p *SignupParams) ConfigureDefaults() {
 	// For backwards compatibility, we default to SMS if params Channel is not specified
 	if p.Phone != "" && p.Channel == "" {
 		p.Channel = sms_provider.SMSProvider
+	}
+
+	if p.CreateSession == nil {
+		createSession := true
+		p.CreateSession = &createSession
 	}
 }
 
@@ -303,7 +316,7 @@ func (a *API) Signup(w http.ResponseWriter, r *http.Request) error {
 	}
 
 	// handles case where Mailer.Autoconfirm is true or Phone.Autoconfirm is true
-	if user.IsConfirmed() || user.IsPhoneConfirmed() {
+	if (user.IsConfirmed() || user.IsPhoneConfirmed()) && params.ShouldCreateSession() {
 		var token *AccessTokenResponse
 		err = db.Transaction(func(tx *storage.Connection) error {
 			var terr error

--- a/internal/api/signup_test.go
+++ b/internal/api/signup_test.go
@@ -169,3 +169,134 @@ func (ts *SignupTestSuite) TestSignupRequestBodyTooLarge() {
 	require.NoError(ts.T(), json.NewDecoder(w.Body).Decode(&data))
 	require.Equal(ts.T(), "request_entity_too_large", data["error_code"])
 }
+
+func (ts *SignupTestSuite) TestSignup_Autoconfirm_CreateSessionFalse() {
+	ts.Config.Mailer.Autoconfirm = true
+	defer func() {
+		ts.Config.Mailer.Autoconfirm = false
+	}()
+
+	var buffer bytes.Buffer
+	require.NoError(ts.T(), json.NewEncoder(&buffer).Encode(map[string]interface{}{
+		"email":          "nosession@example.com",
+		"password":       "test123456",
+		"create_session": false,
+	}))
+
+	req := httptest.NewRequest(http.MethodPost, "/signup", &buffer)
+	req.Header.Set("Content-Type", "application/json")
+
+	w := httptest.NewRecorder()
+	ts.API.handler.ServeHTTP(w, req)
+
+	require.Equal(ts.T(), http.StatusOK, w.Code)
+
+	var user models.User
+	require.NoError(ts.T(), json.NewDecoder(w.Body).Decode(&user))
+	assert.Equal(ts.T(), "nosession@example.com", user.GetEmail())
+	assert.NotNil(ts.T(), user.EmailConfirmedAt)
+
+	// Verify no session was created in DB
+	sessions, err := models.FindAllSessionsForUser(ts.API.db, user.ID, false)
+	require.NoError(ts.T(), err)
+	assert.Empty(ts.T(), sessions)
+}
+
+func (ts *SignupTestSuite) TestSignup_Autoconfirm_CreateSessionTrue() {
+	ts.Config.Mailer.Autoconfirm = true
+	defer func() {
+		ts.Config.Mailer.Autoconfirm = false
+	}()
+
+	var buffer bytes.Buffer
+	require.NoError(ts.T(), json.NewEncoder(&buffer).Encode(map[string]interface{}{
+		"email":          "withsession@example.com",
+		"password":       "test123456",
+		"create_session": true,
+	}))
+
+	req := httptest.NewRequest(http.MethodPost, "/signup", &buffer)
+	req.Header.Set("Content-Type", "application/json")
+
+	w := httptest.NewRecorder()
+	ts.API.handler.ServeHTTP(w, req)
+
+	require.Equal(ts.T(), http.StatusOK, w.Code)
+
+	var token AccessTokenResponse
+	require.NoError(ts.T(), json.NewDecoder(w.Body).Decode(&token))
+	assert.NotEmpty(ts.T(), token.Token)
+	assert.NotEmpty(ts.T(), token.RefreshToken)
+	assert.Equal(ts.T(), "withsession@example.com", token.User.GetEmail())
+
+	// Verify session exists in DB
+	sessions, err := models.FindAllSessionsForUser(ts.API.db, token.User.ID, false)
+	require.NoError(ts.T(), err)
+	assert.NotEmpty(ts.T(), sessions)
+}
+
+func (ts *SignupTestSuite) TestSignup_Autoconfirm_CreateSessionDefault() {
+	ts.Config.Mailer.Autoconfirm = true
+	defer func() {
+		ts.Config.Mailer.Autoconfirm = false
+	}()
+
+	var buffer bytes.Buffer
+	require.NoError(ts.T(), json.NewEncoder(&buffer).Encode(map[string]interface{}{
+		"email":    "defaultsession@example.com",
+		"password": "test123456",
+	}))
+
+	req := httptest.NewRequest(http.MethodPost, "/signup", &buffer)
+	req.Header.Set("Content-Type", "application/json")
+
+	w := httptest.NewRecorder()
+	ts.API.handler.ServeHTTP(w, req)
+
+	require.Equal(ts.T(), http.StatusOK, w.Code)
+
+	var token AccessTokenResponse
+	require.NoError(ts.T(), json.NewDecoder(w.Body).Decode(&token))
+	assert.NotEmpty(ts.T(), token.Token)
+	assert.NotEmpty(ts.T(), token.RefreshToken)
+	assert.Equal(ts.T(), "defaultsession@example.com", token.User.GetEmail())
+
+	// Verify session exists in DB
+	sessions, err := models.FindAllSessionsForUser(ts.API.db, token.User.ID, false)
+	require.NoError(ts.T(), err)
+	assert.NotEmpty(ts.T(), sessions)
+}
+
+func (ts *SignupTestSuite) TestSignup_Phone_Autoconfirm_CreateSessionFalse() {
+	ts.Config.External.Phone.Enabled = true
+	ts.Config.Sms.Autoconfirm = true
+	defer func() {
+		ts.Config.External.Phone.Enabled = false
+		ts.Config.Sms.Autoconfirm = false
+	}()
+
+	var buffer bytes.Buffer
+	require.NoError(ts.T(), json.NewEncoder(&buffer).Encode(map[string]interface{}{
+		"phone":          "1234567890",
+		"password":       "test123456",
+		"create_session": false,
+	}))
+
+	req := httptest.NewRequest(http.MethodPost, "/signup", &buffer)
+	req.Header.Set("Content-Type", "application/json")
+
+	w := httptest.NewRecorder()
+	ts.API.handler.ServeHTTP(w, req)
+
+	require.Equal(ts.T(), http.StatusOK, w.Code)
+
+	var user models.User
+	require.NoError(ts.T(), json.NewDecoder(w.Body).Decode(&user))
+	assert.Equal(ts.T(), "1234567890", user.GetPhone())
+	assert.NotNil(ts.T(), user.PhoneConfirmedAt)
+
+	// Verify no session was created in DB
+	sessions, err := models.FindAllSessionsForUser(ts.API.db, user.ID, false)
+	require.NoError(ts.T(), err)
+	assert.Empty(ts.T(), sessions)
+}

--- a/internal/reloader/reloader_signal_test.go
+++ b/internal/reloader/reloader_signal_test.go
@@ -1,0 +1,107 @@
+//go:build !windows
+
+package reloader
+
+import (
+	"context"
+	"os"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/supabase/auth/internal/e2e"
+	"golang.org/x/sync/errgroup"
+)
+
+func TestWatchSignals(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+	defer cancel()
+
+	dir, cleanup := helpTestDir(t)
+	defer cleanup()
+
+	// test ctx cancel
+	{
+		doneCtx, doneCancel := context.WithCancel(ctx)
+		doneCancel()
+
+		cfg := e2e.Must(e2e.Config()).Reloading
+		rl := NewReloader(cfg, dir)
+
+		err := rl.watchSignal(doneCtx, nil)
+		if exp, got := context.Canceled, err; exp != got {
+			require.Equal(t, exp, got)
+		}
+	}
+
+	{
+		proc, err := os.FindProcess(os.Getpid())
+		require.NoError(t, err)
+
+		const sig = syscall.SIGUSR1
+		cfg := e2e.Must(e2e.Config()).Reloading
+		cfg.GracePeriodInterval = time.Second / 100
+		cfg.PollerInterval = time.Second / 100
+		cfg.SignalEnabled = true
+		cfg.SignalNumber = int(sig)
+		cfg.NotifyEnabled = true
+		cfg.PollerEnabled = true
+
+		rl := NewReloader(cfg, dir)
+
+		egCtx, egCancel := context.WithCancel(ctx)
+		defer egCancel()
+
+		rr := mockReloadRecorder()
+		gateCh := make(chan struct{})
+
+		var eg errgroup.Group
+		eg.Go(func() error {
+			close(gateCh)
+
+			return rl.Watch(egCtx, rr.configFn)
+		})
+
+		eg.Go(func() error {
+			select {
+			case <-gateCh:
+			case <-egCtx.Done():
+				return egCtx.Err()
+			}
+
+			tr := time.NewTicker(time.Second / 16)
+			defer tr.Stop()
+
+			after := time.After(time.Second / 4)
+			for {
+				select {
+				case <-after:
+					return nil
+				case <-tr.C:
+					if err := proc.Signal(sig); err != nil {
+						return err
+					}
+				}
+			}
+		})
+
+		// need to ensure errorCh drains so test isn't racey
+		eg.Go(func() error {
+			defer egCancel()
+
+			select {
+			case <-egCtx.Done():
+				return egCtx.Err()
+			case <-rr.configCh:
+				egCancel()
+				return nil
+			}
+		})
+
+		err = eg.Wait()
+		if exp, got := context.Canceled, err; exp != got {
+			require.Equal(t, exp, got)
+		}
+	}
+}

--- a/internal/reloader/reloader_test.go
+++ b/internal/reloader/reloader_test.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"path"
 	"path/filepath"
-	"syscall"
 	"testing"
 	"time"
 
@@ -26,98 +25,6 @@ func TestLoadConfigFile(t *testing.T) {
 	// test bad multi line config value
 	if err := godotenv.Overload("testdata/60_example_newline.env"); err != nil {
 		t.Fatal(err)
-	}
-}
-
-func TestWatchSignals(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
-	defer cancel()
-
-	dir, cleanup := helpTestDir(t)
-	defer cleanup()
-
-	// test ctx cancel
-	{
-		doneCtx, doneCancel := context.WithCancel(ctx)
-		doneCancel()
-
-		cfg := e2e.Must(e2e.Config()).Reloading
-		rl := NewReloader(cfg, dir)
-
-		err := rl.watchSignal(doneCtx, nil)
-		if exp, got := context.Canceled, err; exp != got {
-			require.Equal(t, exp, got)
-		}
-	}
-
-	{
-		proc, err := os.FindProcess(os.Getpid())
-		require.NoError(t, err)
-
-		const sig = syscall.SIGUSR1
-		cfg := e2e.Must(e2e.Config()).Reloading
-		cfg.GracePeriodInterval = time.Second / 100
-		cfg.PollerInterval = time.Second / 100
-		cfg.SignalEnabled = true
-		cfg.SignalNumber = int(sig)
-		cfg.NotifyEnabled = true
-		cfg.PollerEnabled = true
-
-		rl := NewReloader(cfg, dir)
-
-		egCtx, egCancel := context.WithCancel(ctx)
-		defer egCancel()
-
-		rr := mockReloadRecorder()
-		gateCh := make(chan struct{})
-
-		var eg errgroup.Group
-		eg.Go(func() error {
-			close(gateCh)
-
-			return rl.Watch(egCtx, rr.configFn)
-		})
-
-		eg.Go(func() error {
-			select {
-			case <-gateCh:
-			case <-egCtx.Done():
-				return egCtx.Err()
-			}
-
-			tr := time.NewTicker(time.Second / 16)
-			defer tr.Stop()
-
-			after := time.After(time.Second / 4)
-			for {
-				select {
-				case <-after:
-					return nil
-				case <-tr.C:
-					if err := proc.Signal(sig); err != nil {
-						return err
-					}
-				}
-			}
-		})
-
-		// need to ensure errorCh drains so test isn't racey
-		eg.Go(func() error {
-			defer egCancel()
-
-			select {
-			case <-egCtx.Done():
-				return egCtx.Err()
-			case <-rr.configCh:
-				egCancel()
-				return nil
-			}
-		})
-
-		err = eg.Wait()
-		if exp, got := context.Canceled, err; exp != got {
-			require.Equal(t, exp, got)
-		}
 	}
 }
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -410,12 +410,17 @@ paths:
                   enum:
                     - plain
                     - s256
+                create_session:
+                  type: boolean
+                  description: >
+                    (Optional) If set to false, prevents creating a session/issuing tokens upon signup even when confirmation is disabled or autoconfirm is enabled. Defaults to true.
+                  default: true
                 gotrue_meta_security:
                   $ref: "#/components/schemas/GoTrueSecurity"
       responses:
         200:
           description: >
-            A user already exists and is not confirmed (in which case a user object is returned). A user did not exist and is signed up. If email or phone confirmation is enabled, returns a user object. If confirmation is disabled, returns an access token and refresh token response.
+            A user already exists and is not confirmed (in which case a user object is returned). A user did not exist and is signed up. If email or phone confirmation is enabled, returns a user object. If confirmation is disabled, returns an access token and refresh token response. If `create_session` is false, returns a user object regardless of confirmation settings.
           content:
             application/json:
               schema:


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature.

Resolves #2586 (and relates to [supabase/supabase-flutter#1063](https://github.com/supabase/supabase-flutter/issues/1063)).

## What is the current behavior?

Today the `POST /signup` endpoint creates and returns a session whenever the user is auto-confirmed (or when confirmation is disabled project-wide). A session is only omitted when email/phone confirmation is required.

Client applications reacting to `AuthChangeEvent.SIGNED_IN` or needing to perform post-signup preparatory work before establishing an active session had no opt-in mechanism to sign up without automatically generating session tokens.

## What is the new behavior?

- Adds an optional `create_session` boolean property (defaults to `true`) to `POST /signup` request parameters.
- When `create_session: false` is supplied, the user is created and auto-confirmed (if autoconfirm is enabled), but no session/refresh tokens are generated and no login metering is recorded. The endpoint returns the `models.User` object directly with `200 OK`.
- Retains 100% backwards compatibility: when `create_session` is omitted or set to `true`, the behavior is completely unchanged.
- Adds comprehensive unit and integration tests in `internal/api/signup_test.go`.
- Updates `openapi.yaml` schema and response documentation.
- Improves build compatibility across platforms for socket reuse and signal handling tests.

## Additional context

Verified against live PostgreSQL and test suites (`go test -v ./internal/api -run TestSignup`).
