### PR TITLE
fix(verify): resolve phone change by one-time token, not phone alone

### DIFF
--- a/internal/api/verify.go
+++ b/internal/api/verify.go
@@ -705,7 +705,10 @@ func (a *API) verifyUserAndToken(conn *storage.Connection, params *VerifyParams,
 
 	switch params.Type {
 	case phoneChangeVerification:
-		user, err = models.FindUserByPhoneChangeAndAudience(conn, params.Phone, aud)
+		// Resolved through the one-time token where one exists: phone_change is
+		// not unique, so matching on it alone can return a different user than
+		// the token was issued to. Mirrors the email-change lookup below.
+		user, err = models.FindUserForPhoneChange(conn, params.Phone, tokenHash, aud)
 	case smsVerification:
 		user, err = models.FindUserByPhoneAndAudience(conn, params.Phone, aud)
 	case mail.EmailChangeVerification:

--- a/internal/models/one_time_token.go
+++ b/internal/models/one_time_token.go
@@ -288,3 +288,37 @@ func FindUserForEmailChange(tx *storage.Connection, email, token, aud string, se
 	}
 	return FindUserByEmailChangeNewAndAudience(tx, email, token, aud)
 }
+
+// FindUserForPhoneChange finds the user requesting a change to the given phone
+// number, identifying them by their one-time token rather than by the phone
+// number alone.
+//
+// The phone_change column carries no uniqueness constraint, so several users
+// can hold the same pending value at once (abandoned or still-unverified change
+// requests). Selecting on phone_change alone returns an arbitrary one of them,
+// which can be a different user than the one the token was issued to. Email
+// change already resolves its user through the one-time token for this reason
+// (see FindUserForEmailChange); this does the same for phone change.
+//
+// Falls back to the phone_change lookup when no one-time token matches, so
+// verification paths that do not go through the one_time_tokens table (test
+// OTPs, rows predating it) keep working exactly as before.
+func FindUserForPhoneChange(tx *storage.Connection, phone, tokenHash, aud string) (*User, error) {
+	if tokenHash != "" {
+		ott, err := FindOneTimeToken(tx, tokenHash, PhoneChangeToken)
+		if err != nil && !IsNotFoundError(err) {
+			return nil, err
+		}
+		if ott != nil {
+			user, err := FindUserByID(tx, ott.UserID)
+			if err != nil {
+				return nil, err
+			}
+			if user.Aud == aud && user.PhoneChange == phone {
+				return user, nil
+			}
+		}
+	}
+
+	return FindUserByPhoneChangeAndAudience(tx, phone, aud)
+}

--- a/internal/models/user_test.go
+++ b/internal/models/user_test.go
@@ -878,3 +878,45 @@ func (ts *UserTestSuite) TestAuthenticate() {
 		})
 	}
 }
+
+func (ts *UserTestSuite) TestFindUserForPhoneChangeSelectsTokenOwner() {
+	// phone_change has no uniqueness constraint, so two users can hold the same
+	// pending value at once (an abandoned change request plus a live one). The
+	// lookup must return the user the token was actually issued to, not whichever
+	// row the database happens to return first.
+	const pendingPhone = "+15550001111"
+
+	abandoned, err := NewUser("+15550000001", "abandoned@example.com", "secret", ts.config.JWT.Aud, nil)
+	require.NoError(ts.T(), err)
+	abandoned.PhoneChange = pendingPhone
+	require.NoError(ts.T(), ts.db.Create(abandoned))
+
+	requester, err := NewUser("+15550000002", "requester@example.com", "secret", ts.config.JWT.Aud, nil)
+	require.NoError(ts.T(), err)
+	requester.PhoneChange = pendingPhone
+	// Mirrors production: phone.go stores crypto.GenerateTokenHash(phone, otp) both
+	// on the user column and as the one-time token hash, and verify.go recomputes
+	// the same value from the submitted OTP — so the lookup must match on that.
+	requester.PhoneChangeToken = crypto.GenerateTokenHash(pendingPhone, "654321")
+	require.NoError(ts.T(), ts.db.Create(requester))
+	require.NoError(ts.T(), CreateOneTimeToken(ts.db, requester.ID, pendingPhone, requester.PhoneChangeToken, PhoneChangeToken))
+
+	found, err := FindUserForPhoneChange(ts.db, pendingPhone, requester.PhoneChangeToken, ts.config.JWT.Aud)
+	require.NoError(ts.T(), err)
+	require.Equal(ts.T(), requester.ID, found.ID, "must resolve the user the phone-change token was issued to")
+}
+
+func (ts *UserTestSuite) TestFindUserForPhoneChangeFallsBackWithoutToken() {
+	// Verification paths that never write a one-time token (test OTPs, rows
+	// predating the table) must keep resolving by phone_change alone.
+	const pendingPhone = "+15550002222"
+
+	user, err := NewUser("+15550000003", "legacy@example.com", "secret", ts.config.JWT.Aud, nil)
+	require.NoError(ts.T(), err)
+	user.PhoneChange = pendingPhone
+	require.NoError(ts.T(), ts.db.Create(user))
+
+	found, err := FindUserForPhoneChange(ts.db, pendingPhone, "", ts.config.JWT.Aud)
+	require.NoError(ts.T(), err)
+	require.Equal(ts.T(), user.ID, found.ID)
+}


### PR DESCRIPTION
Closes #2430.

`phone_change` carries no uniqueness constraint, so several users can hold the same pending value at once (abandoned or still-unverified change requests). Verification looked the user up with `FindUserByPhoneChangeAndAudience`, which matches on `phone_change` and audience only and returns whichever row comes first — potentially a different user than the one the token was issued to.

Email change already avoids this by resolving its user through the one-time token (`FindUserForEmailChange`). This applies the same approach to phone change: `FindUserForPhoneChange` looks the user up by the token hash `verify.go` already computes, and confirms the resolved user's audience and pending phone match before returning them.

It falls back to the previous lookup when no one-time token matches, so paths that never write one (test OTPs, rows predating the table) behave exactly as before. The only behaviour change is which user is selected when duplicates exist.

**Verification**

- Added two regression tests. Per CONTRIBUTING, I checked the main one actually fails without the change — it selects the wrong user and reports `must resolve the user the phone-change token was issued to` — and passes with it.
- The full `internal/models` package suite is green against a live database.
- Confirmed the lookup matches what production writes: `internal/api/phone.go` stores `crypto.GenerateTokenHash(phone, otp)` as both the user column and the one-time token hash, which is exactly what `verify.go` recomputes from the submitted OTP.