### PR TITLE
fix(oauth): allow ephemeral loopback redirect ports

### DIFF
--- a/internal/api/oauthserver/authorize.go
+++ b/internal/api/oauthserver/authorize.go
@@ -487,7 +487,7 @@ func (s *Server) validatePKCEParams(codeChallengeMethod, codeChallenge string) e
 		return errors.New("code_challenge_method must be 'S256' or 'plain'")
 	}
 
-	// Validate code challenge format and length (per OAuth2 spec)
+	// Validate code challenge format and length
 	if len(codeChallenge) < 43 || len(codeChallenge) > 128 {
 		return errors.New("code_challenge must be between 43 and 128 characters")
 	}
@@ -495,7 +495,7 @@ func (s *Server) validatePKCEParams(codeChallengeMethod, codeChallenge string) e
 	return nil
 }
 
-// validateResourceParam validates the resource parameter per RFC 8707
+// validateResourceParam validates the requested resource parameter per RFC 8707
 func (s *Server) validateResourceParam(resource string) error {
 	// Resource parameter is optional
 	if resource == "" {
@@ -550,12 +550,55 @@ func (s *Server) validateScopes(scopeString string) error {
 func (s *Server) isValidRedirectURI(client *models.OAuthServerClient, redirectURI string) bool {
 	registeredURIs := client.GetRedirectURIs()
 	for _, registeredURI := range registeredURIs {
-		// exact string matching per OAuth2 spec
-		if registeredURI == redirectURI {
+		// Exact string matching is required except for loopback redirect URIs,
+		// where RFC 8252 permits the client to choose an ephemeral port.
+		if registeredURI == redirectURI || isValidLoopbackRedirectURI(registeredURI, redirectURI) {
 			return true
 		}
 	}
 	return false
+}
+
+// isValidLoopbackRedirectURI applies the RFC 8252 Section 7.3 exception:
+// for HTTP redirects on a loopback host, only the port may differ from the
+// registered URI. Scheme, host, user info, path, query, and fragment remain
+// exact so that the exception cannot be used to broaden the redirect target.
+func isValidLoopbackRedirectURI(registeredURI, redirectURI string) bool {
+	registered, err := url.Parse(registeredURI)
+	if err != nil {
+		return false
+	}
+	requested, err := url.Parse(redirectURI)
+	if err != nil {
+		return false
+	}
+
+	if registered.Scheme != "http" || requested.Scheme != "http" {
+		return false
+	}
+	if !isLoopbackHost(registered.Hostname()) || !isLoopbackHost(requested.Hostname()) {
+		return false
+	}
+	if !strings.EqualFold(registered.Hostname(), requested.Hostname()) {
+		return false
+	}
+	if (registered.User == nil) != (requested.User == nil) {
+		return false
+	}
+	if registered.User != nil && registered.User.String() != requested.User.String() {
+		return false
+	}
+
+	return registered.Opaque == requested.Opaque &&
+		registered.EscapedPath() == requested.EscapedPath() &&
+		registered.ForceQuery == requested.ForceQuery &&
+		registered.RawQuery == requested.RawQuery &&
+		registered.Fragment == requested.Fragment &&
+		registered.RawFragment == requested.RawFragment
+}
+
+func isLoopbackHost(host string) bool {
+	return strings.EqualFold(host, "localhost") || host == "127.0.0.1" || host == "::1"
 }
 
 func (s *Server) consentCoversScopes(consent *models.OAuthServerConsent, requestedScope string) bool {

--- a/internal/api/oauthserver/authorize_test.go
+++ b/internal/api/oauthserver/authorize_test.go
@@ -135,6 +135,73 @@ func TestValidateRequestOrigin(t *testing.T) {
 	}
 }
 
+func TestIsValidLoopbackRedirectURI(t *testing.T) {
+	tests := []struct {
+		name       string
+		registered string
+		requested  string
+		want       bool
+	}{
+		{
+			name:       "allows a different IPv4 loopback port",
+			registered: "http://127.0.0.1/callback",
+			requested:  "http://127.0.0.1:49152/callback",
+			want:       true,
+		},
+		{
+			name:       "allows a different IPv6 loopback port",
+			registered: "http://[::1]/callback",
+			requested:  "http://[::1]:49152/callback",
+			want:       true,
+		},
+		{
+			name:       "allows a different localhost port",
+			registered: "http://localhost/callback",
+			requested:  "http://localhost:49152/callback",
+			want:       true,
+		},
+		{
+			name:       "keeps the registered port exact for non-loopback HTTPS",
+			registered: "https://example.com:8443/callback",
+			requested:  "https://example.com:9443/callback",
+			want:       false,
+		},
+		{
+			name:       "rejects a different loopback path",
+			registered: "http://127.0.0.1/callback",
+			requested:  "http://127.0.0.1:49152/other",
+			want:       false,
+		},
+		{
+			name:       "rejects a different loopback query",
+			registered: "http://127.0.0.1/callback?client=one",
+			requested:  "http://127.0.0.1:49152/callback?client=two",
+			want:       false,
+		},
+		{
+			name:       "rejects a different loopback host",
+			registered: "http://127.0.0.1/callback",
+			requested:  "http://localhost:49152/callback",
+			want:       false,
+		},
+		{
+			name:       "rejects a custom scheme with a different port",
+			registered: "com.example.app://localhost/callback",
+			requested:  "com.example.app://localhost:49152/callback",
+			want:       false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := &models.OAuthServerClient{}
+			client.SetRedirectURIs([]string{tt.registered})
+
+			assert.Equal(t, tt.want, (&Server{}).isValidRedirectURI(client, tt.requested))
+		})
+	}
+}
+
 func TestValidateRequestOriginEdgeCases(t *testing.T) {
 	globalConfig, err := confload.LoadGlobal(oauthServerTestConfig)
 	require.NoError(t, err)
@@ -185,7 +252,7 @@ func TestValidateRequestOriginEdgeCases(t *testing.T) {
 		req.Header.Add("Origin", "https://malicious.com") // Second header (invalid)
 
 		// Go's http.Header.Get() returns only the first header value
-		// So this should pass because first Origin is valid
+		// So this should pass because first header is valid
 		err := server.validateRequestOrigin(req)
 		assert.NoError(t, err)
 	})
@@ -465,8 +532,7 @@ func (ts *OAuthAuthorizeTestSuite) TestGetAuthorization_ExpiredCommitsMarkExpire
 	require.True(ts.T(), ok, "expected *storage.CommitWithError, got %T (%v)", err, err)
 	ts.assertHTTPError(cwe.Err, http.StatusNotFound, apierrors.ErrorCodeOAuthAuthorizationNotFound)
 
-	// The MarkExpired update must be committed even though the handler
-	// returns an error — otherwise an expired row would remain pending.
+	// The MarkExpired update must be committed even though the handler returns an error — otherwise an expired row would remain pending.
 	reloaded := ts.reload(auth.AuthorizationID)
 	assert.Equal(ts.T(), models.OAuthServerAuthorizationExpired, reloaded.Status)
 }


### PR DESCRIPTION
## Summary

This updates the OAuth 2.1 authorization endpoint to support RFC 8252 loopback-interface redirect URIs with ephemeral ports.

## What changed

- Preserve exact redirect URI matching for all non-loopback URIs and for every URI component other than the port.
- Allow a requested `http` redirect to use a different port when the registered and requested hosts are the same loopback host: `localhost`, `127.0.0.1`, or `::1`.
- Keep scheme, host, user info, path, query, fragment, and opaque URI data unchanged when applying the exception.
- Add focused regression coverage for IPv4, IPv6, and localhost ephemeral ports, plus rejection of path, query, host, HTTPS-port, and custom-scheme differences.

This addresses [issue #2703](https://github.com/supabase/auth/issues/2703). RFC 8252 Section 7.3 requires authorization servers to allow any port for loopback IP redirect URIs so native clients can bind an ephemeral local port.

## Validation

- `go test ./internal/api/oauthserver -run '^TestIsValidLoopbackRedirectURI$' -count=1` — passed.
- `go vet ./internal/api/oauthserver` — passed.
- `go test ./internal/api/oauthserver -count=1` — the package reached its database-backed tests, but the sandbox has no PostgreSQL service listening on `localhost:5432`, so those suites could not run here (`connect: connection refused`).

The implementation was also reviewed against the repository’s existing redirect URI validation rules and preserves exact matching outside the RFC 8252 loopback exception.