### PR TITLE
fix(audit): map identity_unlinked action to user log type (fixes #2679)

### DIFF
--- a/internal/models/audit_log_entry.go
+++ b/internal/models/audit_log_entry.go
@@ -83,6 +83,7 @@ var ActionLogTypeMap = map[AuditAction]auditLogType{
 	PasskeyCreatedAction:            user,
 	PasskeyUpdatedAction:            user,
 	PasskeyDeletedAction:            user,
+	IdentityUnlinkAction:            user,
 }
 
 // AuditLogEntry is the database model for audit log entries.


### PR DESCRIPTION
fix(audit): map identity_unlinked action to user log type (fixes #2679)

`ActionLogTypeMap` has no entry for `IdentityUnlinkAction`, so identity
unlink events are persisted with an empty `log_type` (Go map zero value).
Add `IdentityUnlinkAction: user`, consistent with the other user-facing
identity/passkey actions (`PasskeyCreatedAction`, `PasskeyUpdatedAction`,
`PasskeyDeletedAction`).