### PR TITLE
fix(provider): preserve non-standard claims for custom OIDC providers (fixes #2694)

### DIFF
--- a/internal/api/provider/custom_oauth.go
+++ b/internal/api/provider/custom_oauth.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	"github.com/coreos/go-oidc/v3/oidc"
+	"github.com/fatih/structs"
 	"golang.org/x/oauth2"
 )
 
@@ -68,9 +69,27 @@ func (p *CustomOAuthProvider) GetOAuthToken(ctx context.Context, code string, op
 
 // GetUserData fetches user data from the provider's userinfo endpoint
 func (p *CustomOAuthProvider) GetUserData(ctx context.Context, tok *oauth2.Token) (*UserProvidedData, error) {
-	var claims Claims
-	if err := makeRequest(ctx, tok, p.config, p.userinfoURL, &claims); err != nil {
+	var rawClaims map[string]interface{}
+	if err := makeRequest(ctx, tok, p.config, p.userinfoURL, &rawClaims); err != nil {
 		return nil, err
+	}
+
+	claimsBytes, err := json.Marshal(rawClaims)
+	if err != nil {
+		return nil, err
+	}
+
+	var claims Claims
+	if err := json.Unmarshal(claimsBytes, &claims); err != nil {
+		return nil, err
+	}
+
+	// Preserve non-standard claims in CustomClaims
+	for key := range structs.Map(claims) {
+		delete(rawClaims, key)
+	}
+	if len(rawClaims) > 0 {
+		claims.CustomClaims = rawClaims
 	}
 
 	// Apply attribute mapping if configured
@@ -208,9 +227,27 @@ func (p *CustomOIDCProvider) GetUserData(ctx context.Context, tok *oauth2.Token)
 
 	// No ID token, use userinfo endpoint
 	if p.userinfoEndpoint != "" {
-		var claims Claims
-		if err := makeRequest(ctx, tok, p.config, p.userinfoEndpoint, &claims); err != nil {
+		var rawClaims map[string]interface{}
+		if err := makeRequest(ctx, tok, p.config, p.userinfoEndpoint, &rawClaims); err != nil {
 			return nil, err
+		}
+
+		claimsBytes, err := json.Marshal(rawClaims)
+		if err != nil {
+			return nil, err
+		}
+
+		var claims Claims
+		if err := json.Unmarshal(claimsBytes, &claims); err != nil {
+			return nil, err
+		}
+
+		// Preserve non-standard claims in CustomClaims
+		for key := range structs.Map(claims) {
+			delete(rawClaims, key)
+		}
+		if len(rawClaims) > 0 {
+			claims.CustomClaims = rawClaims
 		}
 
 		// Apply attribute mapping

--- a/internal/api/provider/custom_oauth_test.go
+++ b/internal/api/provider/custom_oauth_test.go
@@ -94,6 +94,7 @@ func TestCustomOAuthProvider_GetUserData(t *testing.T) {
 			"email_verified": true,
 			"name":           "Test User",
 			"picture":        "https://example.com/avatar.jpg",
+			"ssn":            "199005152393",
 		})
 	}))
 	defer server.Close()
@@ -125,6 +126,10 @@ func TestCustomOAuthProvider_GetUserData(t *testing.T) {
 	assert.Equal(t, "test@example.com", userData.Emails[0].Email)
 	assert.True(t, userData.Emails[0].Verified)
 	assert.True(t, userData.Emails[0].Primary)
+
+	require.NotNil(t, userData.Metadata)
+	assert.Equal(t, "user-123", userData.Metadata.Subject)
+	assert.Equal(t, map[string]interface{}{"ssn": "199005152393"}, userData.Metadata.CustomClaims)
 }
 
 func TestCustomOAuthProvider_GetUserDataWithAttributeMapping(t *testing.T) {
@@ -184,7 +189,7 @@ func TestApplyAttributeMapping(t *testing.T) {
 				Email:   "test@example.com",
 			},
 			mapping: map[string]interface{}{
-				"email_verified": true, // Literal boolean value
+				"email_verified": true,                // Literal boolean value
 				"iat":            float64(1234567890), // Literal number value
 			},
 			expected: Claims{
@@ -203,15 +208,15 @@ func TestApplyAttributeMapping(t *testing.T) {
 				AvatarURL: "https://example.com/avatar.jpg",
 			},
 			mapping: map[string]interface{}{
-				"name":    "full_name",    // Map full_name -> name
-				"picture": "avatar_url",   // Map avatar_url -> picture
+				"name":    "full_name",  // Map full_name -> name
+				"picture": "avatar_url", // Map avatar_url -> picture
 			},
 			expected: Claims{
-				Subject:  "user-123",
-				Email:    "test@example.com",
-				Name:     "John Doe",
-				Picture:  "https://example.com/avatar.jpg",
-				FullName: "John Doe",  // Original field still exists
+				Subject:   "user-123",
+				Email:     "test@example.com",
+				Name:      "John Doe",
+				Picture:   "https://example.com/avatar.jpg",
+				FullName:  "John Doe", // Original field still exists
 				AvatarURL: "https://example.com/avatar.jpg",
 			},
 		},
@@ -273,8 +278,8 @@ func TestNewCustomOIDCProvider(t *testing.T) {
 		"test-client-secret",
 		"https://myapp.com/callback",
 		[]string{"profile", "email"}, // Without openid
-		server.URL, // issuer
-		true, // PKCE enabled
+		server.URL,                   // issuer
+		true,                         // PKCE enabled
 		[]string{"ios-client", "android-client"},
 		map[string]interface{}{"email": "user_email"},
 		map[string]interface{}{"prompt": "consent"},
@@ -461,7 +466,7 @@ func TestCustomOIDCProvider_RequiresPKCE(t *testing.T) {
 			"https://myapp.com/callback",
 			[]string{"openid"},
 			server.URL, // issuer
-			true, // PKCE enabled
+			true,       // PKCE enabled
 			nil,
 			nil,
 			nil,
@@ -481,7 +486,7 @@ func TestCustomOIDCProvider_RequiresPKCE(t *testing.T) {
 			"https://myapp.com/callback",
 			[]string{"openid"},
 			server.URL, // issuer
-			false, // PKCE disabled
+			false,      // PKCE disabled
 			nil,
 			nil,
 			nil,

--- a/internal/api/provider/oidc.go
+++ b/internal/api/provider/oidc.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/coreos/go-oidc/v3/oidc"
+	"github.com/fatih/structs"
 	"github.com/golang-jwt/jwt/v5"
 )
 
@@ -455,6 +456,23 @@ func parseGenericIDToken(token *oidc.IDToken) (*oidc.IDToken, *UserProvidedData,
 			Verified: data.Metadata.EmailVerified,
 			Primary:  true,
 		})
+	}
+
+	var rawClaims map[string]interface{}
+	if err := token.Claims(&rawClaims); err != nil {
+		return nil, nil, err
+	}
+
+	// Preserve non-standard claims in CustomClaims, consistent with the
+	// keycloak provider (#1917) and SAML assertion handling: any claim the
+	// Claims struct does not consume is kept so providers can pass through
+	// arbitrary claims (e.g. national identifiers) to the application.
+	claimsMap := structs.Map(data.Metadata)
+	for key := range claimsMap {
+		delete(rawClaims, key)
+	}
+	if len(rawClaims) > 0 {
+		data.Metadata.CustomClaims = rawClaims
 	}
 
 	return token, &data, nil

--- a/internal/models/audit_log_entry.go
+++ b/internal/models/audit_log_entry.go
@@ -83,6 +83,7 @@ var ActionLogTypeMap = map[AuditAction]auditLogType{
 	PasskeyCreatedAction:            user,
 	PasskeyUpdatedAction:            user,
 	PasskeyDeletedAction:            user,
+	IdentityUnlinkAction:            user,
 }
 
 // AuditLogEntry is the database model for audit log entries.


### PR DESCRIPTION
fix(provider): preserve non-standard claims for custom OIDC providers (fixes #2694)

Custom OIDC providers (`custom:<id>`) dropped every non-standard claim
from the id_token / userinfo response before writing `identity_data`,
so claims like a Swedish BankID `ssn` or Idura's `identityscheme` never
reached the application.

Port the raw-claim passthrough that already exists for Keycloak (#1917)
and SAML assertions:

- `parseGenericIDToken` now keeps every claim the `Claims` struct does
  not consume in `CustomClaims` (id_token path).
- `CustomOAuthProvider.GetUserData` and
  `CustomOIDCProvider.GetUserData` (userinfo path) do the same.

Test: custom userinfo response with an `ssn` claim now asserts it lands
in `Metadata.CustomClaims`.