### PR TITLE
fix(api): fail closed when session is nil during user update (fixes #2665)

### DIFF
--- a/internal/api/user.go
+++ b/internal/api/user.go
@@ -103,7 +103,7 @@ func (a *API) UserUpdate(w http.ResponseWriter, r *http.Request) error {
 		}
 	}
 
-	if user.HasMFAEnabled() && !session.IsAAL2() {
+	if user.HasMFAEnabled() && (session == nil || !session.IsAAL2()) {
 		if (params.Password != nil && *params.Password != "") || (params.Email != "" && user.GetEmail() != params.Email) || (params.Phone != "" && user.GetPhone() != params.Phone) {
 			return apierrors.NewHTTPError(http.StatusUnauthorized, apierrors.ErrorCodeInsufficientAAL, "AAL2 session is required to update email or password when MFA is enabled.")
 		}
@@ -172,7 +172,7 @@ func (a *API) UserUpdate(w http.ResponseWriter, r *http.Request) error {
 				// current password required when updating password
 				if config.Security.UpdatePasswordRequireCurrentPassword {
 					// ensure user is not in a password recovery flow
-					if !session.IsRecovery() {
+					if session == nil || !session.IsRecovery() {
 						if params.CurrentPassword == nil || *params.CurrentPassword == "" {
 							return apierrors.NewBadRequestError(apierrors.ErrorCodeCurrentPasswordRequired, "Current password required when setting new password.")
 						}


### PR DESCRIPTION
fix(api): fail closed when session is nil during user update (fixes #2665)

A `customize_access_token` hook that blanks `session_id` produces a
token whose session never loads, leaving `session == nil` in `UserUpdate`.
`MinimumViableTokenSchema` only checks `session_id` is a string, so `""`
and the nil UUID pass, and `maybeLoadUserOrSession` skips loading the
session for those values.

`user.HasMFAEnabled() && !session.IsAAL2()` and `!session.IsRecovery()`
then panic on the nil receiver, surfacing as a 500 via `recoverer`.

Fail closed, matching `requirePasskeyManagementAAL` and the existing
`session == nil` guards at lines 154/206:
- AAL2 check now treats a missing session as not meeting AAL2
  (401 `insufficient_aal`).
- Password update now treats a missing session as not in a recovery flow
  (400 `current_password_required`).

The obvious alternative — skipping the checks on nil — would let a
hook-blanked token change a password with no AAL2 and no current
password, so the guards must not be bypassed.