### PR TITLE
fix(api): do not leak account existence on recover for reserved domains (fixes #2702)

### DIFF
--- a/internal/api/recover.go
+++ b/internal/api/recover.go
@@ -69,6 +69,12 @@ func (a *API) Recover(w http.ResponseWriter, r *http.Request) error {
 		return a.sendPasswordRecovery(r, tx, user, flowType)
 	})
 	if err != nil {
+		// The mailer rejects reserved/undeliverable domains; only reachable
+		// for accounts that exist, so it would leak account existence.
+		// Respond identically to the unknown-user path instead.
+		if herr, ok := err.(*apierrors.HTTPError); ok && herr.ErrorCode == apierrors.ErrorCodeEmailAddressInvalid {
+			return sendJSON(w, http.StatusOK, map[string]string{})
+		}
 		return err
 	}
 


### PR DESCRIPTION
fix(api): do not leak account existence on recover for reserved domains (fixes #2702)

`POST /auth/v1/recover` returns `400 email_address_invalid` when the
address belongs to an existing user on a reserved domain (the mailer
rejects it at send time) but a plain success for a missing address on
the same domain. That is an account-existence oracle available with only
the publishable key.

`Recover` now responds with the same empty `200` used by the
unknown-user path when the send fails with `email_address_invalid`, so
existing and missing addresses are indistinguishable. The mailer still
rejects the send, so no email goes out.