### PR TITLE
fix(signup): return 409 instead of raw 500 on concurrent signup race (fixes #2675)

### DIFF
--- a/internal/api/signup.go
+++ b/internal/api/signup.go
@@ -14,6 +14,7 @@ import (
 	"github.com/supabase/auth/internal/metering"
 	"github.com/supabase/auth/internal/models"
 	"github.com/supabase/auth/internal/storage"
+	"github.com/supabase/auth/internal/utilities"
 )
 
 // SignupParams are the parameters the Signup endpoint accepts
@@ -383,6 +384,10 @@ func (a *API) signupNewUser(conn *storage.Connection, user *models.User) (*model
 	err := conn.Transaction(func(tx *storage.Connection) error {
 		var terr error
 		if terr = tx.Create(user); terr != nil {
+			if pgErr := utilities.NewPostgresError(terr); pgErr != nil && pgErr.IsUniqueConstraintViolated() {
+				// A concurrent request created the same user first
+				return apierrors.NewConflictError(apierrors.ErrorCodeUserAlreadyExists, "User already exists").WithInternalError(terr)
+			}
 			return apierrors.NewInternalServerError("Database error saving new user").WithInternalError(terr)
 		}
 		if terr = user.SetRole(tx, config.JWT.DefaultGroupName); terr != nil {


### PR DESCRIPTION
fix(signup): return 409 instead of raw 500 on concurrent signup race (fixes #2675)

Two concurrent `/otp` requests for the same new email can both pass the
user-existence check, then collide on the `users_email_partial_key`
partial unique index during user creation. The losing request surfaced a
raw 500 (`unexpected_failure`, aborted transaction) indistinguishable
from a server outage.

`signupNewUser` now maps a unique-constraint violation (23505) from the
user insert to a structured `409 conflict` with
`error_code=user_already_exists`, so a client can distinguish the race
from an outage. A retry a second later would hit the existing-user OTP
path anyway.