### PR TITLE
fix(external): use email_address_not_provided instead of 500 when provider omits email (fixes #2583)

### DIFF
--- a/internal/api/external.go
+++ b/internal/api/external.go
@@ -182,7 +182,7 @@ func (a *API) internalExternalProviderCallback(w http.ResponseWriter, r *http.Re
 	userData := data.userData
 
 	if len(userData.Emails) == 0 && !emailOptional {
-		return apierrors.NewInternalServerError("Error getting user email from external provider")
+		return apierrors.NewUnprocessableEntityError(apierrors.ErrorCodeEmailAddressNotProvided, "Error getting user email from external provider")
 	}
 
 	userData.Metadata.EmailVerified = false


### PR DESCRIPTION
fix(external): use email_address_not_provided instead of 500 when provider omits email (fixes #2583)

When an external OAuth provider returns no email and the provider is not
email-optional, the callback returns a generic 500
(`unexpected_failure`), mis-classifying a non-server fault and leaving
clients no stable code to branch on.

Use the existing but unused `email_address_not_provided` error code with
422, matching how nearby external-identity conditions are reported. The
OAuth redirect keeps `error=server_error` (422 is not in
`oauthErrorMap`), so existing clients are unaffected while new clients
gain a stable code.