### PR TITLE
fix(otp): dummy signup password must satisfy minimum_password_length (fixes #2456)

### DIFF
--- a/internal/api/magic_link.go
+++ b/internal/api/magic_link.go
@@ -84,7 +84,7 @@ func (a *API) MagicLink(w http.ResponseWriter, r *http.Request) error {
 	if isNewUser {
 		// User either doesn't exist or hasn't completed the signup process.
 		// Sign them up with temporary password.
-		password := crypto.GeneratePassword(config.Password.RequiredCharacters, 33)
+		password := crypto.GeneratePassword(config.Password.RequiredCharacters, max(config.Password.MinLength, 33))
 
 		signUpParams := &SignupParams{
 			Email:               params.Email,

--- a/internal/api/otp.go
+++ b/internal/api/otp.go
@@ -139,7 +139,7 @@ func (a *API) SmsOtp(w http.ResponseWriter, r *http.Request) error {
 	if isNewUser {
 		// User either doesn't exist or hasn't completed the signup process.
 		// Sign them up with temporary password.
-		password, err := password.Generate(64, 10, 1, false, true)
+		password, err := password.Generate(max(config.Password.MinLength, 64), 10, 1, false, true)
 		if err != nil {
 			return apierrors.NewInternalServerError("error creating user").WithInternalError(err)
 		}


### PR DESCRIPTION
fix(otp): dummy signup password must satisfy minimum_password_length (fixes #2456)

OTP/magic-link signup creates the user with an internally generated
dummy password of fixed length (33 for email magic link, 64 for SMS).
When `minimum_password_length` is configured higher than that (e.g.
100), `validateSignupParams` rejects the just-generated password with
`weak_password` 422, breaking passwordless signup entirely.

Generate the dummy password with
`max(config.Password.MinLength, <default>)` so passwordless signup works
regardless of the configured minimum.