### PR TITLE
chore: bump Go version to 1.26.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.5-alpine3.23 as build
+FROM golang:1.26.6-alpine3.23 as build
 ENV GO111MODULE=on
 ENV CGO_ENABLED=0
 ENV GOOS=linux

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM golang:1.26.5-alpine3.23
+FROM golang:1.26.6-alpine3.23
 ENV GO111MODULE=on
 ENV CGO_ENABLED=0
 ENV GOOS=linux

--- a/go.mod
+++ b/go.mod
@@ -186,6 +186,6 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-go 1.26.5
+go 1.26.6
 
 replace github.com/joho/godotenv => ./internal/forks/godotenv

--- a/internal/forks/godotenv/go.mod
+++ b/internal/forks/godotenv/go.mod
@@ -1,3 +1,3 @@
 module github.com/joho/godotenv
 
-go 1.26.5
+go 1.26.6

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/supabase/auth/tools
 
-go 1.26.5
+go 1.26.6
 
 tool (
 	github.com/securego/gosec/v2/cmd/gosec


### PR DESCRIPTION
Bumps Go to version 1.26.6 to address [govulncheck reports in CI](https://github.com/supabase/auth/actions/runs/32158153358/job/95780273573)