### PR TITLE
feat(mfa): add schema for recovery codes factor

### DIFF
--- a/migrations/20260824000000_add_recovery_codes_factor_type.up.sql
+++ b/migrations/20260824000000_add_recovery_codes_factor_type.up.sql
@@ -1,6 +1,6 @@
 /* auth_migration: 20260824000000 */
 do $$ begin
-    alter type {{ index .Options "Namespace" }}.factor_type add value 'recovery_codes';
+    alter type {{ index .Options "Namespace" }}.factor_type add value 'recovery_code';
 exception
     when duplicate_object then null;
 end $$;

--- a/migrations/20260824000000_add_recovery_codes_factor_type.up.sql
+++ b/migrations/20260824000000_add_recovery_codes_factor_type.up.sql
@@ -1,0 +1,6 @@
+/* auth_migration: 20260824000000 */
+do $$ begin
+    alter type {{ index .Options "Namespace" }}.factor_type add value 'recovery_codes';
+exception
+    when duplicate_object then null;
+end $$;

--- a/migrations/20260824000001_add_recovery_codes_tables.up.sql
+++ b/migrations/20260824000001_add_recovery_codes_tables.up.sql
@@ -19,5 +19,5 @@ create table if not exists {{ index .Options "Namespace" }}.mfa_recovery_codes (
 );
 
 /* auth_migration: 20260824000001 */
-create unique index if not exists mfa_recovery_codes_set_id_code_hash_idx
-    on {{ index .Options "Namespace" }}.mfa_recovery_codes (mfa_recovery_code_set_id, code_hash);
+create index if not exists mfa_recovery_codes_set_id_idx
+    on {{ index .Options "Namespace" }}.mfa_recovery_codes (mfa_recovery_code_set_id);

--- a/migrations/20260824000001_add_recovery_codes_tables.up.sql
+++ b/migrations/20260824000001_add_recovery_codes_tables.up.sql
@@ -1,0 +1,27 @@
+-- Enforce exactly one recovery-codes factor per user.
+/* auth_migration: 20260824000001 */
+create unique index if not exists mfa_factors_user_recovery_codes_unique
+    on {{ index .Options "Namespace" }}.mfa_factors (user_id) where factor_type = 'recovery_codes';
+
+/* auth_migration: 20260824000001 */
+create table if not exists {{ index .Options "Namespace" }}.mfa_recovery_code_sets (
+    id uuid primary key,
+    factor_id uuid not null unique references {{ index .Options "Namespace" }}.mfa_factors (id) on delete cascade,
+    failed_verification_count integer not null default 0 check (failed_verification_count >= 0),
+    verification_locked_until timestamptz,
+    created_at timestamptz not null default now(),
+    updated_at timestamptz not null default now()
+);
+
+/* auth_migration: 20260824000001 */
+create table if not exists {{ index .Options "Namespace" }}.mfa_recovery_codes (
+    id uuid primary key,
+    mfa_recovery_code_set_id uuid not null references {{ index .Options "Namespace" }}.mfa_recovery_code_sets (id) on delete cascade,
+    code_hash text not null,
+    used_at timestamptz,
+    created_at timestamptz not null default now()
+);
+
+/* auth_migration: 20260824000001 */
+create index if not exists mfa_recovery_codes_set_id_idx
+    on {{ index .Options "Namespace" }}.mfa_recovery_codes (mfa_recovery_code_set_id);

--- a/migrations/20260824000001_add_recovery_codes_tables.up.sql
+++ b/migrations/20260824000001_add_recovery_codes_tables.up.sql
@@ -1,12 +1,8 @@
--- Enforce exactly one recovery-codes factor per user.
-/* auth_migration: 20260824000001 */
-create unique index if not exists mfa_factors_user_recovery_codes_unique
-    on {{ index .Options "Namespace" }}.mfa_factors (user_id) where factor_type = 'recovery_codes';
-
 /* auth_migration: 20260824000001 */
 create table if not exists {{ index .Options "Namespace" }}.mfa_recovery_code_sets (
     id uuid primary key,
-    factor_id uuid not null unique references {{ index .Options "Namespace" }}.mfa_factors (id) on delete cascade,
+    user_id uuid not null unique references {{ index .Options "Namespace" }}.users (id) on delete cascade,
+    mfa_factor_id uuid not null unique references {{ index .Options "Namespace" }}.mfa_factors (id) on delete cascade,
     failed_verification_count integer not null default 0 check (failed_verification_count >= 0),
     verification_locked_until timestamptz,
     created_at timestamptz not null default now(),
@@ -18,10 +14,10 @@ create table if not exists {{ index .Options "Namespace" }}.mfa_recovery_codes (
     id uuid primary key,
     mfa_recovery_code_set_id uuid not null references {{ index .Options "Namespace" }}.mfa_recovery_code_sets (id) on delete cascade,
     code_hash text not null,
-    used_at timestamptz,
+    consumed_at timestamptz,
     created_at timestamptz not null default now()
 );
 
 /* auth_migration: 20260824000001 */
-create index if not exists mfa_recovery_codes_set_id_idx
-    on {{ index .Options "Namespace" }}.mfa_recovery_codes (mfa_recovery_code_set_id);
+create unique index if not exists mfa_recovery_codes_set_id_code_hash_idx
+    on {{ index .Options "Namespace" }}.mfa_recovery_codes (mfa_recovery_code_set_id, code_hash);


### PR DESCRIPTION
Adds the schemas required to support MFA recovery codes factor.

> [!NOTE]
> To avoid long running migration on Auth server startup due to `mfa_factors (user_id) where factor_type = 'recovery_codes'`, we've decided to denormalize the `user_id` field and add it to the `mfa_recovery_code_sets` which would provide similar guarantees of a user only allowed to have a single set of recovery codes.