### PR TITLE
feat(mfa): add recovery code crypto primitives

### DIFF
--- a/internal/crypto/password_test.go
+++ b/internal/crypto/password_test.go
@@ -35,10 +35,18 @@ func TestArgon2(t *testing.T) {
 		"$argon2id$v=19$m=16,t=2,p=1,keyid=abc$bGJRWThNOHJJTVBSdHl2dQ$NfEnUOuUpb7F2fQkgFUG4g",
 		// m larger than 32 bits
 		"$argon2id$v=19$m=4294967297,t=2,p=1$bGJRWThNOHJJTVBSdHl2dQ$NfEnUOuUpb7F2fQkgFUG4g",
+		// m exceeds the 1 GiB limit
+		"$argon2id$v=19$m=1048577,t=2,p=1$bGJRWThNOHJJTVBSdHl2dQ$NfEnUOuUpb7F2fQkgFUG4g",
 		// t larger than 32 bits
 		"$argon2id$v=19$m=16,t=4294967297,p=1$bGJRWThNOHJJTVBSdHl2dQ$NfEnUOuUpb7F2fQkgFUG4g",
+		// t exceeds the limit of 20
+		"$argon2id$v=19$m=16,t=21,p=1$bGJRWThNOHJJTVBSdHl2dQ$NfEnUOuUpb7F2fQkgFUG4g",
 		// p larger than 8 bits
 		"$argon2id$v=19$m=16,t=2,p=256$bGJRWThNOHJJTVBSdHl2dQ$NfEnUOuUpb7F2fQkgFUG4g",
+		// p exceeds the limit of 16
+		"$argon2id$v=19$m=16,t=2,p=17$bGJRWThNOHJJTVBSdHl2dQ$NfEnUOuUpb7F2fQkgFUG4g",
+		// argon2 prefix but not a well-formed argon2 hash
+		"$argon2id$v=19$m=16,t=2",
 		// salt not Base64
 		"$argon2id$v=19$m=16,t=2,p=1$!!!$NfEnUOuUpb7F2fQkgFUG4g",
 		// hash not Base64

--- a/internal/crypto/recovery_codes.go
+++ b/internal/crypto/recovery_codes.go
@@ -1,0 +1,147 @@
+package crypto
+
+import (
+	"crypto/rand"
+	"crypto/subtle"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"io"
+	"regexp"
+	"strconv"
+	"strings"
+	"unicode"
+
+	"golang.org/x/crypto/argon2"
+)
+
+// Recovery codes use the base32 alphabet (RFC 4648, lowercased) to
+// avoid ambiguous characters (0/O, 1/I/L). Canonical form is lowercase.
+const recoveryCodeAlphabet = "abcdefghijklmnopqrstuvwxyz234567"
+
+// argon2id parameters for newly generated recovery-code hashes. Verification reads
+// the parameters from the stored hash, so these can change without breaking existing codes.
+const (
+	recoveryCodeArgon2idMemoryKiB   uint32 = 19456
+	recoveryCodeArgon2idIterations  uint32 = 1
+	recoveryCodeArgon2idParallelism uint8  = 1
+	recoveryCodeArgon2idSaltLength         = 16
+	recoveryCodeArgon2idKeyLength   uint32 = 32
+)
+
+var ErrRecoveryCodeMismatchedHashAndCode = errors.New("crypto: recovery code hash and code mismatch")
+
+// Strict PHC subset for recovery-code hashes: argon2id only, version 19 only,
+// no keyid/data extensions, unpadded standard base64.
+var recoveryCodeHashRegexp = regexp.MustCompile(`^\$argon2id\$v=19\$m=(?P<m>[0-9]+),t=(?P<t>[0-9]+),p=(?P<p>[0-9]+)\$(?P<salt>[A-Za-z0-9+/]+)\$(?P<hash>[A-Za-z0-9+/]+)$`)
+
+// GenerateRecoveryCode generates a random recovery code of length characters
+// from the lowercase base32 alphabet.
+func GenerateRecoveryCode(length int) string {
+	code := strings.Builder{}
+	code.Grow(length)
+
+	for range length {
+		code.WriteByte(recoveryCodeAlphabet[secureRandomInt(len(recoveryCodeAlphabet))])
+	}
+
+	return code.String()
+}
+
+// NormalizeRecoveryCode converts user input to the canonical form a recovery
+// code is hashed in: all whitespace and hyphen separators stripped, lowercase.
+func NormalizeRecoveryCode(input string) string {
+	stripped := strings.Map(func(r rune) rune {
+		if r == '-' || unicode.IsSpace(r) {
+			return -1
+		}
+		return r
+	}, input)
+
+	return strings.ToLower(stripped)
+}
+
+// GenerateRecoveryCodeHash hashes a recovery code with argon2id and a random salt,
+// returning a PHC string of the form $argon2id$v=19$m=19456,t=1,p=1$<salt>$<digest>
+func GenerateRecoveryCodeHash(code string) (string, error) {
+	salt := make([]byte, recoveryCodeArgon2idSaltLength)
+	if _, err := io.ReadFull(rand.Reader, salt); err != nil {
+		return "", err
+	}
+
+	digest := argon2.IDKey(
+		[]byte(code),
+		salt,
+		recoveryCodeArgon2idIterations,
+		recoveryCodeArgon2idMemoryKiB,
+		recoveryCodeArgon2idParallelism,
+		recoveryCodeArgon2idKeyLength,
+	)
+
+	return fmt.Sprintf(
+		"$argon2id$v=%d$m=%d,t=%d,p=%d$%s$%s",
+		argon2.Version,
+		recoveryCodeArgon2idMemoryKiB,
+		recoveryCodeArgon2idIterations,
+		recoveryCodeArgon2idParallelism,
+		base64.RawStdEncoding.EncodeToString(salt),
+		base64.RawStdEncoding.EncodeToString(digest),
+	), nil
+}
+
+// CompareHashAndRecoveryCode compares a stored recovery-code hash with a
+// candidate code, returning nil if they match and ErrRecoveryCodeMismatchedHashAndCode otherwise.
+func CompareHashAndRecoveryCode(hash, code string) error {
+	submatch := recoveryCodeHashRegexp.FindStringSubmatchIndex(hash)
+	if submatch == nil {
+		return errors.New("crypto: incorrect recovery code hash format")
+	}
+
+	m := string(recoveryCodeHashRegexp.ExpandString(nil, "$m", hash, submatch))
+	t := string(recoveryCodeHashRegexp.ExpandString(nil, "$t", hash, submatch))
+	p := string(recoveryCodeHashRegexp.ExpandString(nil, "$p", hash, submatch))
+	saltB64 := string(recoveryCodeHashRegexp.ExpandString(nil, "$salt", hash, submatch))
+	hashB64 := string(recoveryCodeHashRegexp.ExpandString(nil, "$hash", hash, submatch))
+
+	memory, err := strconv.ParseUint(m, 10, 32)
+	if err != nil {
+		return fmt.Errorf("crypto: recovery code hash has invalid m parameter %q %w", m, err)
+	}
+	if memory > 1024*1024 { // 1 GiB in KiB
+		return fmt.Errorf("crypto: recovery code hash has m parameter %d exceeds memory limit", memory)
+	}
+
+	time, err := strconv.ParseUint(t, 10, 32)
+	if err != nil {
+		return fmt.Errorf("crypto: recovery code hash has invalid t parameter %q %w", t, err)
+	}
+	if time == 0 || time > 20 {
+		return fmt.Errorf("crypto: recovery code hash has t parameter %d outside time limits", time)
+	}
+
+	threads, err := strconv.ParseUint(p, 10, 8)
+	if err != nil {
+		return fmt.Errorf("crypto: recovery code hash has invalid p parameter %q %w", p, err)
+	}
+	if threads == 0 || threads > 16 {
+		return fmt.Errorf("crypto: recovery code hash has p parameter %d outside thread limits", threads)
+	}
+
+	salt, err := base64.RawStdEncoding.DecodeString(saltB64)
+	if err != nil {
+		return fmt.Errorf("crypto: recovery code hash has invalid base64 in the salt section %w", err)
+	}
+
+	rawHash, err := base64.RawStdEncoding.DecodeString(hashB64)
+	if err != nil {
+		return fmt.Errorf("crypto: recovery code hash has invalid base64 in the hash section %w", err)
+	}
+
+	derivedKey := argon2.IDKey([]byte(code), salt, uint32(time), uint32(memory), uint8(threads), uint32(len(rawHash))) // #nosec G115
+
+	if subtle.ConstantTimeCompare(derivedKey, rawHash) != 1 {
+		return ErrRecoveryCodeMismatchedHashAndCode
+	}
+
+	return nil
+}

--- a/internal/crypto/recovery_codes.go
+++ b/internal/crypto/recovery_codes.go
@@ -23,7 +23,7 @@ const recoveryCodeAlphabet = "abcdefghijklmnopqrstuvwxyz234567"
 // the parameters from the stored hash, so these can change without breaking existing codes.
 const (
 	recoveryCodeArgon2idMemoryKiB   uint32 = 19456
-	recoveryCodeArgon2idIterations  uint32 = 1
+	recoveryCodeArgon2idIterations  uint32 = 2
 	recoveryCodeArgon2idParallelism uint8  = 1
 	recoveryCodeArgon2idSaltLength         = 16
 	recoveryCodeArgon2idKeyLength   uint32 = 32
@@ -62,7 +62,7 @@ func NormalizeRecoveryCode(input string) string {
 }
 
 // GenerateRecoveryCodeHash hashes a recovery code with argon2id and a random salt,
-// returning a PHC string of the form $argon2id$v=19$m=19456,t=1,p=1$<salt>$<digest>
+// returning a PHC string of the form $argon2id$v=19$m=19456,t=2,p=1$<salt>$<digest>
 func GenerateRecoveryCodeHash(code string) (string, error) {
 	salt := make([]byte, recoveryCodeArgon2idSaltLength)
 	if _, err := io.ReadFull(rand.Reader, salt); err != nil {
@@ -127,14 +127,24 @@ func CompareHashAndRecoveryCode(hash, code string) error {
 		return fmt.Errorf("crypto: recovery code hash has p parameter %d outside thread limits", threads)
 	}
 
+	if memory < 8*threads { // RFC 9106 requires at least 8 KiB of memory per thread
+		return fmt.Errorf("crypto: recovery code hash has m parameter %d below memory minimum", memory)
+	}
+
 	salt, err := base64.RawStdEncoding.DecodeString(saltB64)
 	if err != nil {
 		return fmt.Errorf("crypto: recovery code hash has invalid base64 in the salt section %w", err)
+	}
+	if len(salt) < 8 { // RFC 9106 minimum salt length for password hashing
+		return fmt.Errorf("crypto: recovery code hash has salt of %d bytes below length minimum", len(salt))
 	}
 
 	rawHash, err := base64.RawStdEncoding.DecodeString(hashB64)
 	if err != nil {
 		return fmt.Errorf("crypto: recovery code hash has invalid base64 in the hash section %w", err)
+	}
+	if len(rawHash) < 16 { // short digests weaken the constant-time comparison below
+		return fmt.Errorf("crypto: recovery code hash has digest of %d bytes below length minimum", len(rawHash))
 	}
 
 	derivedKey := argon2.IDKey([]byte(code), salt, uint32(time), uint32(memory), uint8(threads), uint32(len(rawHash))) // #nosec G115

--- a/internal/crypto/recovery_codes_test.go
+++ b/internal/crypto/recovery_codes_test.go
@@ -61,7 +61,7 @@ func TestGenerateRecoveryCodeHash(t *testing.T) {
 	hash, err := GenerateRecoveryCodeHash(code)
 	require.NoError(t, err)
 
-	prefix := "$argon2id$v=19$m=19456,t=1,p=1$"
+	prefix := "$argon2id$v=19$m=19456,t=2,p=1$"
 	require.True(t, strings.HasPrefix(hash, prefix), "hash %q does not have prefix %q", hash, prefix)
 
 	parts := strings.Split(strings.TrimPrefix(hash, prefix), "$")
@@ -120,6 +120,19 @@ func TestCompareHashAndRecoveryCodeParameterAgility(t *testing.T) {
 
 	assert.NoError(t, CompareHashAndRecoveryCode(hash, code))
 	assert.ErrorIs(t, CompareHashAndRecoveryCode(hash, "wrongcodejklmnp27"), ErrRecoveryCodeMismatchedHashAndCode)
+
+	// a hash sitting exactly on every minimum bound (m=8*p, 8-byte salt,
+	// 16-byte digest) must still verify
+	minSalt := []byte("01234567")
+	minDigest := argon2.IDKey([]byte(code), minSalt, 1, 8, 1, 16)
+	minHash := fmt.Sprintf(
+		"$argon2id$v=19$m=8,t=1,p=1$%s$%s",
+		base64.RawStdEncoding.EncodeToString(minSalt),
+		base64.RawStdEncoding.EncodeToString(minDigest),
+	)
+
+	assert.NoError(t, CompareHashAndRecoveryCode(minHash, code))
+	assert.ErrorIs(t, CompareHashAndRecoveryCode(minHash, "wrongcodejklmnp27"), ErrRecoveryCodeMismatchedHashAndCode)
 }
 
 func TestCompareHashAndRecoveryCodeNegativeExamples(t *testing.T) {
@@ -138,6 +151,12 @@ func TestCompareHashAndRecoveryCodeNegativeExamples(t *testing.T) {
 		"$argon2id$v=19$m=4294967297,t=2,p=1$bGJRWThNOHJJTVBSdHl2dQ$NfEnUOuUpb7F2fQkgFUG4g",
 		// m exceeds the 1 GiB limit
 		"$argon2id$v=19$m=1048577,t=2,p=1$bGJRWThNOHJJTVBSdHl2dQ$NfEnUOuUpb7F2fQkgFUG4g",
+		// m is 0
+		"$argon2id$v=19$m=0,t=2,p=1$bGJRWThNOHJJTVBSdHl2dQ$NfEnUOuUpb7F2fQkgFUG4g",
+		// m below the minimum of 8 KiB per thread
+		"$argon2id$v=19$m=7,t=2,p=1$bGJRWThNOHJJTVBSdHl2dQ$NfEnUOuUpb7F2fQkgFUG4g",
+		// m below the minimum of 8 KiB per thread at the thread limit
+		"$argon2id$v=19$m=127,t=2,p=16$bGJRWThNOHJJTVBSdHl2dQ$NfEnUOuUpb7F2fQkgFUG4g",
 		// t larger than 32 bits
 		"$argon2id$v=19$m=16,t=4294967297,p=1$bGJRWThNOHJJTVBSdHl2dQ$NfEnUOuUpb7F2fQkgFUG4g",
 		// t is 0
@@ -160,8 +179,12 @@ func TestCompareHashAndRecoveryCodeNegativeExamples(t *testing.T) {
 		"$argon2id$v=19$m=16,t=2,p=1$bGJRWThNOHJJTVBSdHl2dQ$AAAAA",
 		// salt empty
 		"$argon2id$v=19$m=16,t=2,p=1$$NfEnUOuUpb7F2fQkgFUG4g",
+		// salt of 4 bytes, below the minimum of 8
+		"$argon2id$v=19$m=16,t=2,p=1$AAAAAA$NfEnUOuUpb7F2fQkgFUG4g",
 		// hash empty
 		"$argon2id$v=19$m=16,t=2,p=1$bGJRWThNOHJJTVBSdHl2dQ$",
+		// hash of 8 bytes, below the minimum of 16
+		"$argon2id$v=19$m=16,t=2,p=1$bGJRWThNOHJJTVBSdHl2dQ$AAAAAAAAAAA",
 		// bcrypt hash
 		"$2y$04$mIJxfrCaEI3GukZe11CiXublhEFanu5.ododkll1WphfSp6pn4zIu",
 		// not a hash at all

--- a/internal/crypto/recovery_codes_test.go
+++ b/internal/crypto/recovery_codes_test.go
@@ -1,0 +1,156 @@
+package crypto
+
+import (
+	"encoding/base64"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/argon2"
+)
+
+func TestGenerateRecoveryCode(t *testing.T) {
+	for _, length := range []int{13, 16, 64} {
+		code := GenerateRecoveryCode(length)
+
+		assert.Len(t, code, length)
+
+		for _, c := range code {
+			assert.Contains(t, recoveryCodeAlphabet, string(c))
+		}
+	}
+
+	// check for duplicate codes across a large sample
+	codes := make(map[string]bool)
+	for range 100 {
+		code := GenerateRecoveryCode(16)
+
+		if codes[code] {
+			t.Errorf("GenerateRecoveryCode() generated duplicate code: %s", code)
+		}
+		codes[code] = true
+	}
+}
+
+func TestNormalizeRecoveryCode(t *testing.T) {
+	examples := []struct {
+		input    string
+		expected string
+	}{
+		{" AbCD EfgH-JKLM NP27 ", "abcdefghjklmnp27"},
+		{"ABCD-EFGH-JKLM-NP27", "abcdefghjklmnp27"},
+		{"abcdefghjklmnp27", "abcdefghjklmnp27"},
+		{"\tabcd efgh\njklm np27\r", "abcdefghjklmnp27"},
+		{"----", ""},
+		{"", ""},
+	}
+
+	for _, example := range examples {
+		assert.Equal(t, example.expected, NormalizeRecoveryCode(example.input))
+	}
+}
+
+func TestGenerateRecoveryCodeHash(t *testing.T) {
+	code := GenerateRecoveryCode(16)
+
+	hash, err := GenerateRecoveryCodeHash(code)
+	require.NoError(t, err)
+
+	prefix := "$argon2id$v=19$m=19456,t=1,p=1$"
+	require.True(t, strings.HasPrefix(hash, prefix), "hash %q does not have prefix %q", hash, prefix)
+
+	parts := strings.Split(strings.TrimPrefix(hash, prefix), "$")
+	require.Len(t, parts, 2)
+
+	salt, err := base64.RawStdEncoding.DecodeString(parts[0])
+	require.NoError(t, err)
+	assert.Len(t, salt, recoveryCodeArgon2idSaltLength)
+
+	digest, err := base64.RawStdEncoding.DecodeString(parts[1])
+	require.NoError(t, err)
+	assert.Len(t, digest, int(recoveryCodeArgon2idKeyLength))
+
+	// a fresh salt is drawn per call, so hashing the same code twice must
+	// yield different hashes
+	otherHash, err := GenerateRecoveryCodeHash(code)
+	require.NoError(t, err)
+	assert.NotEqual(t, hash, otherHash)
+}
+
+func TestCompareHashAndRecoveryCode(t *testing.T) {
+	code := GenerateRecoveryCode(16)
+
+	hash, err := GenerateRecoveryCodeHash(code)
+	require.NoError(t, err)
+
+	assert.NoError(t, CompareHashAndRecoveryCode(hash, code))
+
+	err = CompareHashAndRecoveryCode(hash, GenerateRecoveryCode(16))
+	assert.ErrorIs(t, err, ErrRecoveryCodeMismatchedHashAndCode)
+}
+
+func TestCompareHashAndRecoveryCodeParameterAgility(t *testing.T) {
+	// parameters are read from the hash, so a hash generated with different
+	// parameters than the current defaults must still verify
+	code := "abcdefghjklmnp27"
+	salt := []byte("0123456789abcdef")
+
+	digest := argon2.IDKey([]byte(code), salt, 2, 16, 2, 24)
+	hash := fmt.Sprintf(
+		"$argon2id$v=19$m=16,t=2,p=2$%s$%s",
+		base64.RawStdEncoding.EncodeToString(salt),
+		base64.RawStdEncoding.EncodeToString(digest),
+	)
+
+	assert.NoError(t, CompareHashAndRecoveryCode(hash, code))
+	assert.ErrorIs(t, CompareHashAndRecoveryCode(hash, "wrongcodejklmnp27"), ErrRecoveryCodeMismatchedHashAndCode)
+}
+
+func TestCompareHashAndRecoveryCodeNegativeExamples(t *testing.T) {
+	negativeExamples := []string{
+		// argon2i
+		"$argon2i$v=19$m=16,t=2,p=1$bGJRWThNOHJJTVBSdHl2dQ$NfEnUOuUpb7F2fQkgFUG4g",
+		// argon2d
+		"$argon2d$v=19$m=16,t=2,p=1$bGJRWThNOHJJTVBSdHl2dQ$NfEnUOuUpb7F2fQkgFUG4g",
+		// v=16
+		"$argon2id$v=16$m=16,t=2,p=1$bGJRWThNOHJJTVBSdHl2dQ$NfEnUOuUpb7F2fQkgFUG4g",
+		// data
+		"$argon2id$v=19$m=16,t=2,p=1,data=abc$bGJRWThNOHJJTVBSdHl2dQ$NfEnUOuUpb7F2fQkgFUG4g",
+		// keyid
+		"$argon2id$v=19$m=16,t=2,p=1,keyid=abc$bGJRWThNOHJJTVBSdHl2dQ$NfEnUOuUpb7F2fQkgFUG4g",
+		// m larger than 32 bits
+		"$argon2id$v=19$m=4294967297,t=2,p=1$bGJRWThNOHJJTVBSdHl2dQ$NfEnUOuUpb7F2fQkgFUG4g",
+		// m exceeds the 1 GiB limit
+		"$argon2id$v=19$m=1048577,t=2,p=1$bGJRWThNOHJJTVBSdHl2dQ$NfEnUOuUpb7F2fQkgFUG4g",
+		// t is 0
+		"$argon2id$v=19$m=16,t=0,p=1$bGJRWThNOHJJTVBSdHl2dQ$NfEnUOuUpb7F2fQkgFUG4g",
+		// t exceeds the limit of 20
+		"$argon2id$v=19$m=16,t=21,p=1$bGJRWThNOHJJTVBSdHl2dQ$NfEnUOuUpb7F2fQkgFUG4g",
+		// p is 0
+		"$argon2id$v=19$m=16,t=2,p=0$bGJRWThNOHJJTVBSdHl2dQ$NfEnUOuUpb7F2fQkgFUG4g",
+		// p exceeds the limit of 16
+		"$argon2id$v=19$m=16,t=2,p=17$bGJRWThNOHJJTVBSdHl2dQ$NfEnUOuUpb7F2fQkgFUG4g",
+		// salt not base64
+		"$argon2id$v=19$m=16,t=2,p=1$!!!$NfEnUOuUpb7F2fQkgFUG4g",
+		// hash not base64
+		"$argon2id$v=19$m=16,t=2,p=1$bGJRWThNOHJJTVBSdHl2dQ$!!!",
+		// salt empty
+		"$argon2id$v=19$m=16,t=2,p=1$$NfEnUOuUpb7F2fQkgFUG4g",
+		// hash empty
+		"$argon2id$v=19$m=16,t=2,p=1$bGJRWThNOHJJTVBSdHl2dQ$",
+		// bcrypt hash
+		"$2y$04$mIJxfrCaEI3GukZe11CiXublhEFanu5.ododkll1WphfSp6pn4zIu",
+		// not a hash at all
+		"not-a-hash",
+		// empty string
+		"",
+	}
+
+	for _, example := range negativeExamples {
+		err := CompareHashAndRecoveryCode(example, "test")
+		assert.Error(t, err, "expected %q to be rejected", example)
+		assert.NotErrorIs(t, err, ErrRecoveryCodeMismatchedHashAndCode, "expected %q to fail parsing, not comparison", example)
+	}
+}

--- a/internal/crypto/recovery_codes_test.go
+++ b/internal/crypto/recovery_codes_test.go
@@ -1,10 +1,13 @@
 package crypto
 
 import (
+	"crypto/rand"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"strings"
 	"testing"
+	"testing/iotest"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -79,6 +82,17 @@ func TestGenerateRecoveryCodeHash(t *testing.T) {
 	assert.NotEqual(t, hash, otherHash)
 }
 
+func TestGenerateRecoveryCodeHashRandFailure(t *testing.T) {
+	originalReader := rand.Reader
+	rand.Reader = iotest.ErrReader(errors.New("out of entropy"))
+	defer func() {
+		rand.Reader = originalReader
+	}()
+
+	_, err := GenerateRecoveryCodeHash("abcdefghjklmnp27")
+	require.Error(t, err)
+}
+
 func TestCompareHashAndRecoveryCode(t *testing.T) {
 	code := GenerateRecoveryCode(16)
 
@@ -124,18 +138,26 @@ func TestCompareHashAndRecoveryCodeNegativeExamples(t *testing.T) {
 		"$argon2id$v=19$m=4294967297,t=2,p=1$bGJRWThNOHJJTVBSdHl2dQ$NfEnUOuUpb7F2fQkgFUG4g",
 		// m exceeds the 1 GiB limit
 		"$argon2id$v=19$m=1048577,t=2,p=1$bGJRWThNOHJJTVBSdHl2dQ$NfEnUOuUpb7F2fQkgFUG4g",
+		// t larger than 32 bits
+		"$argon2id$v=19$m=16,t=4294967297,p=1$bGJRWThNOHJJTVBSdHl2dQ$NfEnUOuUpb7F2fQkgFUG4g",
 		// t is 0
 		"$argon2id$v=19$m=16,t=0,p=1$bGJRWThNOHJJTVBSdHl2dQ$NfEnUOuUpb7F2fQkgFUG4g",
 		// t exceeds the limit of 20
 		"$argon2id$v=19$m=16,t=21,p=1$bGJRWThNOHJJTVBSdHl2dQ$NfEnUOuUpb7F2fQkgFUG4g",
+		// p larger than 8 bits
+		"$argon2id$v=19$m=16,t=2,p=256$bGJRWThNOHJJTVBSdHl2dQ$NfEnUOuUpb7F2fQkgFUG4g",
 		// p is 0
 		"$argon2id$v=19$m=16,t=2,p=0$bGJRWThNOHJJTVBSdHl2dQ$NfEnUOuUpb7F2fQkgFUG4g",
 		// p exceeds the limit of 16
 		"$argon2id$v=19$m=16,t=2,p=17$bGJRWThNOHJJTVBSdHl2dQ$NfEnUOuUpb7F2fQkgFUG4g",
 		// salt not base64
 		"$argon2id$v=19$m=16,t=2,p=1$!!!$NfEnUOuUpb7F2fQkgFUG4g",
+		// salt in the base64 alphabet but not decodable (length % 4 == 1)
+		"$argon2id$v=19$m=16,t=2,p=1$AAAAA$NfEnUOuUpb7F2fQkgFUG4g",
 		// hash not base64
 		"$argon2id$v=19$m=16,t=2,p=1$bGJRWThNOHJJTVBSdHl2dQ$!!!",
+		// hash in the base64 alphabet but not decodable (length % 4 == 1)
+		"$argon2id$v=19$m=16,t=2,p=1$bGJRWThNOHJJTVBSdHl2dQ$AAAAA",
 		// salt empty
 		"$argon2id$v=19$m=16,t=2,p=1$$NfEnUOuUpb7F2fQkgFUG4g",
 		// hash empty


### PR DESCRIPTION
This PR adds the pieces necessary to generate the recovery codes.

- The codes are lowercase, base32 in their canonical form
  - We normalize inputs to allow users to enter codes like "ABCD-EFGH" and compare them consistently as "abcdefgh"
- Codes are hashed and salted using argon2id
  - They're stored as PHC strings to be able to change parameters in the future without breaking existing hashes
  - argon2id was chosen because:
    - We allow configurable lengths of codes and should securely store the hashes in the worst case (e.g.: 10 character codes)
    - It doesn't have the 72-byte limit from bcrypt (more of a safe guard than a realistic code length)
    - NIST recommends using a password hashing scheme + salting for recovery codes < 112 bits

> [!NOTE]
> This argon2 hash parsing and comparison is intentionally separate from the password one as they serve different purposes and will likely evolve independently so I didn't want to couple them.