### PR TITLE
feat(oauth): emit login metering events for OAuth server token exchanges

### DIFF
--- a/internal/api/oauthserver/handlers.go
+++ b/internal/api/oauthserver/handlers.go
@@ -11,6 +11,7 @@ import (
 	"github.com/gofrs/uuid"
 	"github.com/supabase/auth/internal/api/apierrors"
 	"github.com/supabase/auth/internal/api/shared"
+	"github.com/supabase/auth/internal/metering"
 	"github.com/supabase/auth/internal/models"
 	"github.com/supabase/auth/internal/observability"
 	"github.com/supabase/auth/internal/storage"
@@ -458,6 +459,10 @@ func (s *Server) handleAuthorizationCodeGrant(ctx context.Context, w http.Respon
 
 		tokenResponse.IDToken = idToken
 	}
+
+	metering.RecordLogin(metering.LoginTypeOAuthServerAuthorizationCode, user.ID, &metering.LoginData{
+		ClientID: client.ID.String(),
+	})
 
 	// Convert to OAuth-compliant response format (exclude user info for OAuth clients)
 	oauthResponse := map[string]interface{}{

--- a/internal/api/oauthserver/handlers.go
+++ b/internal/api/oauthserver/handlers.go
@@ -19,10 +19,11 @@ import (
 	"github.com/supabase/auth/internal/utilities"
 )
 
-// OAuth 2.1 Grant Types
+// OAuth 2.1 Grant Types, aliased from internal/tokens so the OAuth server's grant type
+// dispatch and its metering events share one source of truth.
 const (
-	GrantTypeAuthorizationCode = "authorization_code"
-	GrantTypeRefreshToken      = "refresh_token"
+	GrantTypeAuthorizationCode = tokens.GrantTypeAuthorizationCode
+	GrantTypeRefreshToken      = tokens.GrantTypeRefreshToken
 )
 
 // OAuthServerClientResponse represents the response format for OAuth client operations
@@ -460,8 +461,11 @@ func (s *Server) handleAuthorizationCodeGrant(ctx context.Context, w http.Respon
 		tokenResponse.IDToken = idToken
 	}
 
-	metering.RecordLogin(metering.LoginTypeOAuthServerAuthorizationCode, user.ID, &metering.LoginData{
-		ClientID: client.ID.String(),
+	metering.RecordLogin(metering.LoginTypeOAuthServer, user.ID, &metering.LoginData{
+		OAuthServer: &metering.OAuthServerData{
+			ClientID:  client.ID.String(),
+			GrantType: GrantTypeAuthorizationCode,
+		},
 	})
 
 	// Convert to OAuth-compliant response format (exclude user info for OAuth clients)

--- a/internal/api/oauthserver/handlers_metering_test.go
+++ b/internal/api/oauthserver/handlers_metering_test.go
@@ -1,0 +1,38 @@
+package oauthserver
+
+import (
+	"net/http"
+	"net/http/httptest"
+
+	logrustest "github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/require"
+	"github.com/supabase/auth/internal/api/shared"
+)
+
+func (ts *OAuthClientTestSuite) TestAuthorizationCodeGrantRecordsOAuthServerLoginMetric() {
+	client, _ := ts.createTestOAuthClient()
+	user := ts.createTestUser("oauth-server-metering@example.com")
+	code := ts.mintApprovedCode(client.ID, user.ID)
+
+	hook := logrustest.NewGlobal()
+	defer hook.Reset()
+
+	req := httptest.NewRequest(http.MethodPost, "/oauth/token", nil)
+	ctx := shared.WithOAuthServerClient(req.Context(), client)
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+	params := &OAuthTokenParams{GrantType: GrantTypeAuthorizationCode, Code: code}
+
+	err := ts.Server.handleAuthorizationCodeGrant(ctx, w, req, params)
+	require.NoError(ts.T(), err)
+
+	found := false
+	for _, entry := range hook.AllEntries() {
+		if entry.Data["action"] == "login" && entry.Data["login_method"] == "oauth_server_authorization_code" {
+			require.Equal(ts.T(), client.ID.String(), entry.Data["client_id"])
+			require.Equal(ts.T(), user.ID.String(), entry.Data["user_id"])
+			found = true
+		}
+	}
+	require.True(ts.T(), found, "expected an oauth_server_authorization_code login metering event")
+}

--- a/internal/api/oauthserver/handlers_metering_test.go
+++ b/internal/api/oauthserver/handlers_metering_test.go
@@ -28,11 +28,12 @@ func (ts *OAuthClientTestSuite) TestAuthorizationCodeGrantRecordsOAuthServerLogi
 
 	found := false
 	for _, entry := range hook.AllEntries() {
-		if entry.Data["action"] == "login" && entry.Data["login_method"] == "oauth_server_authorization_code" {
+		if entry.Data["action"] == "login" && entry.Data["login_method"] == "oauth_server" {
 			require.Equal(ts.T(), client.ID.String(), entry.Data["client_id"])
+			require.Equal(ts.T(), "authorization_code", entry.Data["grant_type"])
 			require.Equal(ts.T(), user.ID.String(), entry.Data["user_id"])
 			found = true
 		}
 	}
-	require.True(ts.T(), found, "expected an oauth_server_authorization_code login metering event")
+	require.True(ts.T(), found, "expected an oauth_server login metering event for the authorization_code grant")
 }

--- a/internal/metering/record.go
+++ b/internal/metering/record.go
@@ -27,6 +27,7 @@ const (
 	// authorization_code grant (this app acting as the OAuth server, not a third-party provider).
 	LoginTypeOAuthServerAuthorizationCode LoginType = "oauth_server_authorization_code"
 	// LoginTypeOAuthServerTokenRefresh is additive alongside LoginTypeToken for OAuth server token refreshes.
+	// #nosec G101 - No hardcoded credentials, this is a login analytics label.
 	LoginTypeOAuthServerTokenRefresh LoginType = "oauth_server_token_refresh"
 )
 

--- a/internal/metering/record.go
+++ b/internal/metering/record.go
@@ -23,12 +23,9 @@ const (
 	LoginTypeMFA       LoginType = "mfa"   // for MFA verifications
 	LoginTypePasskey   LoginType = "passkey"
 
-	// LoginTypeOAuthServerAuthorizationCode is for the OAuth 2.1 authorization server's
-	// authorization_code grant (this app acting as the OAuth server, not a third-party provider).
-	LoginTypeOAuthServerAuthorizationCode LoginType = "oauth_server_authorization_code"
-	// LoginTypeOAuthServerTokenRefresh is additive alongside LoginTypeToken for OAuth server token refreshes.
-	// #nosec G101 - No hardcoded credentials, this is a login analytics label.
-	LoginTypeOAuthServerTokenRefresh LoginType = "oauth_server_token_refresh"
+	// LoginTypeOAuthServer is for the OAuth 2.1 authorization server (this app acting as the
+	// OAuth server, not a third-party provider)
+	LoginTypeOAuthServer LoginType = "oauth_server"
 )
 
 // Provider constants for consistent login analytics
@@ -54,8 +51,8 @@ type LoginData struct {
 	// Web3 specific data (for blockchain authentication)
 	Web3 *Web3Data `json:"web3,omitempty"`
 
-	// ClientID is the OAuth server client ID, for OAuth server login events
-	ClientID string `json:"client_id,omitempty"`
+	// OAuthServer specific data (for LoginTypeOAuthServer events)
+	OAuthServer *OAuthServerData `json:"oauth_server,omitempty"`
 
 	// Additional context for future extensibility
 	Extra map[string]interface{} `json:"extra,omitempty"`
@@ -75,6 +72,15 @@ type Web3Data struct {
 	URI string `json:"uri,omitempty"`
 }
 
+// OAuthServerData contains OAuth 2.1 authorization server specific data
+type OAuthServerData struct {
+	// ClientID is the OAuth server client ID, for per-client usage reporting
+	ClientID string `json:"client_id,omitempty"`
+	// GrantType is the OAuth 2.1 grant type behind this login event
+	// (e.g. "authorization_code", "refresh_token")
+	GrantType string `json:"grant_type,omitempty"`
+}
+
 var logger = logrus.StandardLogger().WithField("metering", true)
 
 func RecordLogin(loginType LoginType, userID uuid.UUID, data *LoginData) {
@@ -90,8 +96,14 @@ func RecordLogin(loginType LoginType, userID uuid.UUID, data *LoginData) {
 			fields["provider"] = data.Provider
 		}
 
-		if data.ClientID != "" {
-			fields["client_id"] = data.ClientID
+		// Add OAuth server context fields
+		if data.OAuthServer != nil {
+			if data.OAuthServer.ClientID != "" {
+				fields["client_id"] = data.OAuthServer.ClientID
+			}
+			if data.OAuthServer.GrantType != "" {
+				fields["grant_type"] = data.OAuthServer.GrantType
+			}
 		}
 
 		// Add Web3 context fields

--- a/internal/metering/record.go
+++ b/internal/metering/record.go
@@ -22,6 +22,12 @@ const (
 	LoginTypeToken     LoginType = "token" // for refresh token flows, to be backward-compatible with existing data
 	LoginTypeMFA       LoginType = "mfa"   // for MFA verifications
 	LoginTypePasskey   LoginType = "passkey"
+
+	// LoginTypeOAuthServerAuthorizationCode is for the OAuth 2.1 authorization server's
+	// authorization_code grant (this app acting as the OAuth server, not a third-party provider).
+	LoginTypeOAuthServerAuthorizationCode LoginType = "oauth_server_authorization_code"
+	// LoginTypeOAuthServerTokenRefresh is additive alongside LoginTypeToken for OAuth server token refreshes.
+	LoginTypeOAuthServerTokenRefresh LoginType = "oauth_server_token_refresh"
 )
 
 // Provider constants for consistent login analytics
@@ -46,6 +52,9 @@ type LoginData struct {
 
 	// Web3 specific data (for blockchain authentication)
 	Web3 *Web3Data `json:"web3,omitempty"`
+
+	// ClientID is the OAuth server client ID, for OAuth server login events
+	ClientID string `json:"client_id,omitempty"`
 
 	// Additional context for future extensibility
 	Extra map[string]interface{} `json:"extra,omitempty"`
@@ -78,6 +87,10 @@ func RecordLogin(loginType LoginType, userID uuid.UUID, data *LoginData) {
 	if data != nil {
 		if data.Provider != "" {
 			fields["provider"] = data.Provider
+		}
+
+		if data.ClientID != "" {
+			fields["client_id"] = data.ClientID
 		}
 
 		// Add Web3 context fields

--- a/internal/tokens/service.go
+++ b/internal/tokens/service.go
@@ -28,6 +28,14 @@ import (
 
 const retryLoopDuration = 5.0
 
+// OAuth2 grant type values. Defined here (rather than in
+// internal/api/oauthserver, which imports this package) so both the OAuth server's grant type
+// dispatch and this package's own metering calls share a single source of truth.
+const (
+	GrantTypeAuthorizationCode = "authorization_code"
+	GrantTypeRefreshToken      = "refresh_token"
+)
+
 // AMRClaim supports unmarshalling AMR as either strings or AMREntry objects.
 type AMRClaim []models.AMREntry
 
@@ -648,8 +656,11 @@ func (s *Service) RefreshTokenGrant(ctx context.Context, db *storage.Connection,
 		}
 		metering.RecordLogin(metering.LoginTypeToken, user.ID, nil)
 		if sessionClientID != nil {
-			metering.RecordLogin(metering.LoginTypeOAuthServerTokenRefresh, user.ID, &metering.LoginData{
-				ClientID: sessionClientID.String(),
+			metering.RecordLogin(metering.LoginTypeOAuthServer, user.ID, &metering.LoginData{
+				OAuthServer: &metering.OAuthServerData{
+					ClientID:  sessionClientID.String(),
+					GrantType: GrantTypeRefreshToken,
+				},
 			})
 		}
 		return newTokenResponse, nil

--- a/internal/tokens/service.go
+++ b/internal/tokens/service.go
@@ -28,9 +28,7 @@ import (
 
 const retryLoopDuration = 5.0
 
-// OAuth2 grant type values. Defined here (rather than in
-// internal/api/oauthserver, which imports this package) so both the OAuth server's grant type
-// dispatch and this package's own metering calls share a single source of truth.
+// OAuth2 server grant type values
 const (
 	GrantTypeAuthorizationCode = "authorization_code"
 	GrantTypeRefreshToken      = "refresh_token"

--- a/internal/tokens/service.go
+++ b/internal/tokens/service.go
@@ -647,6 +647,11 @@ func (s *Service) RefreshTokenGrant(ctx context.Context, db *storage.Connection,
 			}
 		}
 		metering.RecordLogin(metering.LoginTypeToken, user.ID, nil)
+		if sessionClientID != nil {
+			metering.RecordLogin(metering.LoginTypeOAuthServerTokenRefresh, user.ID, &metering.LoginData{
+				ClientID: sessionClientID.String(),
+			})
+		}
 		return newTokenResponse, nil
 	}
 

--- a/internal/tokens/service_test.go
+++ b/internal/tokens/service_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/gofrs/uuid"
 	"github.com/golang-jwt/jwt/v5"
+	logrustest "github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"github.com/supabase/auth/internal/conf"
@@ -185,6 +186,68 @@ func (ts *RefreshTokenV2Suite) TestUpdatesLastSignInAt() {
 	require.NoError(ts.T(), err)
 	require.NotNil(ts.T(), dbUser.LastSignInAt)
 	require.WithinDuration(ts.T(), clock, *dbUser.LastSignInAt, time.Second)
+}
+
+func (ts *RefreshTokenV2Suite) TestOAuthServerRefreshRecordsAdditiveLoginMetric() {
+	config := ts.config()
+
+	oauthClient := &models.OAuthServerClient{
+		ID:                      uuid.Must(uuid.NewV4()),
+		ClientSecretHash:        "test-hash",
+		RegistrationType:        "dynamic",
+		ClientType:              models.OAuthServerClientTypeConfidential,
+		TokenEndpointAuthMethod: "client_secret_basic",
+		RedirectURIs:            "https://example.com/callback",
+		GrantTypes:              "authorization_code,refresh_token",
+	}
+	require.NoError(ts.T(), models.CreateOAuthServerClient(ts.Conn, oauthClient))
+	clientID := oauthClient.ID
+
+	srv := NewService(config, &panicHookManager{})
+
+	req, err := http.NewRequest("POST", "https://example.com/", nil)
+	require.NoError(ts.T(), err)
+	req = req.WithContext(context.Background())
+	responseHeaders := make(http.Header)
+
+	at, err := srv.IssueRefreshToken(
+		req,
+		responseHeaders,
+		ts.Conn,
+		ts.User,
+		models.OAuthProviderAuthorizationCode,
+		models.GrantParams{OAuthClientID: &clientID},
+	)
+	require.NoError(ts.T(), err)
+	require.NotNil(ts.T(), at)
+
+	hook := logrustest.NewGlobal()
+	defer hook.Reset()
+
+	responseHeaders = make(http.Header)
+	nrt, err := srv.RefreshTokenGrant(context.Background(), ts.Conn, req, responseHeaders, RefreshTokenGrantParams{
+		RefreshToken: at.RefreshToken,
+		ClientID:     &clientID,
+	})
+	require.NoError(ts.T(), err)
+	require.NotNil(ts.T(), nrt)
+
+	var sawGenericToken, sawOAuthServerRefresh bool
+	for _, entry := range hook.AllEntries() {
+		if entry.Data["action"] != "login" {
+			continue
+		}
+		switch entry.Data["login_method"] {
+		case "token":
+			sawGenericToken = true
+			require.NotContains(ts.T(), entry.Data, "client_id")
+		case "oauth_server_token_refresh":
+			sawOAuthServerRefresh = true
+			require.Equal(ts.T(), clientID.String(), entry.Data["client_id"])
+		}
+	}
+	require.True(ts.T(), sawGenericToken, "existing generic token refresh login event must still fire")
+	require.True(ts.T(), sawOAuthServerRefresh, "additive oauth_server_token_refresh login event must fire with client_id")
 }
 
 func (ts *RefreshTokenV2Suite) TestMaliciousReuse() {

--- a/internal/tokens/service_test.go
+++ b/internal/tokens/service_test.go
@@ -241,13 +241,14 @@ func (ts *RefreshTokenV2Suite) TestOAuthServerRefreshRecordsAdditiveLoginMetric(
 		case "token":
 			sawGenericToken = true
 			require.NotContains(ts.T(), entry.Data, "client_id")
-		case "oauth_server_token_refresh":
+		case "oauth_server":
 			sawOAuthServerRefresh = true
 			require.Equal(ts.T(), clientID.String(), entry.Data["client_id"])
+			require.Equal(ts.T(), "refresh_token", entry.Data["grant_type"])
 		}
 	}
 	require.True(ts.T(), sawGenericToken, "existing generic token refresh login event must still fire")
-	require.True(ts.T(), sawOAuthServerRefresh, "additive oauth_server_token_refresh login event must fire with client_id")
+	require.True(ts.T(), sawOAuthServerRefresh, "additive oauth_server login event must fire with client_id and grant_type=refresh_token")
 }
 
 func (ts *RefreshTokenV2Suite) TestMaliciousReuse() {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature (analytics/observability only, no behavior change)

## What is the current behavior?

OAuth 2.1 authorization server logins aren't represented in standard `Login` metering events:
  - The initial authorization_code → token exchange emits no login event.
  - Refreshes of OAuth server tokens only emit the generic `login_method: token` event, with no attribution to the OAuth server or client.

This makes it impossible to answer "what share of logins flow through the OAuth server?"

## What is the new behavior?

- `handleAuthorizationCodeGrant` now records a `oauth_server_authorization_code` login event (with `client_id`) once the exchange has fully succeeded.
- `RefreshTokenGrant` now additionally records an `oauth_server_token_refresh` login event (with `client_id`) for OAuth server sessions, alongside the existing (unchanged) generic `token` event.
- `metering.LoginData` gained a `ClientID` field, surfaced as `client_id` in the emitted log fields.

 

 Resolves AUTH-1539