### PR TITLE
chore(codeql): override default codeql setup for go 1.27 toolchain

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,48 @@
+name: "CodeQL"
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+  schedule:
+    - cron: "16 13 * * 1"
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: actions
+            build-mode: none
+          - language: go
+            build-mode: autobuild
+          - language: javascript-typescript
+            build-mode: none
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Go
+        if: matrix.language == 'go'
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
+        with:
+          go-version-file: go.mod
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## What kind of change does this PR introduce?

Chore. Update codeql to use go 1.27 toolchain

## What is the current behavior?

Currently failing with:

```bash
  [2026-08-26 23:29:16] [build-stderr] 2026/08/26 23:29:16 Warning: go list command failed, output below:
  [2026-08-26 23:29:16] [build-stderr] stdout:
  [2026-08-26 23:29:16] [build-stderr] stderr:
  [2026-08-26 23:29:16] [build-stderr] go: go.mod requires go >= 1.27.0 (running go 1.26.7; GOTOOLCHAIN=local)
  [2026-08-26 23:29:16] [build-stderr] 2026/08/26 23:29:16 Warning: go list command failed, output below:
  [2026-08-26 23:29:16] [build-stderr] stdout:
  [2026-08-26 23:29:16] [build-stderr] stderr:
  [2026-08-26 23:29:16] [build-stderr] go: go.mod requires go >= 1.27.0 (running go 1.26.7; GOTOOLCHAIN=local)
  [2026-08-26 23:29:16] [build-stderr] 2026/08/26 23:29:16 Warning: go list command failed, output below:
  [2026-08-26 23:29:16] [build-stderr] stdout:
  [2026-08-26 23:29:16] [build-stderr] stderr:
  [2026-08-26 23:29:16] [build-stderr] go: go.mod requires go >= 1.27.0 (running go 1.26.7; GOTOOLCHAIN=local)
  [2026-08-26 23:29:16] [build-stderr] 2026/08/26 23:29:16 Running extractor command '/opt/hostedtoolcache/CodeQL/2.26.3/x64/codeql/go/tools/linux64/go-extractor [./...]' from directory '.'.
  [2026-08-26 23:29:16] [build-stderr] 2026/08/26 23:29:16 Build flags: ''; patterns: './...'
  [2026-08-26 23:29:16] [build-stderr] 2026/08/26 23:29:16 Running packages.Load.
  [2026-08-26 23:29:17] [build-stderr] 2026/08/26 23:29:17 Error running go tooling: err: exit status 1: stderr: go: go.mod requires go >= 1.27.0 (running go 1.26.7; GOTOOLCHAIN=local)
  [2026-08-26 23:29:17] [build-stderr] 2026/08/26 23:29:17 Extraction failed for .: exit status 1
  [2026-08-26 23:29:17] [build-stderr] 2026/08/26 23:29:17 Running extractor command '/opt/hostedtoolcache/CodeQL/2.26.3/x64/codeql/go/tools/linux64/go-extractor [./...]' from directory 'internal/forks/godotenv'.
  [2026-08-26 23:29:17] [build-stderr] 2026/08/26 23:29:17 Build flags: ''; patterns: './...'
  [2026-08-26 23:29:17] [build-stderr] 2026/08/26 23:29:17 Running packages.Load.
  [2026-08-26 23:29:17] [build-stderr] 2026/08/26 23:29:17 Error running go tooling: err: exit status 1: stderr: go: go.mod requires go >= 1.27.0 (running go 1.26.7; GOTOOLCHAIN=local)
  [2026-08-26 23:29:17] [build-stderr] 2026/08/26 23:29:17 Extraction failed for internal/forks/godotenv: exit status 1
  [2026-08-26 23:29:17] [build-stderr] 2026/08/26 23:29:17 Running extractor command '/opt/hostedtoolcache/CodeQL/2.26.3/x64/codeql/go/tools/linux64/go-extractor [./...]' from directory 'tools'.
  [2026-08-26 23:29:17] [build-stderr] 2026/08/26 23:29:17 Build flags: ''; patterns: './...'
  [2026-08-26 23:29:17] [build-stderr] 2026/08/26 23:29:17 Running packages.Load.
  [2026-08-26 23:29:17] [build-stderr] 2026/08/26 23:29:17 Error running go tooling: err: exit status 1: stderr: go: go.mod requires go >= 1.27.0 (running go 1.26.7; GOTOOLCHAIN=local)
  [2026-08-26 23:29:17] [build-stderr] 2026/08/26 23:29:17 Extraction failed for tools: exit status 1
  [2026-08-26 23:29:17] [build-stderr] 2026/08/26 23:29:17 Extraction failed for all discovered Go projects.
  [2026-08-26 23:29:17] [ERROR] Spawned process exited abnormally (code 1; tried to run: [/opt/hostedtoolcache/CodeQL/2.26.3/x64/codeql/tools/linux64/preload_tracer, /opt/hostedtoolcache/CodeQL/2.26.3/x64/codeql/go/tools/autobuild.sh])
  A fatal error occurred: Exit status 1 from command: [/opt/hostedtoolcache/CodeQL/2.26.3/x64/codeql/go/tools/autobuild.sh]
  Error: We were unable to automatically build your code. Please replace the call to the autobuild action with your custom build steps. We were unable to automatically build your code. Please change the build mode for this language to manual and specify build steps for your project. See https://docs.github.com/en/code-security/code-scanning/troubleshooting-code-scanning/automatic-build-failed for more information. Encountered a fatal error while running "/opt/hostedtoolcache/CodeQL/2.26.3/x64/codeql/codeql database trace-command --use-build-mode --working-dir /home/runner/work/auth/auth /home/runner/work/_temp/codeql_databases/go". Exit code was 2 and error was: A fatal error occurred: Exit status 1 from command: [/opt/hostedtoolcache/CodeQL/2.26.3/x64/codeql/go/tools/autobuild.sh]. See the logs for more details.
```

## What is the new behavior?

Not failing.

## Additional context

Related to: https://github.com/supabase/auth/pull/2744