### PR TITLE
feat(mfa): add recovery codes configuration

### DIFF
--- a/example.env
+++ b/example.env
@@ -271,6 +271,13 @@ GOTRUE_SMS_TEST_OTP_VALID_UNTIL="<ISO date time>" # (e.g. 2023-09-29T08:14:06Z)
 GOTRUE_MFA_WEB_AUTHN_ENROLL_ENABLED="false"
 GOTRUE_MFA_WEB_AUTHN_VERIFY_ENABLED="false"
 
+GOTRUE_MFA_RECOVERY_CODES_ENROLL_ENABLED="false"
+GOTRUE_MFA_RECOVERY_CODES_VERIFY_ENABLED="false"
+GOTRUE_MFA_RECOVERY_CODES_COUNT="10" # between 4 and 16
+GOTRUE_MFA_RECOVERY_CODES_CODE_LENGTH="16" # between 13 and 32
+GOTRUE_MFA_RECOVERY_CODES_MAX_VERIFY_ATTEMPTS="5" # between 3 and 15
+GOTRUE_MFA_RECOVERY_CODES_LOCKOUT_DURATION="15m" # between 1m and 24h
+
 # Experimental Configuration
 # The functionality related to experimental features may change or be removed in future releases
 # without prior notice.

--- a/internal/conf/configuration.go
+++ b/internal/conf/configuration.go
@@ -176,16 +176,47 @@ type PhoneFactorTypeConfiguration struct {
 	Template     string             `json:"template"`
 }
 
+type RecoveryCodesFactorTypeConfiguration struct {
+	EnrollEnabled     bool          `json:"enroll_enabled" split_words:"true" default:"false"`
+	VerifyEnabled     bool          `json:"verify_enabled" split_words:"true" default:"false"`
+	Count             int           `json:"count" default:"10"`
+	CodeLength        int           `json:"code_length" split_words:"true" default:"16"`
+	MaxVerifyAttempts int           `json:"max_verify_attempts" split_words:"true" default:"5"`
+	LockoutDuration   time.Duration `json:"lockout_duration" split_words:"true" default:"15m"`
+}
+
+func (c *RecoveryCodesFactorTypeConfiguration) Validate() error {
+	if !c.EnrollEnabled && !c.VerifyEnabled {
+		return nil
+	}
+
+	var errs []error
+	if c.Count < 4 || c.Count > 16 {
+		errs = append(errs, fmt.Errorf("conf: GOTRUE_MFA_RECOVERY_CODES_COUNT must be between 4 and 16, got %d", c.Count))
+	}
+	if c.CodeLength < 13 || c.CodeLength > 32 {
+		errs = append(errs, fmt.Errorf("conf: GOTRUE_MFA_RECOVERY_CODES_CODE_LENGTH must be between 13 and 32, got %d", c.CodeLength))
+	}
+	if c.MaxVerifyAttempts < 3 || c.MaxVerifyAttempts > 15 {
+		errs = append(errs, fmt.Errorf("conf: GOTRUE_MFA_RECOVERY_CODES_MAX_VERIFY_ATTEMPTS must be between 3 and 15, got %d", c.MaxVerifyAttempts))
+	}
+	if c.LockoutDuration < time.Minute || c.LockoutDuration > 24*time.Hour {
+		errs = append(errs, fmt.Errorf("conf: GOTRUE_MFA_RECOVERY_CODES_LOCKOUT_DURATION must be between 1m and 24h, got %v", c.LockoutDuration))
+	}
+	return errors.Join(errs...)
+}
+
 // MFAConfiguration holds all the MFA related Configuration
 type MFAConfiguration struct {
-	ChallengeExpiryDuration     float64                      `json:"challenge_expiry_duration" default:"300" split_words:"true"`
-	FactorExpiryDuration        time.Duration                `json:"factor_expiry_duration" default:"300s" split_words:"true"`
-	RateLimitChallengeAndVerify float64                      `split_words:"true" default:"15"`
-	MaxEnrolledFactors          float64                      `split_words:"true" default:"10"`
-	MaxVerifiedFactors          int                          `split_words:"true" default:"10"`
-	Phone                       PhoneFactorTypeConfiguration `split_words:"true"`
-	TOTP                        TOTPFactorTypeConfiguration  `split_words:"true"`
-	WebAuthn                    MFAFactorTypeConfiguration   `split_words:"true"`
+	ChallengeExpiryDuration     float64                              `json:"challenge_expiry_duration" default:"300" split_words:"true"`
+	FactorExpiryDuration        time.Duration                        `json:"factor_expiry_duration" default:"300s" split_words:"true"`
+	RateLimitChallengeAndVerify float64                              `split_words:"true" default:"15"`
+	MaxEnrolledFactors          float64                              `split_words:"true" default:"10"`
+	MaxVerifiedFactors          int                                  `split_words:"true" default:"10"`
+	Phone                       PhoneFactorTypeConfiguration         `split_words:"true"`
+	TOTP                        TOTPFactorTypeConfiguration          `split_words:"true"`
+	WebAuthn                    MFAFactorTypeConfiguration           `split_words:"true"`
+	RecoveryCodes               RecoveryCodesFactorTypeConfiguration `split_words:"true"`
 }
 
 type WebAuthnConfiguration struct {
@@ -1317,6 +1348,7 @@ func (c *GlobalConfiguration) Validate() error {
 		&c.Hook,
 		&c.JWT.Keys,
 		&c.CustomOAuth,
+		&c.MFA.RecoveryCodes,
 	}
 
 	for _, validatable := range validatables {

--- a/internal/conf/configuration_test.go
+++ b/internal/conf/configuration_test.go
@@ -1019,6 +1019,153 @@ func TestWebAuthnConfigurationValidate(t *testing.T) {
 	}
 }
 
+func TestRecoveryCodesConfigurationValidate(t *testing.T) {
+	validConfig := func() RecoveryCodesFactorTypeConfiguration {
+		return RecoveryCodesFactorTypeConfiguration{
+			EnrollEnabled:     true,
+			VerifyEnabled:     true,
+			Count:             10,
+			CodeLength:        16,
+			MaxVerifyAttempts: 5,
+			LockoutDuration:   15 * time.Minute,
+		}
+	}
+
+	cases := []struct {
+		desc   string
+		mutate func(c *RecoveryCodesFactorTypeConfiguration)
+		errs   []string
+	}{
+		{
+			desc: "valid baseline",
+		},
+		{
+			desc:   "count at lower bound",
+			mutate: func(c *RecoveryCodesFactorTypeConfiguration) { c.Count = 4 },
+		},
+		{
+			desc:   "count at upper bound",
+			mutate: func(c *RecoveryCodesFactorTypeConfiguration) { c.Count = 16 },
+		},
+		{
+			desc:   "count below lower bound",
+			mutate: func(c *RecoveryCodesFactorTypeConfiguration) { c.Count = 3 },
+			errs:   []string{"GOTRUE_MFA_RECOVERY_CODES_COUNT must be between 4 and 16, got 3"},
+		},
+		{
+			desc:   "count above upper bound",
+			mutate: func(c *RecoveryCodesFactorTypeConfiguration) { c.Count = 17 },
+			errs:   []string{"GOTRUE_MFA_RECOVERY_CODES_COUNT must be between 4 and 16, got 17"},
+		},
+		{
+			desc:   "code length at lower bound",
+			mutate: func(c *RecoveryCodesFactorTypeConfiguration) { c.CodeLength = 13 },
+		},
+		{
+			desc:   "code length at upper bound",
+			mutate: func(c *RecoveryCodesFactorTypeConfiguration) { c.CodeLength = 32 },
+		},
+		{
+			desc:   "code length below lower bound",
+			mutate: func(c *RecoveryCodesFactorTypeConfiguration) { c.CodeLength = 12 },
+			errs:   []string{"GOTRUE_MFA_RECOVERY_CODES_CODE_LENGTH must be between 13 and 32, got 12"},
+		},
+		{
+			desc:   "code length above upper bound",
+			mutate: func(c *RecoveryCodesFactorTypeConfiguration) { c.CodeLength = 33 },
+			errs:   []string{"GOTRUE_MFA_RECOVERY_CODES_CODE_LENGTH must be between 13 and 32, got 33"},
+		},
+		{
+			desc:   "max verify attempts at lower bound",
+			mutate: func(c *RecoveryCodesFactorTypeConfiguration) { c.MaxVerifyAttempts = 3 },
+		},
+		{
+			desc:   "max verify attempts at upper bound",
+			mutate: func(c *RecoveryCodesFactorTypeConfiguration) { c.MaxVerifyAttempts = 15 },
+		},
+		{
+			desc:   "max verify attempts below lower bound",
+			mutate: func(c *RecoveryCodesFactorTypeConfiguration) { c.MaxVerifyAttempts = 2 },
+			errs:   []string{"GOTRUE_MFA_RECOVERY_CODES_MAX_VERIFY_ATTEMPTS must be between 3 and 15, got 2"},
+		},
+		{
+			desc:   "max verify attempts above upper bound",
+			mutate: func(c *RecoveryCodesFactorTypeConfiguration) { c.MaxVerifyAttempts = 16 },
+			errs:   []string{"GOTRUE_MFA_RECOVERY_CODES_MAX_VERIFY_ATTEMPTS must be between 3 and 15, got 16"},
+		},
+		{
+			desc:   "lockout duration at lower bound",
+			mutate: func(c *RecoveryCodesFactorTypeConfiguration) { c.LockoutDuration = time.Minute },
+		},
+		{
+			desc:   "lockout duration at upper bound",
+			mutate: func(c *RecoveryCodesFactorTypeConfiguration) { c.LockoutDuration = 24 * time.Hour },
+		},
+		{
+			desc:   "lockout duration below lower bound",
+			mutate: func(c *RecoveryCodesFactorTypeConfiguration) { c.LockoutDuration = 59 * time.Second },
+			errs:   []string{"GOTRUE_MFA_RECOVERY_CODES_LOCKOUT_DURATION must be between 1m and 24h, got 59s"},
+		},
+		{
+			desc:   "lockout duration above upper bound",
+			mutate: func(c *RecoveryCodesFactorTypeConfiguration) { c.LockoutDuration = 24*time.Hour + time.Second },
+			errs:   []string{"GOTRUE_MFA_RECOVERY_CODES_LOCKOUT_DURATION must be between 1m and 24h, got 24h0m1s"},
+		},
+		{
+			desc: "multiple invalid settings reported together",
+			mutate: func(c *RecoveryCodesFactorTypeConfiguration) {
+				c.Count = 0
+				c.LockoutDuration = 0
+			},
+			errs: []string{
+				"GOTRUE_MFA_RECOVERY_CODES_COUNT must be between 4 and 16, got 0",
+				"GOTRUE_MFA_RECOVERY_CODES_LOCKOUT_DURATION must be between 1m and 24h, got 0s",
+			},
+		},
+		{
+			desc: "enroll enabled alone triggers validation",
+			mutate: func(c *RecoveryCodesFactorTypeConfiguration) {
+				c.VerifyEnabled = false
+				c.Count = 3
+			},
+			errs: []string{"GOTRUE_MFA_RECOVERY_CODES_COUNT must be between 4 and 16, got 3"},
+		},
+		{
+			desc: "verify enabled alone triggers validation",
+			mutate: func(c *RecoveryCodesFactorTypeConfiguration) {
+				c.EnrollEnabled = false
+				c.Count = 3
+			},
+			errs: []string{"GOTRUE_MFA_RECOVERY_CODES_COUNT must be between 4 and 16, got 3"},
+		},
+		{
+			desc: "validation skipped when both flags disabled",
+			mutate: func(c *RecoveryCodesFactorTypeConfiguration) {
+				*c = RecoveryCodesFactorTypeConfiguration{}
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.desc, func(t *testing.T) {
+			c := validConfig()
+			if tc.mutate != nil {
+				tc.mutate(&c)
+			}
+
+			err := c.Validate()
+			if len(tc.errs) == 0 {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			for _, msg := range tc.errs {
+				require.Contains(t, err.Error(), msg)
+			}
+		})
+	}
+}
+
 func toPtr[T any](v T) *T {
 	return &(&([1]T{T(v)}))[0]
 }

--- a/internal/conf/confload/confload_test.go
+++ b/internal/conf/confload/confload_test.go
@@ -294,6 +294,72 @@ func TestExperimentalScimEndpoints(t *testing.T) {
 	}
 }
 
+func TestMFARecoveryCodesConfig(t *testing.T) {
+	baseEnv := func() {
+		os.Clearenv()
+		os.Setenv("GOTRUE_SITE_URL", "http://localhost:8080")
+		os.Setenv("GOTRUE_DB_DRIVER", "postgres")
+		os.Setenv("GOTRUE_DB_DATABASE_URL", "fake")
+		os.Setenv("GOTRUE_JWT_SECRET", "secret")
+		os.Setenv("API_EXTERNAL_URL", "http://localhost:9999")
+	}
+
+	// defaults land when no recovery-code vars are set
+	{
+		baseEnv()
+		cfg, err := LoadGlobalFromEnv()
+		require.NoError(t, err)
+		require.NotNil(t, cfg)
+		assert.Equal(t, false, cfg.MFA.RecoveryCodes.EnrollEnabled)
+		assert.Equal(t, false, cfg.MFA.RecoveryCodes.VerifyEnabled)
+		assert.Equal(t, 10, cfg.MFA.RecoveryCodes.Count)
+		assert.Equal(t, 16, cfg.MFA.RecoveryCodes.CodeLength)
+		assert.Equal(t, 5, cfg.MFA.RecoveryCodes.MaxVerifyAttempts)
+		assert.Equal(t, 15*time.Minute, cfg.MFA.RecoveryCodes.LockoutDuration)
+	}
+
+	// maps GOTRUE_MFA_RECOVERY_CODES_* into the struct
+	{
+		baseEnv()
+		os.Setenv("GOTRUE_MFA_RECOVERY_CODES_ENROLL_ENABLED", "true")
+		os.Setenv("GOTRUE_MFA_RECOVERY_CODES_VERIFY_ENABLED", "true")
+		os.Setenv("GOTRUE_MFA_RECOVERY_CODES_COUNT", "12")
+		os.Setenv("GOTRUE_MFA_RECOVERY_CODES_CODE_LENGTH", "20")
+		os.Setenv("GOTRUE_MFA_RECOVERY_CODES_MAX_VERIFY_ATTEMPTS", "4")
+		os.Setenv("GOTRUE_MFA_RECOVERY_CODES_LOCKOUT_DURATION", "30m")
+		cfg, err := LoadGlobalFromEnv()
+		require.NoError(t, err)
+		require.NotNil(t, cfg)
+		assert.Equal(t, true, cfg.MFA.RecoveryCodes.EnrollEnabled)
+		assert.Equal(t, true, cfg.MFA.RecoveryCodes.VerifyEnabled)
+		assert.Equal(t, 12, cfg.MFA.RecoveryCodes.Count)
+		assert.Equal(t, 20, cfg.MFA.RecoveryCodes.CodeLength)
+		assert.Equal(t, 4, cfg.MFA.RecoveryCodes.MaxVerifyAttempts)
+		assert.Equal(t, 30*time.Minute, cfg.MFA.RecoveryCodes.LockoutDuration)
+	}
+
+	// an explicit out-of-range value fails loading when the feature is enabled
+	{
+		baseEnv()
+		os.Setenv("GOTRUE_MFA_RECOVERY_CODES_ENROLL_ENABLED", "true")
+		os.Setenv("GOTRUE_MFA_RECOVERY_CODES_COUNT", "0")
+		cfg, err := LoadGlobalFromEnv()
+		require.Error(t, err)
+		require.Nil(t, cfg)
+		require.Contains(t, err.Error(), "GOTRUE_MFA_RECOVERY_CODES_COUNT must be between 4 and 16, got 0")
+	}
+
+	// out-of-range values are ignored while the feature is disabled
+	{
+		baseEnv()
+		os.Setenv("GOTRUE_MFA_RECOVERY_CODES_COUNT", "0")
+		cfg, err := LoadGlobalFromEnv()
+		require.NoError(t, err)
+		require.NotNil(t, cfg)
+		assert.Equal(t, 0, cfg.MFA.RecoveryCodes.Count)
+	}
+}
+
 func TestLoading(t *testing.T) {
 	os.Clearenv()
 


### PR DESCRIPTION
Adds recovery codes configuration.

- Enforces bounds checks for security
- Only validated if recovery codes is enabled

> [!NOTE]
> I'm intentionally hard failing rather than logging a warning for out of bounds config to avoid silently overwriting config or allowing insecure options.