### PR TITLE
chore: invalidate tokens on admin initiated change

### DIFF
--- a/internal/api/admin.go
+++ b/internal/api/admin.go
@@ -341,6 +341,18 @@ func (a *API) adminUserUpdate(w http.ResponseWriter, r *http.Request) error {
 				return terr
 			}
 		}
+
+		// Reassigning a user's email or phone changes the account's contact
+		// method, so any outstanding recovery/confirmation/email-change/
+		// phone-change tokens issued before the change can no longer be
+		// trusted (e.g. a recovery link still deliverable to the old
+		// mailbox). Clear them, matching the treatment the password branch
+		// above and UpdateUserEmailFromIdentities already apply.
+		if params.Email != "" || params.Phone != "" {
+			if terr := user.ClearAllPendingTokens(tx); terr != nil {
+				return terr
+			}
+		}
 		user.Identities = append(user.Identities, identities...)
 
 		if addingFirstPassword {

--- a/internal/api/admin_test.go
+++ b/internal/api/admin_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stretchr/testify/suite"
 	"github.com/supabase/auth/internal/api/apierrors"
 	"github.com/supabase/auth/internal/conf"
+	"github.com/supabase/auth/internal/crypto"
 	"github.com/supabase/auth/internal/models"
 )
 
@@ -631,6 +632,49 @@ func (ts *AdminTestSuite) TestAdminUserUpdate() {
 
 		}
 	}
+}
+
+// TestAdminUserUpdateClearsPendingTokensOnEmailChange verifies that
+// reassigning a user's email via the admin update endpoint invalidates any
+// outstanding recovery token, so a recovery link issued before the change
+// (and still deliverable to the old mailbox) can no longer be redeemed.
+func (ts *AdminTestSuite) TestAdminUserUpdateClearsPendingTokensOnEmailChange() {
+	u, err := models.NewUser("", "pending-tokens@example.com", "test", ts.Config.JWT.Aud, nil)
+	require.NoError(ts.T(), err, "Error making new user")
+	require.NoError(ts.T(), ts.API.db.Create(u), "Error creating user")
+
+	// simulate an outstanding password-recovery token
+	recoveryHash := crypto.GenerateTokenHash(u.GetEmail(), "123456")
+	now := time.Now()
+	u.RecoveryToken = recoveryHash
+	u.RecoverySentAt = &now
+	require.NoError(ts.T(), ts.API.db.UpdateOnly(u, "recovery_token", "recovery_sent_at"))
+	require.NoError(ts.T(), models.CreateOneTimeToken(ts.API.db, u.ID, u.GetEmail(), recoveryHash, models.RecoveryToken))
+
+	// sanity check: the token is redeemable before the email change
+	_, err = models.FindUserByRecoveryToken(ts.API.db, recoveryHash)
+	require.NoError(ts.T(), err, "recovery token should be redeemable before the email change")
+
+	var buffer bytes.Buffer
+	require.NoError(ts.T(), json.NewEncoder(&buffer).Encode(map[string]interface{}{
+		"email": "pending-tokens-new@example.com",
+	}))
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPut, fmt.Sprintf("/admin/users/%s", u.ID), &buffer)
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", ts.token))
+	ts.API.handler.ServeHTTP(w, req)
+	require.Equal(ts.T(), http.StatusOK, w.Code)
+
+	// the stored recovery token column must be cleared
+	updated, err := models.FindUserByID(ts.API.db, u.ID)
+	require.NoError(ts.T(), err)
+	require.Empty(ts.T(), updated.RecoveryToken, "recovery token should be cleared after an admin email change")
+
+	// and the one-time token row must no longer resolve to a user
+	_, err = models.FindUserByRecoveryToken(ts.API.db, recoveryHash)
+	require.Error(ts.T(), err, "recovery token should no longer be redeemable after an admin email change")
+	require.True(ts.T(), models.IsNotFoundError(err), "expected NotFoundError")
 }
 
 func (ts *AdminTestSuite) TestAdminUserUpdatePasswordFailed() {


### PR DESCRIPTION


## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Admin initiated user changes do not revoke pending tokens

## What is the new behavior?

Ensures user changes that an admin initiates are treated the same as user initiated changes (revoke pending reset/invite tokens)


