### PR TITLE
chore: ensure consistent ban behaviour

### DIFF
--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -208,6 +208,11 @@ func (a *API) requireAdminCredentials(w http.ResponseWriter, req *http.Request) 
 
 		session := getSession(ctx)
 		user := getUser(ctx)
+
+		if user != nil && user.IsBanned() {
+			return nil, apierrors.NewForbiddenError(apierrors.ErrorCodeUserBanned, "User is banned")
+		}
+
 		if session != nil && user != nil {
 			validity := session.CheckValidity(models.SessionValidityConfig{
 				Timebox:           a.config.Sessions.Timebox,

--- a/internal/api/middleware_test.go
+++ b/internal/api/middleware_test.go
@@ -947,4 +947,31 @@ func (ts *MiddlewareTestSuite) TestRequireAdminCredentialsSessionCheck() {
 		_, err := ts.API.requireAdminCredentials(httptest.NewRecorder(), newRequest(token))
 		require.NoError(ts.T(), err)
 	})
+
+	ts.Run("admin token for a banned user is rejected", func() {
+		// Separate user so banning doesn't affect the other subtests.
+		bannedUser, err := models.NewUser("", "banned-admin@example.com", "password", ts.Config.JWT.Aud, nil)
+		require.NoError(ts.T(), err)
+		require.NoError(ts.T(), ts.API.db.Create(bannedUser))
+		require.NoError(ts.T(), bannedUser.Ban(ts.API.db, time.Hour))
+
+		bannedSession, err := models.NewSession(bannedUser.ID, nil)
+		require.NoError(ts.T(), err)
+		require.NoError(ts.T(), ts.API.db.Create(bannedSession))
+
+		token := signClaims(&AccessTokenClaims{
+			Role:      "supabase_admin",
+			SessionId: bannedSession.ID.String(),
+			RegisteredClaims: jwt.RegisteredClaims{
+				Subject:   bannedUser.ID.String(),
+				ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour)),
+			},
+		})
+
+		_, err = ts.API.requireAdminCredentials(httptest.NewRecorder(), newRequest(token))
+		require.Error(ts.T(), err)
+		httpErr, ok := err.(*HTTPError)
+		require.True(ts.T(), ok, "expected HTTPError, got %T", err)
+		require.Equal(ts.T(), apierrors.ErrorCodeUserBanned, httpErr.ErrorCode)
+	})
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

consistency fix

## What is the current behavior?

user ban status isn't checked on admin users

## What is the new behavior?

user ban status is checked on admin users
