### PR TITLE
feat(mfa): add recovery codes verify endpoint

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -303,6 +303,8 @@ func NewAPIWithVersion(globalConfig *conf.GlobalConfiguration, db *storage.Conne
 			r.Route("/recovery-codes", func(r *router) {
 				r.Get("/", api.RecoveryCodesStatus)
 				r.Post("/", api.RecoveryCodesGenerate)
+				r.With(api.limitHandler(api.limiterOpts.FactorVerify)).
+					Post("/verify", api.RecoveryCodesVerify)
 			})
 
 			r.Route("/{factor_id}", func(r *router) {

--- a/internal/api/helpers.go
+++ b/internal/api/helpers.go
@@ -58,6 +58,7 @@ type RequestParams interface {
 		PasswordGrantParams |
 		RecoverParams |
 		RecoveryCodesGenerateParams |
+		RecoveryCodesVerifyParams |
 		RefreshTokenGrantParams |
 		ResendConfirmationParams |
 		SignupParams |

--- a/internal/api/recovery_codes.go
+++ b/internal/api/recovery_codes.go
@@ -1,13 +1,17 @@
 package api
 
 import (
+	"errors"
 	"net/http"
+	"time"
 
 	"github.com/gofrs/uuid"
 	"github.com/sirupsen/logrus"
 	"github.com/supabase/auth/internal/api/apierrors"
 	"github.com/supabase/auth/internal/conf"
 	"github.com/supabase/auth/internal/crypto"
+	"github.com/supabase/auth/internal/hooks/v0hooks"
+	"github.com/supabase/auth/internal/metering"
 	"github.com/supabase/auth/internal/models"
 	"github.com/supabase/auth/internal/storage"
 	"github.com/supabase/auth/internal/utilities"
@@ -16,6 +20,11 @@ import (
 // RecoveryCodesGenerateParams are the parameters for generating recovery codes.
 type RecoveryCodesGenerateParams struct {
 	FriendlyName string `json:"friendly_name"`
+}
+
+// RecoveryCodesVerifyParams are the parameters for verifying a recovery code.
+type RecoveryCodesVerifyParams struct {
+	Code string `json:"code"`
 }
 
 // RecoveryCodesResponse is the response shared by the recovery-code endpoints.
@@ -173,4 +182,193 @@ func (a *API) RecoveryCodesGenerate(w http.ResponseWriter, r *http.Request) erro
 		Total:        len(codes),
 		Codes:        codes,
 	})
+}
+
+func recoveryCodeVerificationFailedError() *apierrors.HTTPError {
+	return apierrors.NewUnprocessableEntityError(apierrors.ErrorCodeMFAVerificationFailed, "Invalid recovery code entered")
+}
+
+func recoveryCodeLockedError() *apierrors.HTTPError {
+	return apierrors.NewTooManyRequestsError(apierrors.ErrorCodeMFARecoveryCodesLocked, "Too many failed verification attempts, try again later")
+}
+
+// RecoveryCodesVerify redeems a single recovery code and upgrades the user's session to AAL2.
+func (a *API) RecoveryCodesVerify(w http.ResponseWriter, r *http.Request) error {
+	ctx := r.Context()
+	user := getUser(ctx)
+	session := getSession(ctx)
+	config := a.config
+	db := a.db.WithContext(ctx)
+
+	if session == nil || user == nil {
+		return apierrors.NewInternalServerError("A valid session and a registered user are required to verify recovery codes")
+	}
+
+	if !config.MFA.RecoveryCodes.VerifyEnabled {
+		return apierrors.NewUnprocessableEntityError(apierrors.ErrorCodeMFARecoveryCodesVerifyDisabled, "MFA verification is disabled for recovery codes")
+	}
+
+	params := &RecoveryCodesVerifyParams{}
+	if err := retrieveRequestParams(r, params); err != nil {
+		return err
+	}
+
+	code := crypto.NormalizeRecoveryCode(params.Code)
+	if code == "" {
+		return apierrors.NewBadRequestError(apierrors.ErrorCodeValidationFailed, "Code needs to be non-empty")
+	}
+
+	set, err := models.FindRecoveryCodeSetByUser(db, user.ID)
+	if err != nil {
+		if models.IsNotFoundError(err) {
+			return recoveryCodeVerificationFailedError()
+		}
+
+		return apierrors.NewInternalServerError("Database error finding recovery code set").WithInternalError(err)
+	}
+
+	if set.IsLocked(time.Now()) {
+		return recoveryCodeLockedError()
+	}
+
+	factor, err := models.FindFactorByFactorID(db, set.MFAFactorID)
+	if err != nil {
+		if models.IsNotFoundError(err) {
+			return recoveryCodeVerificationFailedError()
+		}
+
+		return apierrors.NewInternalServerError("Database error finding recovery code factor").WithInternalError(err)
+	}
+
+	entries, err := models.FindUnusedRecoveryCodes(db, set.ID)
+	if err != nil {
+		return apierrors.NewInternalServerError("Database error finding recovery codes").WithInternalError(err)
+	}
+
+	// Compare against every unused code without early exit.
+	var matched *models.RecoveryCodeEntry
+	for i := range entries {
+		switch cerr := crypto.CompareHashAndRecoveryCode(entries[i].CodeHash, code); {
+		case cerr == nil:
+			if matched == nil {
+				matched = &entries[i]
+			}
+		case !errors.Is(cerr, crypto.ErrRecoveryCodeMismatchedHashAndCode):
+			// A malformed stored hash is treated as a non-match.
+			logrus.WithError(cerr).WithField("recovery_code_id", entries[i].ID).Warn("Invalid recovery code hash in database")
+		}
+	}
+	valid := matched != nil
+
+	if config.Hook.MFAVerificationAttempt.Enabled {
+		input := v0hooks.NewMFAVerificationAttemptInput(
+			r,
+			user.ID,
+			factor.ID,
+			factor.FactorType,
+			valid,
+		)
+
+		output := v0hooks.MFAVerificationAttemptOutput{}
+		err := a.hooksMgr.InvokeHook(nil, r, input, &output)
+		if err != nil {
+			return err
+		}
+
+		if output.Decision == v0hooks.HookRejection {
+			if err := models.Logout(db, user.ID); err != nil {
+				return err
+			}
+
+			if output.Message == "" {
+				output.Message = v0hooks.DefaultMFAHookRejectionMessage
+			}
+
+			return apierrors.NewForbiddenError(apierrors.ErrorCodeMFAVerificationRejected, "%s", output.Message)
+		}
+	}
+
+	var token *AccessTokenResponse
+	err = db.Transaction(func(tx *storage.Connection) error {
+		lockedSet, terr := models.FindRecoveryCodeSetForUpdate(tx, user.ID)
+		if terr != nil {
+			if models.IsNotFoundError(terr) {
+				return recoveryCodeVerificationFailedError()
+			}
+
+			return apierrors.NewInternalServerError("Database error locking recovery code set").WithInternalError(terr)
+		}
+
+		now := time.Now()
+		if lockedSet.IsLocked(now) {
+			return recoveryCodeLockedError()
+		}
+
+		if terr := lockedSet.ClearExpiredLockout(tx, now); terr != nil {
+			return apierrors.NewInternalServerError("Database error clearing recovery code lockout").WithInternalError(terr)
+		}
+
+		consumed := false
+		if valid {
+			switch terr := matched.MarkConsumed(tx); {
+			case terr == nil:
+				consumed = true
+			case !errors.Is(terr, models.RecoveryCodeAlreadyConsumedError{}):
+				return apierrors.NewInternalServerError("Database error consuming recovery code").WithInternalError(terr)
+			}
+		}
+
+		if !consumed {
+			// A code consumed by a concurrent request counts as a failure, exactly like a wrong code.
+			// The increment must commit even though the request fails.
+			if terr := lockedSet.RegisterFailure(tx, now, config.MFA.RecoveryCodes.MaxVerifyAttempts, config.MFA.RecoveryCodes.LockoutDuration); terr != nil {
+				return apierrors.NewInternalServerError("Database error recording failed verification").WithInternalError(terr)
+			}
+
+			return storage.NewCommitWithError(recoveryCodeVerificationFailedError())
+		}
+
+		if terr := lockedSet.ResetLockout(tx); terr != nil {
+			return apierrors.NewInternalServerError("Database error resetting recovery code lockout").WithInternalError(terr)
+		}
+
+		_, remaining, terr := models.CountRecoveryCodes(tx, lockedSet.ID)
+		if terr != nil {
+			return apierrors.NewInternalServerError("Database error counting recovery codes").WithInternalError(terr)
+		}
+
+		if terr := models.NewAuditLogEntry(config.AuditLog, r, tx, user, models.RecoveryCodesVerifiedAction, utilities.GetIPAddress(r), map[string]any{
+			"factor_id": factor.ID,
+			"remaining": remaining,
+		}); terr != nil {
+			return terr
+		}
+
+		user, terr = models.FindUserByID(tx, user.ID)
+		if terr != nil {
+			return terr
+		}
+
+		token, terr = a.updateMFASessionAndClaims(r, tx, user, models.MFARecoveryCode, models.GrantParams{
+			FactorID: &factor.ID,
+		})
+		if terr != nil {
+			return terr
+		}
+
+		if terr := models.InvalidateSessionsWithAALLessThan(tx, user.ID, models.AAL2.String()); terr != nil {
+			return apierrors.NewInternalServerError("Failed to update sessions. %s", terr)
+		}
+
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	metering.RecordLogin(metering.LoginTypeMFA, user.ID, &metering.LoginData{
+		Provider: metering.ProviderMFARecoveryCode,
+	})
+
+	return sendJSON(w, http.StatusOK, token)
 }

--- a/internal/api/recovery_codes_test.go
+++ b/internal/api/recovery_codes_test.go
@@ -8,9 +8,12 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"regexp"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/gofrs/uuid"
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"github.com/supabase/auth/internal/api/apierrors"
@@ -72,8 +75,12 @@ func (ts *RecoveryCodesTestSuite) SetupTest() {
 
 	// ts.Config is shared across tests; reset every knob this suite touches.
 	ts.Config.MFA.RecoveryCodes.EnrollEnabled = true
+	ts.Config.MFA.RecoveryCodes.VerifyEnabled = true
+	ts.Config.MFA.RecoveryCodes.MaxVerifyAttempts = 5
+	ts.Config.MFA.RecoveryCodes.LockoutDuration = 15 * time.Minute
 	ts.Config.MFA.MaxEnrolledFactors = 10
 	ts.Config.MFA.MaxVerifiedFactors = 10
+	ts.Config.Hook.MFAVerificationAttempt.Enabled = false
 	ts.Config.Mailer.Notifications.MFAFactorEnrolledEnabled = false
 	if mockMailer, ok := ts.Mailer.(*mockclient.MockMailer); ok {
 		mockMailer.Reset()
@@ -370,4 +377,362 @@ func (ts *RecoveryCodesTestSuite) TestRecoveryCodesGenerateEnrolledNotificationD
 	ts.performGenerate(ts.aal2Token(), nil)
 
 	require.Empty(ts.T(), mockMailer.MFAFactorEnrolledMailCalls, "Expected no MFA factor enrolled notification email to be sent")
+}
+
+// grantSession creates an AAL1 session through the refresh-token grant flow
+func (ts *RecoveryCodesTestSuite) grantSession() *models.Session {
+	rt, err := models.GrantAuthenticatedUser(ts.API.db, ts.TestUser, models.GrantParams{})
+	require.NoError(ts.T(), err)
+	require.NotNil(ts.T(), rt.SessionId)
+	session, err := models.FindSessionByID(ts.API.db, *rt.SessionId, false)
+	require.NoError(ts.T(), err)
+	return session
+}
+
+// enrollForVerify generates a recovery-code set at AAL2 on the main test
+// session, then returns the generate response plus a fresh AAL1 session
+// (verify is issued from AAL1) and a token for it.
+func (ts *RecoveryCodesTestSuite) enrollForVerify() (RecoveryCodesResponse, *models.Session, string) {
+	resp := ts.performGenerate(ts.aal2Token(), nil)
+	session := ts.grantSession()
+	return resp, session, ts.token(ts.TestUser, &session.ID)
+}
+
+func (ts *RecoveryCodesTestSuite) performVerify(token, code string) *httptest.ResponseRecorder {
+	var buffer bytes.Buffer
+	require.NoError(ts.T(), json.NewEncoder(&buffer).Encode(map[string]any{"code": code}))
+	return ts.serveRequest(http.MethodPost, "http://localhost/factors/recovery-codes/verify", token, &buffer)
+}
+
+// recoveryCodeSetState re-reads the set row so tests can assert on the internal lockout state directly.
+func (ts *RecoveryCodesTestSuite) recoveryCodeSetState() *models.RecoveryCodeSet {
+	set, err := models.FindRecoveryCodeSetByUser(ts.API.db, ts.TestUser.ID)
+	require.NoError(ts.T(), err)
+	return set
+}
+
+func (ts *RecoveryCodesTestSuite) unusedCodeCount() int {
+	entries, err := models.FindUnusedRecoveryCodes(ts.API.db, ts.recoveryCodeSetState().ID)
+	require.NoError(ts.T(), err)
+	return len(entries)
+}
+
+const wrongCode = "aaaaaaaaaaaaa"
+
+func (ts *RecoveryCodesTestSuite) TestRecoveryCodesVerifySuccess() {
+	generateResp, verifySession, token := ts.enrollForVerify()
+
+	// A second AAL1 session that must be invalidated by the upgrade.
+	secondSession, err := models.NewSession(ts.TestUser.ID, nil)
+	require.NoError(ts.T(), err)
+	require.NoError(ts.T(), ts.API.db.Create(secondSession))
+
+	// Burn one failure first so success resets the counter.
+	w := ts.performVerify(token, wrongCode)
+	ts.requireErrorCode(w, http.StatusUnprocessableEntity, apierrors.ErrorCodeMFAVerificationFailed)
+	require.Equal(ts.T(), 1, ts.recoveryCodeSetState().FailedVerificationCount)
+
+	w = ts.performVerify(token, generateResp.Codes[0])
+	require.Equal(ts.T(), http.StatusOK, w.Code)
+	tokenResp := &AccessTokenResponse{}
+	require.NoError(ts.T(), json.NewDecoder(w.Body).Decode(tokenResp))
+	require.NotEmpty(ts.T(), tokenResp.Token)
+	require.NotEmpty(ts.T(), tokenResp.RefreshToken)
+
+	// The reissued access token is AAL2 with an mfa/recovery_code AMR entry.
+	claims := &AccessTokenClaims{}
+	_, _, err = jwt.NewParser().ParseUnverified(tokenResp.Token, claims)
+	require.NoError(ts.T(), err)
+	require.Equal(ts.T(), models.AAL2.String(), claims.AuthenticatorAssuranceLevel)
+	methods := make([]string, 0, len(claims.AuthenticationMethodReference))
+	for _, entry := range claims.AuthenticationMethodReference {
+		methods = append(methods, entry.Method)
+	}
+	require.Contains(ts.T(), methods, models.MFARecoveryCode.String())
+
+	// Code consumed, lockout state reset.
+	set := ts.recoveryCodeSetState()
+	require.Equal(ts.T(), 0, set.FailedVerificationCount)
+	require.Nil(ts.T(), set.VerificationLockedUntil)
+	require.Equal(ts.T(), 9, ts.unusedCodeCount())
+
+	// The caller's session was upgraded in place; the other AAL1 session is gone.
+	upgraded, err := models.FindSessionByID(ts.API.db, verifySession.ID, false)
+	require.NoError(ts.T(), err)
+	require.True(ts.T(), upgraded.IsAAL2())
+	_, err = models.FindSessionByID(ts.API.db, secondSession.ID, false)
+	require.EqualError(ts.T(), err, models.SessionNotFoundError{}.Error())
+
+	logs, err := models.FindAuditLogEntries(ts.API.db, []string{"action"}, string(models.RecoveryCodesVerifiedAction), nil)
+	require.NoError(ts.T(), err)
+	require.Len(ts.T(), logs, 1)
+	require.Equal(ts.T(), "factor", logs[0].Payload["log_type"])
+	traits, ok := logs[0].Payload["traits"].(map[string]any)
+	require.True(ts.T(), ok)
+	require.Equal(ts.T(), generateResp.ID.String(), traits["factor_id"])
+	require.EqualValues(ts.T(), 9, traits["remaining"])
+}
+
+func (ts *RecoveryCodesTestSuite) TestRecoveryCodesVerifyInputForgiveness() {
+	generateResp, _, token := ts.enrollForVerify()
+
+	cases := []struct {
+		desc   string
+		format func(string) string
+	}{
+		{desc: "Hyphenated", format: func(c string) string {
+			return c[:4] + "-" + c[4:8] + "-" + c[8:12] + "-" + c[12:]
+		}},
+		{desc: "Spaced", format: func(c string) string {
+			return " " + c[:8] + " " + c[8:] + " "
+		}},
+		{desc: "Uppercase", format: strings.ToUpper},
+	}
+
+	for i, c := range cases {
+		ts.Run(c.desc, func() {
+			w := ts.performVerify(token, c.format(generateResp.Codes[i]))
+			require.Equal(ts.T(), http.StatusOK, w.Code)
+		})
+	}
+}
+
+func (ts *RecoveryCodesTestSuite) TestRecoveryCodesVerifyReuseFails() {
+	generateResp, _, token := ts.enrollForVerify()
+
+	w := ts.performVerify(token, generateResp.Codes[0])
+	require.Equal(ts.T(), http.StatusOK, w.Code)
+
+	// Reusing a consumed code is a failure like any other: uniform error and the counter increments.
+	w = ts.performVerify(token, generateResp.Codes[0])
+	ts.requireErrorCode(w, http.StatusUnprocessableEntity, apierrors.ErrorCodeMFAVerificationFailed)
+	require.Equal(ts.T(), 1, ts.recoveryCodeSetState().FailedVerificationCount)
+	require.Equal(ts.T(), 9, ts.unusedCodeCount())
+}
+
+func (ts *RecoveryCodesTestSuite) TestRecoveryCodesVerifyUniformFailures() {
+	// Absent set: no enrollment yet.
+	absentSet := ts.performVerify(ts.token(ts.TestUser, &ts.TestSession.ID), wrongCode)
+
+	generateResp, _, token := ts.enrollForVerify()
+
+	// Wrong code.
+	invalid := ts.performVerify(token, wrongCode)
+
+	// Consumed code.
+	w := ts.performVerify(token, generateResp.Codes[0])
+	require.Equal(ts.T(), http.StatusOK, w.Code)
+	consumed := ts.performVerify(token, generateResp.Codes[0])
+
+	// All three failure modes are indistinguishable: same status, identical body bytes.
+	for _, recorder := range []*httptest.ResponseRecorder{absentSet, invalid, consumed} {
+		require.Equal(ts.T(), http.StatusUnprocessableEntity, recorder.Code)
+	}
+	require.Equal(ts.T(), absentSet.Body.String(), invalid.Body.String())
+	require.Equal(ts.T(), invalid.Body.String(), consumed.Body.String())
+
+	// Failed verifications are not audited; only the one success above is.
+	logs, err := models.FindAuditLogEntries(ts.API.db, []string{"action"}, string(models.RecoveryCodesVerifiedAction), nil)
+	require.NoError(ts.T(), err)
+	require.Len(ts.T(), logs, 1)
+}
+
+func (ts *RecoveryCodesTestSuite) TestRecoveryCodesVerifyLockout() {
+	ts.Config.MFA.RecoveryCodes.MaxVerifyAttempts = 3
+
+	generateResp, _, token := ts.enrollForVerify()
+
+	for range 3 {
+		w := ts.performVerify(token, wrongCode)
+		ts.requireErrorCode(w, http.StatusUnprocessableEntity, apierrors.ErrorCodeMFAVerificationFailed)
+	}
+	set := ts.recoveryCodeSetState()
+	require.Equal(ts.T(), 3, set.FailedVerificationCount)
+	require.NotNil(ts.T(), set.VerificationLockedUntil)
+	lockedUntil := *set.VerificationLockedUntil
+
+	// While locked, even a correct code is rejected without being evaluated and the lock is not extended.
+	w := ts.performVerify(token, generateResp.Codes[0])
+	ts.requireErrorCode(w, http.StatusTooManyRequests, apierrors.ErrorCodeMFARecoveryCodesLocked)
+	set = ts.recoveryCodeSetState()
+	require.Equal(ts.T(), 3, set.FailedVerificationCount)
+	require.NotNil(ts.T(), set.VerificationLockedUntil)
+	require.True(ts.T(), lockedUntil.Equal(*set.VerificationLockedUntil), "lockout must not be extended by attempts while locked")
+	require.Equal(ts.T(), 10, ts.unusedCodeCount())
+
+	// Backdate the lock to simulate expiry.
+	past := time.Now().Add(-time.Minute)
+	set.VerificationLockedUntil = &past
+	require.NoError(ts.T(), ts.API.db.UpdateOnly(set, "verification_locked_until"))
+
+	// The first attempt after expiry is processed with a fresh counter.
+	w = ts.performVerify(token, wrongCode)
+	ts.requireErrorCode(w, http.StatusUnprocessableEntity, apierrors.ErrorCodeMFAVerificationFailed)
+	set = ts.recoveryCodeSetState()
+	require.Equal(ts.T(), 1, set.FailedVerificationCount)
+	require.Nil(ts.T(), set.VerificationLockedUntil)
+
+	// A success after expiry works and resets everything.
+	w = ts.performVerify(token, generateResp.Codes[0])
+	require.Equal(ts.T(), http.StatusOK, w.Code)
+	set = ts.recoveryCodeSetState()
+	require.Equal(ts.T(), 0, set.FailedVerificationCount)
+	require.Nil(ts.T(), set.VerificationLockedUntil)
+}
+
+func (ts *RecoveryCodesTestSuite) setVerificationHook(functionName, functionSQL string) {
+	ts.Config.Hook.MFAVerificationAttempt.Enabled = true
+	ts.Config.Hook.MFAVerificationAttempt.URI = "pg-functions://postgres/auth/" + functionName
+	require.NoError(ts.T(), ts.Config.Hook.MFAVerificationAttempt.PopulateExtensibilityPoint())
+	require.NoError(ts.T(), ts.API.db.RawQuery(functionSQL).Exec())
+	ts.T().Cleanup(func() {
+		require.NoError(ts.T(), ts.API.db.RawQuery(fmt.Sprintf("drop function if exists %s(input jsonb)", functionName)).Exec())
+	})
+}
+
+func (ts *RecoveryCodesTestSuite) TestRecoveryCodesVerifyHookContinue() {
+	ts.setVerificationHook("recovery_codes_hook_continue", `
+        create or replace function recovery_codes_hook_continue(input jsonb)
+        returns json as $$
+        begin
+            return json_build_object('decision', 'continue');
+        end; $$ language plpgsql;`)
+
+	generateResp, _, token := ts.enrollForVerify()
+
+	w := ts.performVerify(token, generateResp.Codes[0])
+	require.Equal(ts.T(), http.StatusOK, w.Code)
+	require.Equal(ts.T(), 9, ts.unusedCodeCount())
+}
+
+func (ts *RecoveryCodesTestSuite) TestRecoveryCodesVerifyHookRejection() {
+	// Rejecting only on the recovery-code factor type also pins the hook payload:
+	// if factor_type or factor_id were missing, the hook would continue and the
+	// request would succeed, failing this test.
+	ts.setVerificationHook("recovery_codes_hook_reject", `
+        create or replace function recovery_codes_hook_reject(input jsonb)
+        returns json as $$
+        begin
+            if input->>'factor_type' = 'recovery_code' and input->>'factor_id' is not null then
+                return json_build_object('decision', 'reject', 'message', 'recovery code sign-in rejected');
+            end if;
+            return json_build_object('decision', 'continue');
+        end; $$ language plpgsql;`)
+
+	generateResp, _, token := ts.enrollForVerify()
+
+	// A valid code is submitted; the rejection must not consume it.
+	w := ts.performVerify(token, generateResp.Codes[0])
+	ts.requireErrorCode(w, http.StatusForbidden, apierrors.ErrorCodeMFAVerificationRejected)
+
+	// All the user's sessions are terminated.
+	_, err := models.FindSessionByID(ts.API.db, ts.TestSession.ID, false)
+	require.EqualError(ts.T(), err, models.SessionNotFoundError{}.Error())
+
+	// No code burned, counter untouched.
+	set := ts.recoveryCodeSetState()
+	require.Equal(ts.T(), 0, set.FailedVerificationCount)
+	require.Nil(ts.T(), set.VerificationLockedUntil)
+	require.Equal(ts.T(), 10, ts.unusedCodeCount())
+}
+
+func (ts *RecoveryCodesTestSuite) TestRecoveryCodesVerifyHookError() {
+	ts.setVerificationHook("recovery_codes_hook_error", `
+        create or replace function recovery_codes_hook_error(input jsonb)
+        returns json as $$
+        begin
+            RAISE EXCEPTION 'Intentional Error for Testing';
+        end; $$ language plpgsql;`)
+
+	generateResp, _, token := ts.enrollForVerify()
+
+	w := ts.performVerify(token, generateResp.Codes[0])
+	require.Equal(ts.T(), http.StatusInternalServerError, w.Code)
+
+	// The request failed before the transaction: nothing consumed, nothing counted.
+	set := ts.recoveryCodeSetState()
+	require.Equal(ts.T(), 0, set.FailedVerificationCount)
+	require.Equal(ts.T(), 10, ts.unusedCodeCount())
+}
+
+func (ts *RecoveryCodesTestSuite) TestRecoveryCodesVerifyHookSkippedWhenNoSet() {
+	ts.setVerificationHook("recovery_codes_hook_reject_all", `
+        create or replace function recovery_codes_hook_reject_all(input jsonb)
+        returns json as $$
+        begin
+            return json_build_object('decision', 'reject');
+        end; $$ language plpgsql;`)
+
+	// No set enrolled: the uniform failure is returned without invoking the
+	// hook, so no rejection (and no logout) can happen.
+	token := ts.token(ts.TestUser, &ts.TestSession.ID)
+	w := ts.performVerify(token, wrongCode)
+	ts.requireErrorCode(w, http.StatusUnprocessableEntity, apierrors.ErrorCodeMFAVerificationFailed)
+
+	_, err := models.FindSessionByID(ts.API.db, ts.TestSession.ID, false)
+	require.NoError(ts.T(), err, "sessions must survive when the hook is skipped")
+}
+
+func (ts *RecoveryCodesTestSuite) TestRecoveryCodesVerifyCrossUserIsolation() {
+	// Enroll the test user.
+	_, _, token := ts.enrollForVerify()
+
+	// A second user with their own verified factor, session, and codes.
+	otherUser, err := models.NewUser("", "other@example.com", "password", ts.Config.JWT.Aud, nil)
+	require.NoError(ts.T(), err)
+	require.NoError(ts.T(), ts.API.db.Create(otherUser))
+	otherFactor := models.NewTOTPFactor(otherUser, "other_factor")
+	require.NoError(ts.T(), otherFactor.SetSecret("secretkey", ts.Config.Security.DBEncryption.Encrypt, ts.Config.Security.DBEncryption.EncryptionKeyID, ts.Config.Security.DBEncryption.EncryptionKey))
+	require.NoError(ts.T(), ts.API.db.Create(otherFactor))
+	require.NoError(ts.T(), otherFactor.UpdateStatus(ts.API.db, models.FactorStateVerified))
+	otherSession, err := models.NewSession(otherUser.ID, &otherFactor.ID)
+	require.NoError(ts.T(), err)
+	require.NoError(ts.T(), ts.API.db.Create(otherSession))
+	require.NoError(ts.T(), otherSession.UpdateAALAndAssociatedFactor(ts.API.db, models.AAL2, &otherFactor.ID))
+	otherResp := ts.performGenerate(ts.token(otherUser, &otherSession.ID), nil)
+
+	// The test user submits the other user's valid code: uniform failure, the
+	// test user's counter increments, and the other user's code stays unused.
+	w := ts.performVerify(token, otherResp.Codes[0])
+	ts.requireErrorCode(w, http.StatusUnprocessableEntity, apierrors.ErrorCodeMFAVerificationFailed)
+
+	require.Equal(ts.T(), 1, ts.recoveryCodeSetState().FailedVerificationCount)
+
+	otherSet, err := models.FindRecoveryCodeSetByUser(ts.API.db, otherUser.ID)
+	require.NoError(ts.T(), err)
+	otherEntries, err := models.FindUnusedRecoveryCodes(ts.API.db, otherSet.ID)
+	require.NoError(ts.T(), err)
+	require.Len(ts.T(), otherEntries, 10)
+	require.Equal(ts.T(), 0, otherSet.FailedVerificationCount)
+}
+
+func (ts *RecoveryCodesTestSuite) TestRecoveryCodesVerifyDisabled() {
+	ts.Config.MFA.RecoveryCodes.VerifyEnabled = false
+
+	generateResp, _, token := ts.enrollForVerify()
+	w := ts.performVerify(token, generateResp.Codes[0])
+	ts.requireErrorCode(w, http.StatusUnprocessableEntity, apierrors.ErrorCodeMFARecoveryCodesVerifyDisabled)
+}
+
+func (ts *RecoveryCodesTestSuite) TestRecoveryCodesVerifyBadInput() {
+	_, _, token := ts.enrollForVerify()
+
+	cases := []struct {
+		desc string
+		body io.Reader
+	}{
+		{desc: "Missing body", body: nil},
+		{desc: "Empty code", body: bytes.NewBufferString(`{"code": ""}`)},
+		{desc: "Separators-only code", body: bytes.NewBufferString(`{"code": " -- - "}`)},
+	}
+
+	for _, c := range cases {
+		ts.Run(c.desc, func() {
+			w := ts.serveRequest(http.MethodPost, "http://localhost/factors/recovery-codes/verify", token, c.body)
+			require.Equal(ts.T(), http.StatusBadRequest, w.Code)
+		})
+	}
+
+	// Malformed input never reaches the failure counter.
+	require.Equal(ts.T(), 0, ts.recoveryCodeSetState().FailedVerificationCount)
 }


### PR DESCRIPTION
Adds the `POST /factors/recovery-codes/verify` endpoint to redeem a recovery code for an AAL2 session.

- Failures increment the per-user lockout
- Invokes the MFA verification hook
- Emits audit and metering events

```http
POST /factors/recovery-codes/verify
Authorization: Bearer <aal1-access-token>

{ "code": "K4M9-X7QP-2AB8-HT3Z" }
```

The code is normalized (`k4m9x7qp2ab8ht3z`) and the caller's own session is upgraded to AAL2:

```json
{
  "access_token": "…",
  "token_type": "bearer",
  "refresh_token": "…",
  "user": {}
}
```