### PR TITLE
feat(otp): add expires_at column to one_time_tokens table

### DIFF
--- a/migrations/20260831180000_add_expires_at_to_one_time_tokens.up.sql
+++ b/migrations/20260831180000_add_expires_at_to_one_time_tokens.up.sql
@@ -1,0 +1,3 @@
+/* auth_migration: 20260831180000 */
+alter table {{ index .Options "Namespace" }}.one_time_tokens
+    add column if not exists expires_at timestamptz;


### PR DESCRIPTION
## What kind of change does this PR introduce?
It's a schema migration.

## What is the current behavior?
There is no `expires_at` column on the `one_time_tokens` table. 

OTP flows rely on `users.*_sent_at` timestamps to infer expiration.

## What is the new behavior?
There is an `expires_at` column on the `one_time_tokens` table.

This will allow us to stop relying on the `users` table for expiration data.

## Additional context
See AUTH-1552 and its project.
