### PR TITLE
chore: add lefthook pre-commit hooks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,13 +36,7 @@ jobs:
         with:
           go-version-file: go.mod
       - name: Check gofmt
-        run: |
-          set -x
-
-          if [ ! -z $(gofmt -l .) ]
-          then
-            echo 'Make sure to run "gofmt -s -w ." before commit!' && exit 1
-          fi
+        run: make check-format
       - name: Init Database
         run: psql -f hack/init_postgres.sql postgresql://postgres:root@localhost:5432/postgres
       - name: Run migrations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,6 +95,16 @@ If you are on macOS Catalina you may [run into issues installing Soda with Brew]
 git clone https://github.com/supabase/auth
 ```
 
+- (Optional, but recommended) Install [lefthook](https://github.com/evilmartians/lefthook) and activate the repo's git hooks. This mirrors CI's checks locally before each commit, so a mistake is caught early instead of failing CI. See `lefthook.yml` for the current list.
+
+```zsh
+# See https://github.com/evilmartians/lefthook/blob/master/docs/install.md for all install methods
+brew install lefthook
+
+# From the repo root, activate the hooks defined in lefthook.yml
+make hooks
+```
+
 ### Install Auth
 
 To begin installation, be sure to start from the root directory.

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-.PHONY: all build deps image migrate test vet sec vulncheck format unused release
-.PHONY: check-gosec check-govulncheck check-oapi-codegen check-staticcheck check-go-version
+.PHONY: all build deps image migrate test vet sec vulncheck format hooks lint unused release
+.PHONY: check-gosec check-govulncheck check-oapi-codegen check-staticcheck check-go-version check-format
 CHECK_FILES ?= ./...
 
 ifdef RELEASE_VERSION
@@ -72,13 +72,14 @@ deps: ## Install dependencies.
 	@go mod download
 	@go mod verify
 
-release-test: \
+lint: \
 	check-go-version \
 	vet \
 	static \
 	sec \
-	vulncheck \
-	test
+	vulncheck
+
+release-test: lint test
 
 release: $(RELEASE_ARCHIVES)
 
@@ -183,6 +184,19 @@ docker-clean: ## Remove the development containers and volumes
 
 format:
 	gofmt -s -w .
+
+check-format: ## Verify gofmt formatting. Pass FILES="..." to scope the check.
+	@files=$$(gofmt -s -l $(or $(FILES),.)); \
+	if [ -n "$$files" ]; then \
+		echo "The following files are not gofmt-formatted:"; \
+		echo "$$files"; \
+		echo 'Run "make format" and re-stage the changes.'; \
+		exit 1; \
+	fi
+
+hooks: ## Install the git hooks defined in lefthook.yml (requires: brew install lefthook).
+	lefthook install
+	$(MAKE) -C tools
 
 clean:
 	$(MAKE) -C tools clean

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,10 @@
+# Setup: see CONTRIBUTING.md.
+pre-commit:
+  parallel: true
+  commands:
+    gofmt:
+      glob: "*.go"
+      run: make check-format
+    lint:
+      glob: "*.go"
+      run: make -j lint


### PR DESCRIPTION
I noticed that we didn't have any pre-commit hooks setup, so proposing that we add some.

I chose `lefthook` because it runs whatever command you give it without pinning its own tool versions, which gives us a nicer way to use shared targets.

## What kind of change does this PR introduce?
Chore

## What is the current behavior?
CI runs the linting checks. Contributors find their mistakes only after they push a branch. The `gofmt` check lives inline in `test.yml` rather than in a Make target, and the output instructs users to use a different command than the one run, so nothing keeps a local check and the CI check in sync.

## What is the new behavior?
- Added an optional `lefthook` configuration. 
- Add a `hooks` make target. It activates the hooks + builds the lint tools.
- Added a `lint` make target to hold all of the static analysis checks, and had `release-test` and `left hook` reference it so they share one list.
- Added a `check-format` make target to replace the inline `gofmt` step in `.github/workflows/test.yaml`

The hooks are optional. `CONTRIBUTING.md` has installation steps.

## Additional context
A couple notes:
- CI gets slightly stricter. The old inline `gofmt` step ran `gofmt -l`, but its own error message said to run `gofmt -s -w` and `make format` has always applied `-s` ([simplify](https://pkg.go.dev/cmd/gofmt)). So, biasing in that direction seemed best. There are no changes today.
- These might be slow at first, but we can tune, and they're optional
 
Closes AUTH-1573