### PR TITLE
chore: add support for verbose flag to the migration tool to view successful migrations

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -407,9 +407,7 @@ make migrate_test
 ```
 
 This passes `--verbose` to the `migrate` command, which logs the name of each
-migration as it is applied. `make migrate_dev` applies the same migrations
-without verbose logging, and `make test` stays at the quiet log level set in
-`hack/test.env`.
+migration as it is applied.
 
 ## Testing
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -406,6 +406,11 @@ If you need to run any new migrations:
 make migrate_test
 ```
 
+This passes `--verbose` to the `migrate` command, which logs the name of each
+migration as it is applied. `make migrate_dev` applies the same migrations
+without verbose logging, and `make test` stays at the quiet log level set in
+`hack/test.env`.
+
 ## Testing
 
 Currently, we don't use a separate test database, so the same database created when installing Auth to run locally is used.

--- a/Makefile
+++ b/Makefile
@@ -110,7 +110,7 @@ migrate_dev: ## Run database migrations for development.
 	hack/migrate.sh postgres
 
 migrate_test: ## Run database migrations for test.
-	hack/migrate.sh postgres
+	hack/migrate.sh postgres --verbose
 
 test: auth ## Run tests.
 	go test -failfast $(CHECK_FILES) -coverprofile=coverage.out -coverpkg ./... -p 1 -race -v -count=1

--- a/cmd/migrate_cmd.go
+++ b/cmd/migrate_cmd.go
@@ -23,8 +23,6 @@ var migrateCmd = cobra.Command{
 	Run:  migrate,
 }
 
-// popProgressLogger prints pop's migration progress, one line per applied
-// migration, and hides SQL statement logging.
 func popProgressLogger(lvl logging.Level, s string, args ...interface{}) {
 	if lvl == logging.SQL || lvl == logging.Debug {
 		return
@@ -35,7 +33,6 @@ func popProgressLogger(lvl logging.Level, s string, args ...interface{}) {
 	fmt.Println(s)
 }
 
-// popNoopLogger hides pop migration logging.
 func popNoopLogger(logging.Level, string, ...interface{}) {}
 
 func migrate(cmd *cobra.Command, args []string) {
@@ -60,9 +57,6 @@ func migrate(cmd *cobra.Command, args []string) {
 		log.SetLevel(level)
 	}
 
-	// Decide what pop prints while migrations run, from most to least
-	// output: debug shows everything, --verbose shows progress only, any
-	// other configured level hides migration logging entirely.
 	switch {
 	case log.Level == logrus.DebugLevel:
 		pop.Debug = true

--- a/cmd/migrate_cmd.go
+++ b/cmd/migrate_cmd.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"embed"
+	"fmt"
 	"net/url"
 	"os"
 
@@ -13,6 +14,8 @@ import (
 )
 
 var EmbeddedMigrations embed.FS
+
+var migrateVerbose bool
 
 var migrateCmd = cobra.Command{
 	Use:  "migrate",
@@ -40,16 +43,23 @@ func migrate(cmd *cobra.Command, args []string) {
 			log.Fatalf("Failed to parse log level: %+v", err)
 		}
 		log.SetLevel(level)
-		if level == logrus.DebugLevel {
-			// Set to true to display query info
-			pop.Debug = true
-		}
-		if level != logrus.DebugLevel {
-			var noopLogger = func(lvl logging.Level, s string, args ...interface{}) {
+	}
+
+	switch {
+	case log.Level == logrus.DebugLevel:
+		pop.Debug = true
+	case migrateVerbose:
+		pop.SetLogger(func(lvl logging.Level, s string, args ...interface{}) {
+			if lvl == logging.SQL || lvl == logging.Debug {
+				return
 			}
-			// Hide pop migration logging
-			pop.SetLogger(noopLogger)
-		}
+			if len(args) > 0 {
+				s = fmt.Sprintf(s, args...)
+			}
+			fmt.Println(s)
+		})
+	case globalConfig.Logging.Level != "":
+		pop.SetLogger(func(logging.Level, string, ...interface{}) {})
 	}
 
 	q := u.Query()

--- a/cmd/migrate_cmd.go
+++ b/cmd/migrate_cmd.go
@@ -23,6 +23,21 @@ var migrateCmd = cobra.Command{
 	Run:  migrate,
 }
 
+// popProgressLogger prints pop's migration progress, one line per applied
+// migration, and hides SQL statement logging.
+func popProgressLogger(lvl logging.Level, s string, args ...interface{}) {
+	if lvl == logging.SQL || lvl == logging.Debug {
+		return
+	}
+	if len(args) > 0 {
+		s = fmt.Sprintf(s, args...)
+	}
+	fmt.Println(s)
+}
+
+// popNoopLogger hides pop migration logging.
+func popNoopLogger(logging.Level, string, ...interface{}) {}
+
 func migrate(cmd *cobra.Command, args []string) {
 	globalConfig := loadGlobalConfig(cmd.Context())
 	u, err := url.Parse(globalConfig.DB.URL)
@@ -45,21 +60,16 @@ func migrate(cmd *cobra.Command, args []string) {
 		log.SetLevel(level)
 	}
 
+	// Decide what pop prints while migrations run, from most to least
+	// output: debug shows everything, --verbose shows progress only, any
+	// other configured level hides migration logging entirely.
 	switch {
 	case log.Level == logrus.DebugLevel:
 		pop.Debug = true
 	case migrateVerbose:
-		pop.SetLogger(func(lvl logging.Level, s string, args ...interface{}) {
-			if lvl == logging.SQL || lvl == logging.Debug {
-				return
-			}
-			if len(args) > 0 {
-				s = fmt.Sprintf(s, args...)
-			}
-			fmt.Println(s)
-		})
+		pop.SetLogger(popProgressLogger)
 	case globalConfig.Logging.Level != "":
-		pop.SetLogger(func(logging.Level, string, ...interface{}) {})
+		pop.SetLogger(popNoopLogger)
 	}
 
 	q := u.Query()

--- a/cmd/root_cmd.go
+++ b/cmd/root_cmd.go
@@ -28,6 +28,7 @@ func RootCommand() *cobra.Command {
 	rootCmd.AddCommand(&serveCmd, &migrateCmd, &versionCmd, adminCmd())
 	rootCmd.PersistentFlags().StringVarP(&configFile, "config", "c", "", "base configuration file to load")
 	rootCmd.PersistentFlags().StringVarP(&watchDir, "config-dir", "d", "", "directory containing a sorted list of config files to watch for changes")
+	migrateCmd.Flags().BoolVarP(&migrateVerbose, "verbose", "v", false, "print the name of each migration as it is applied")
 	return &rootCmd
 }
 

--- a/hack/migrate.sh
+++ b/hack/migrate.sh
@@ -3,10 +3,9 @@
 DB_ENV=$1
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-DATABASE="$DIR/database.yml"
 
 export GOTRUE_DB_DRIVER="postgres"
 export GOTRUE_DB_DATABASE_URL="postgres://supabase_auth_admin:root@localhost:5432/$DB_ENV"
 export GOTRUE_DB_MIGRATIONS_PATH=$DIR/../migrations
 
-go run main.go migrate -c $DIR/test.env
+go run main.go migrate -c "$DIR/test.env" "${@:2}"


### PR DESCRIPTION
## What kind of change does this PR introduce?
Chore

## What is the current behavior?
When running `make migrate_test`, a successful migration produces no output.

This is because `migrate` installed a no-op logger at any non-debug level. This make command inherited the `test.env` file which defaults to `WARN` level. `DEBUG` was too noisy because it prints every SQL statement and two full migration status tables.

## What is the new behavior?
When running `make migrate_test`, the name of each applied migration is output:

```bash
> add_my_table
> add_my_other_table
Successfully applied 2 migrations.
```

If there are no migrations to run, when the `--verbose` flag is provided we now see:
```bash
Migrations already up to date, nothing to apply
0.0245 seconds
```

Added:
- A `--verbose` flag on the `migrate` command, which prints progress messages to stdout. It does not print SQL or JSON (that was tried, but human readability was an issue due to the JSON formatter mangling output).
- The `migrate_test` Make target passes in `--verbose`, and our helper script forwards it to the `migrate` command.

## Additional context
AUTH-1574
