### PR TITLE
chore: update go-chi/chi/v5@5.3.x

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -126,7 +126,7 @@ require (
 	github.com/fatih/structs v1.1.0
 	github.com/fsnotify/fsnotify v1.7.0
 	github.com/fxamacker/cbor/v2 v2.9.1
-	github.com/go-chi/chi/v5 v5.2.4
+	github.com/go-chi/chi/v5 v5.3.2
 	github.com/go-webauthn/webauthn v0.16.5
 	github.com/gobuffalo/pop/v6 v6.1.1
 	github.com/gobwas/glob v0.2.3

--- a/go.sum
+++ b/go.sum
@@ -126,8 +126,8 @@ github.com/fsnotify/fsnotify v1.7.0 h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nos
 github.com/fsnotify/fsnotify v1.7.0/go.mod h1:40Bi/Hjc2AVfZrqy+aj+yEI+/bRxZnMJyTJwOpGvigM=
 github.com/fxamacker/cbor/v2 v2.9.1 h1:2rWm8B193Ll4VdjsJY28jxs70IdDsHRWgQYAI80+rMQ=
 github.com/fxamacker/cbor/v2 v2.9.1/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj23V5ytsSxQ=
-github.com/go-chi/chi/v5 v5.2.4 h1:WtFKPHwlywe8Srng8j2BhOD9312j9cGUxG1SP4V2cR4=
-github.com/go-chi/chi/v5 v5.2.4/go.mod h1:X7Gx4mteadT3eDOMTsXzmI4/rwUpOwBHLpAfupzFJP0=
+github.com/go-chi/chi/v5 v5.3.2 h1:5YQkICvTCSZ25hoRsyJazN0scjzKGiu4VAUc7H1o1nY=
+github.com/go-chi/chi/v5 v5.3.2/go.mod h1:R+tYY2hNuVUUjxoPtqUdgBqevM9s9njzkTLutVsOCto=
 github.com/go-jose/go-jose/v4 v4.1.4 h1:moDMcTHmvE6Groj34emNPLs/qtYXRVcd6S7NHbHz3kA=
 github.com/go-jose/go-jose/v4 v4.1.4/go.mod h1:x4oUasVrzR7071A4TnHLGSPpNOm2a21K9Kf04k1rs08=
 github.com/go-kit/log v0.1.0/go.mod h1:zbhenjAZHb184qTLMA9ZjW7ThYL0H2mk7Q6pNt4vbaY=


### PR DESCRIPTION
## What kind of change does this PR introduce?

Chore. Update `github.com/go-chi/chi/v5` to latest.

## What is the current behavior?

```bash
Vulnerability #1: GO-2026-5777
    Chi's RealIP Middleware allows IP spoofing via unvalidated X-Forwarded-For
    header in github.com/go-chi/chi
  More info: https://pkg.go.dev/vuln/GO-2026-5777
  Module: github.com/go-chi/chi/v5
    Found in: github.com/go-chi/chi/v5@v5.2.4
    Fixed in: github.com/go-chi/chi/v5@v5.3.0

Vulnerability #2: GO-2026-5775
    Chi Middleware vulnerable to IP spoofing via X-Forwarded-For header in
    github.com/go-chi/chi
  More info: https://pkg.go.dev/vuln/GO-2026-5775
  Module: github.com/go-chi/chi/v5
    Found in: github.com/go-chi/chi/v5@v5.2.4
    Fixed in: github.com/go-chi/chi/v5@v5.3.0

Vulnerability #3: GO-2026-5774
    Chi has an IP spoofing vulnerability in middleware.RealIP in
    github.com/go-chi/chi
  More info: https://pkg.go.dev/vuln/GO-2026-5774
  Module: github.com/go-chi/chi/v5
    Found in: github.com/go-chi/chi/v5@v5.2.4
    Fixed in: github.com/go-chi/chi/v5@v5.3.0
```

## Additional context

- https://pkg.go.dev/vuln/GO-2026-5774
- https://pkg.go.dev/vuln/GO-2026-5775
- https://pkg.go.dev/vuln/GO-2026-5777
