### PR TITLE
feat: fix golangci-lint errors

### DIFF
--- a/internal/api/custom_oauth_admin.go
+++ b/internal/api/custom_oauth_admin.go
@@ -436,11 +436,12 @@ func validateProviderParams(params *AdminCustomOAuthProviderParams, providerType
 	}
 
 	// Type-specific validations
-	if providerType == models.ProviderTypeOIDC {
+	switch providerType {
+	case models.ProviderTypeOIDC:
 		if params.Issuer == "" {
 			return apierrors.NewBadRequestError(apierrors.ErrorCodeValidationFailed, "issuer is required for OIDC providers")
 		}
-	} else if providerType == models.ProviderTypeOAuth2 {
+	case models.ProviderTypeOAuth2:
 		if params.AuthorizationURL == "" {
 			return apierrors.NewBadRequestError(apierrors.ErrorCodeValidationFailed, "authorization_url is required for OAuth2 providers")
 		}
@@ -459,12 +460,13 @@ func validateProviderParams(params *AdminCustomOAuthProviderParams, providerType
 func validateProviderURLs(params *AdminCustomOAuthProviderParams, providerType models.ProviderType) error {
 	var urls []string
 
-	if providerType == models.ProviderTypeOIDC {
+	switch providerType {
+	case models.ProviderTypeOIDC:
 		urls = append(urls, params.Issuer)
 		if params.DiscoveryURL != nil && *params.DiscoveryURL != "" {
 			urls = append(urls, *params.DiscoveryURL)
 		}
-	} else if providerType == models.ProviderTypeOAuth2 {
+	case models.ProviderTypeOAuth2:
 		urls = []string{
 			params.AuthorizationURL,
 			params.TokenURL,

--- a/internal/api/e2e_test.go
+++ b/internal/api/e2e_test.go
@@ -44,7 +44,7 @@ func genPhone() string {
 	sb.WriteString("1")
 	for range 9 {
 		// #nosec G404
-		sb.WriteString(fmt.Sprintf("%d", rand.Intn(9)))
+		fmt.Fprintf(&sb, "%d", rand.Intn(9))
 	}
 	phone := sb.String()
 	return phone

--- a/internal/api/external.go
+++ b/internal/api/external.go
@@ -406,7 +406,7 @@ func (a *API) createAccountFromExternalIdentity(tx *storage.Connection, r *http.
 		return 0, nil, apierrors.NewForbiddenError(apierrors.ErrorCodeUserBanned, "User is banned")
 	}
 
-	hasEmails := providerType != Web3Provider && !(emailOptional && decision.CandidateEmail.Email == "")
+	hasEmails := providerType != Web3Provider && (!emailOptional || decision.CandidateEmail.Email != "")
 
 	if hasEmails && !user.IsConfirmed() {
 		// The user may have other unconfirmed email + password

--- a/internal/api/hooks.go
+++ b/internal/api/hooks.go
@@ -104,10 +104,7 @@ func (a *API) triggerBeforeUserCreatedExternal(
 		Data:     identityData,
 	}
 
-	isSSOUser := false
-	if strings.HasPrefix(decision.LinkingDomain, "sso:") {
-		isSSOUser = true
-	}
+	isSSOUser := strings.HasPrefix(decision.LinkingDomain, "sso:")
 
 	user, err := params.ToUserModel(isSSOUser)
 	if err != nil {

--- a/internal/api/mail.go
+++ b/internal/api/mail.go
@@ -255,9 +255,10 @@ func (a *API) adminGenerateLink(w http.ResponseWriter, r *http.Request) error {
 			user.EmailChangeSentAt = &now
 			user.EmailChange = params.NewEmail
 			user.EmailChangeConfirmStatus = zeroConfirmation
-			if params.Type == "email_change_current" {
+			switch params.Type {
+			case "email_change_current":
 				user.EmailChangeTokenCurrent = hashedToken
-			} else if params.Type == "email_change_new" {
+			case "email_change_new":
 				user.EmailChangeTokenNew = crypto.GenerateTokenHash(params.NewEmail, otp)
 			}
 			terr = tx.UpdateOnly(user, "email_change_token_current", "email_change_token_new", "email_change", "email_change_sent_at", "email_change_confirm_status")

--- a/internal/api/mfa_test.go
+++ b/internal/api/mfa_test.go
@@ -528,13 +528,14 @@ func (ts *MFATestSuite) TestMFAVerifyFactor() {
 			var f *models.Factor
 			var sharedSecret string
 
-			if v.factorType == models.TOTP {
+			switch v.factorType {
+			case models.TOTP:
 				friendlyName := uuid.Must(uuid.NewV4()).String()
 				f = models.NewTOTPFactor(ts.TestUser, friendlyName)
 				sharedSecret = ts.TestOTPKey.Secret()
 				f.Secret = sharedSecret
 				require.NoError(ts.T(), ts.API.db.Create(f), "Error updating new test factor")
-			} else if v.factorType == models.Phone {
+			case models.Phone:
 				friendlyName := uuid.Must(uuid.NewV4()).String()
 				numDigits := 10
 				otp := crypto.GenerateOtp(numDigits)
@@ -550,12 +551,13 @@ func (ts *MFATestSuite) TestMFAVerifyFactor() {
 
 			var c *models.Challenge
 			var code string
-			if v.factorType == models.TOTP {
+			switch v.factorType {
+			case models.TOTP:
 				c = f.CreateChallenge(utilities.GetIPAddress(req))
 				// Verify TOTP code
 				code, err = totp.GenerateCode(sharedSecret, time.Now().UTC())
 				require.NoError(ts.T(), err)
-			} else if v.factorType == models.Phone {
+			case models.Phone:
 				code = "123456"
 				c, err = f.CreatePhoneChallenge(utilities.GetIPAddress(req), code, ts.Config.Security.DBEncryption.Encrypt, ts.Config.Security.DBEncryption.EncryptionKeyID, ts.Config.Security.DBEncryption.EncryptionKey)
 				require.NoError(ts.T(), err)

--- a/internal/api/provider/custom_oauth_test.go
+++ b/internal/api/provider/custom_oauth_test.go
@@ -253,7 +253,8 @@ func TestNewCustomOIDCProvider(t *testing.T) {
 	// Mock OIDC provider server
 	var server *httptest.Server
 	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/.well-known/openid-configuration" {
+		switch r.URL.Path {
+		case "/.well-known/openid-configuration":
 			w.Header().Set("Content-Type", "application/json")
 			json.NewEncoder(w).Encode(map[string]interface{}{
 				"issuer":                 server.URL,
@@ -262,7 +263,7 @@ func TestNewCustomOIDCProvider(t *testing.T) {
 				"userinfo_endpoint":      server.URL + "/userinfo",
 				"jwks_uri":               server.URL + "/jwks",
 			})
-		} else if r.URL.Path == "/jwks" {
+		case "/jwks":
 			w.Header().Set("Content-Type", "application/json")
 			json.NewEncoder(w).Encode(map[string]interface{}{
 				"keys": []interface{}{},
@@ -385,7 +386,8 @@ func TestCustomOIDCProvider_AuthCodeURL(t *testing.T) {
 	// Mock OIDC provider server
 	var server *httptest.Server
 	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/.well-known/openid-configuration" {
+		switch r.URL.Path {
+		case "/.well-known/openid-configuration":
 			w.Header().Set("Content-Type", "application/json")
 			json.NewEncoder(w).Encode(map[string]interface{}{
 				"issuer":                 server.URL,
@@ -393,7 +395,7 @@ func TestCustomOIDCProvider_AuthCodeURL(t *testing.T) {
 				"token_endpoint":         server.URL + "/token",
 				"jwks_uri":               server.URL + "/jwks",
 			})
-		} else if r.URL.Path == "/jwks" {
+		case "/jwks":
 			w.Header().Set("Content-Type", "application/json")
 			json.NewEncoder(w).Encode(map[string]interface{}{
 				"keys": []interface{}{},
@@ -487,7 +489,8 @@ func TestCustomOIDCProvider_RequiresPKCE(t *testing.T) {
 	// Mock OIDC provider server
 	var server *httptest.Server
 	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/.well-known/openid-configuration" {
+		switch r.URL.Path {
+		case "/.well-known/openid-configuration":
 			w.Header().Set("Content-Type", "application/json")
 			json.NewEncoder(w).Encode(map[string]interface{}{
 				"issuer":                 server.URL,
@@ -495,7 +498,7 @@ func TestCustomOIDCProvider_RequiresPKCE(t *testing.T) {
 				"token_endpoint":         server.URL + "/token",
 				"jwks_uri":               server.URL + "/jwks",
 			})
-		} else if r.URL.Path == "/jwks" {
+		case "/jwks":
 			w.Header().Set("Content-Type", "application/json")
 			json.NewEncoder(w).Encode(map[string]interface{}{
 				"keys": []interface{}{},

--- a/internal/api/provider/facebook.go
+++ b/internal/api/provider/facebook.go
@@ -79,7 +79,7 @@ func (p facebookProvider) RequiresPKCE() bool {
 }
 
 func (p facebookProvider) GetUserData(ctx context.Context, tok *oauth2.Token) (*UserProvidedData, error) {
-	hash := hmac.New(sha256.New, []byte(p.Config.ClientSecret))
+	hash := hmac.New(sha256.New, []byte(p.ClientSecret))
 	hash.Write([]byte(tok.AccessToken))
 	appsecretProof := hex.EncodeToString(hash.Sum(nil))
 

--- a/internal/api/provider/google.go
+++ b/internal/api/provider/google.go
@@ -87,7 +87,7 @@ var internalUserInfoEndpointGoogle = UserInfoEndpointGoogle
 func (g googleProvider) GetUserData(ctx context.Context, tok *oauth2.Token) (*UserProvidedData, error) {
 	if idToken := tok.Extra("id_token"); idToken != nil {
 		_, data, err := ParseIDToken(ctx, g.oidc, &oidc.Config{
-			ClientID: g.Config.ClientID,
+			ClientID: g.ClientID,
 		}, idToken.(string), ParseIDTokenOptions{
 			AccessToken: tok.AccessToken,
 		})

--- a/internal/api/provider/twitch.go
+++ b/internal/api/provider/twitch.go
@@ -94,7 +94,7 @@ func (t twitchProvider) GetUserData(ctx context.Context, tok *oauth2.Token) (*Us
 	}
 
 	// set headers
-	req.Header.Set("Client-Id", t.Config.ClientID)
+	req.Header.Set("Client-Id", t.ClientID)
 	req.Header.Set("Authorization", "Bearer "+tok.AccessToken)
 
 	client := &http.Client{Timeout: defaultTimeout}

--- a/internal/api/resend_test.go
+++ b/internal/api/resend_test.go
@@ -266,10 +266,11 @@ func (ts *ResendTestSuite) TestResendSuccess() {
 				require.NoError(ts.T(), err)
 				require.NotEmpty(ts.T(), dbUser)
 
-				if c.params["type"] == mail.SignupVerification {
+				switch c.params["type"] {
+				case mail.SignupVerification:
 					require.NotEqual(ts.T(), dbUser.ConfirmationToken, c.user.ConfirmationToken)
 					require.NotEqual(ts.T(), dbUser.ConfirmationSentAt, c.user.ConfirmationSentAt)
-				} else if c.params["type"] == mail.EmailChangeVerification {
+				case mail.EmailChangeVerification:
 					require.NotEqual(ts.T(), dbUser.EmailChangeTokenNew, c.user.EmailChangeTokenNew)
 					require.NotEqual(ts.T(), dbUser.EmailChangeSentAt, c.user.EmailChangeSentAt)
 				}

--- a/internal/api/sms_provider/twilio_verify.go
+++ b/internal/api/sms_provider/twilio_verify.go
@@ -82,7 +82,7 @@ func (t *TwilioVerifyProvider) SendSms(phone, message, channel string) (string, 
 		return "", err
 	}
 	defer utilities.SafeClose(res.Body)
-	if !(res.StatusCode == http.StatusOK || res.StatusCode == http.StatusCreated) {
+	if res.StatusCode != http.StatusOK && res.StatusCode != http.StatusCreated {
 		resp := &twilioErrResponse{}
 		if err := json.NewDecoder(res.Body).Decode(resp); err != nil {
 			return "", err

--- a/internal/api/sso_test.go
+++ b/internal/api/sso_test.go
@@ -703,9 +703,10 @@ func (ts *SSOTestSuite) TestSingleSignOn() {
 
 		locationURLString := ""
 
-		if example.Code == http.StatusSeeOther {
+		switch example.Code {
+		case http.StatusSeeOther:
 			locationURLString = w.Header().Get("Location")
-		} else if example.Code == http.StatusOK {
+		case http.StatusOK:
 			var response struct {
 				URL string `json:"url"`
 			}
@@ -715,7 +716,7 @@ func (ts *SSOTestSuite) TestSingleSignOn() {
 			require.NotEmpty(ts.T(), response.URL)
 
 			locationURLString = response.URL
-		} else {
+		default:
 			continue
 		}
 

--- a/internal/api/verify.go
+++ b/internal/api/verify.go
@@ -406,7 +406,8 @@ func (a *API) smsVerify(r *http.Request, conn *storage.Connection, user *models.
 	phoneIdentityWasCreated := false
 	err := conn.Transaction(func(tx *storage.Connection) error {
 
-		if params.Type == smsVerification {
+		switch params.Type {
+		case smsVerification:
 			if terr := models.NewAuditLogEntry(config.AuditLog, r, tx, user, models.UserSignedUpAction, "", map[string]interface{}{
 				"provider": PhoneProvider,
 			}); terr != nil {
@@ -415,7 +416,7 @@ func (a *API) smsVerify(r *http.Request, conn *storage.Connection, user *models.
 			if terr := user.ConfirmPhone(tx); terr != nil {
 				return apierrors.NewInternalServerError("Error confirming user").WithInternalError(terr)
 			}
-		} else if params.Type == phoneChangeVerification {
+		case phoneChangeVerification:
 			if terr := models.NewAuditLogEntry(config.AuditLog, r, tx, user, models.UserModifiedAction, "", nil); terr != nil {
 				return terr
 			}

--- a/internal/api/verify_test.go
+++ b/internal/api/verify_test.go
@@ -751,9 +751,10 @@ func (ts *VerifyTestSuite) TestVerifyPKCEOTP() {
 			var buffer bytes.Buffer
 			// since the test user is the same, the tokens are being cleared after each successful verification attempt
 			// so we create them on each run
-			if c.payload.Type == "signup" {
+			switch c.payload.Type {
+			case "signup":
 				require.NoError(ts.T(), models.CreateOneTimeToken(ts.API.db, u.ID, u.GetEmail(), c.payload.Token, models.ConfirmationToken))
-			} else if c.payload.Type == "magiclink" {
+			case "magiclink":
 				require.NoError(ts.T(), models.CreateOneTimeToken(ts.API.db, u.ID, u.GetEmail(), c.payload.Token, models.RecoveryToken))
 			}
 
@@ -1034,10 +1035,10 @@ func (ts *VerifyTestSuite) TestVerifyValidOtp() {
 			u.EmailChangeSentAt = &c.sentTime
 			u.PhoneChangeSentAt = &c.sentTime
 
-			u.ConfirmationToken = c.expected.tokenHash
-			u.RecoveryToken = c.expected.tokenHash
-			u.EmailChangeTokenNew = c.expected.tokenHash
-			u.PhoneChangeToken = c.expected.tokenHash
+			u.ConfirmationToken = c.tokenHash
+			u.RecoveryToken = c.tokenHash
+			u.EmailChangeTokenNew = c.tokenHash
+			u.PhoneChangeToken = c.tokenHash
 
 			require.NoError(ts.T(), models.CreateOneTimeToken(ts.API.db, u.ID, "relates_to not used", u.ConfirmationToken, models.ConfirmationToken))
 			require.NoError(ts.T(), models.CreateOneTimeToken(ts.API.db, u.ID, "relates_to not used", u.RecoveryToken, models.RecoveryToken))
@@ -1056,7 +1057,7 @@ func (ts *VerifyTestSuite) TestVerifyValidOtp() {
 			// Setup response recorder
 			w := httptest.NewRecorder()
 			ts.API.handler.ServeHTTP(w, req)
-			assert.Equal(ts.T(), c.expected.code, w.Code)
+			assert.Equal(ts.T(), c.code, w.Code)
 		})
 	}
 }

--- a/internal/conf/configuration.go
+++ b/internal/conf/configuration.go
@@ -785,7 +785,7 @@ type SmsProviderConfiguration struct {
 }
 
 func (c *SmsProviderConfiguration) GetTestOTP(phone string, now time.Time) (string, bool) {
-	if c.TestOTP != nil && (c.TestOTPValidUntil.Time.IsZero() || now.Before(c.TestOTPValidUntil.Time)) {
+	if c.TestOTP != nil && (c.TestOTPValidUntil.IsZero() || now.Before(c.TestOTPValidUntil.Time)) {
 		testOTP, ok := c.TestOTP[phone]
 		return testOTP, ok
 	}

--- a/internal/conf/envparse/envparse.go
+++ b/internal/conf/envparse/envparse.go
@@ -76,7 +76,7 @@ const (
 )
 
 func parseBytes(src []byte, out map[string]string) error {
-	src = bytes.Replace(src, []byte("\r\n"), []byte("\n"), -1)
+	src = bytes.ReplaceAll(src, []byte("\r\n"), []byte("\n"))
 	cutset := src
 	for {
 		cutset = getStatementStart(cutset)

--- a/internal/models/audit_log_entry.go
+++ b/internal/models/audit_log_entry.go
@@ -192,7 +192,7 @@ func FindAuditLogEntries(tx *storage.Connection, filterColumns []string, filterV
 		values := make([]interface{}, len(filterColumns))
 
 		for idx, col := range filterColumns {
-			builder.WriteString(fmt.Sprintf("payload->>'%s' ILIKE ?", col))
+			fmt.Fprintf(builder, "payload->>'%s' ILIKE ?", col)
 			values[idx] = lf
 
 			if idx+1 < len(filterColumns) {

--- a/internal/models/custom_oauth_provider_test.go
+++ b/internal/models/custom_oauth_provider_test.go
@@ -539,7 +539,8 @@ func (ts *CustomOAuthProviderTestSuite) createTestProvider(providerType Provider
 		Enabled:      true,
 	}
 
-	if providerType == ProviderTypeOAuth2 {
+	switch providerType {
+	case ProviderTypeOAuth2:
 		authURL := "https://example.com/authorize"
 		// #nosec G101 - These are test URLs, not actual credentials
 		tokenURL := "https://example.com/token"
@@ -547,7 +548,7 @@ func (ts *CustomOAuthProviderTestSuite) createTestProvider(providerType Provider
 		provider.AuthorizationURL = &authURL
 		provider.TokenURL = &tokenURL
 		provider.UserinfoURL = &userinfoURL
-	} else if providerType == ProviderTypeOIDC {
+	case ProviderTypeOIDC:
 		// For OIDC, generate a unique issuer to avoid constraint violations
 		issuer := "https://oidc-" + identifier + ".example.com"
 		provider.Issuer = &issuer

--- a/internal/models/oauth_authorization_test.go
+++ b/internal/models/oauth_authorization_test.go
@@ -368,7 +368,7 @@ func TestFindOAuthServerAuthorizationByIDForUpdate_SkipLocked(t *testing.T) {
 	})
 	require.NoError(t, CreateOAuthServerAuthorization(db, auth))
 
-	holdTx, err := db.Connection.NewTransaction()
+	holdTx, err := db.NewTransaction()
 	require.NoError(t, err)
 	defer func() { _ = holdTx.TX.Rollback() }()
 	held := &storage.Connection{Connection: holdTx}

--- a/internal/storage/dial.go
+++ b/internal/storage/dial.go
@@ -412,7 +412,7 @@ func (c *Connection) WithContext(ctx context.Context) *Connection {
 func getExcludedColumns(model interface{}, includeColumns ...string) ([]string, error) {
 	sm := &pop.Model{Value: model}
 	st := reflect.TypeOf(model)
-	if st.Kind() == reflect.Ptr {
+	if st.Kind() == reflect.Pointer {
 		_ = st.Elem()
 	}
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Chore. Auto fix golangci-lint errors.

```bash
$ golangci-lint run --fix ./...
```

## What is the current behavior?

```bash
モ golangci-lint run
../../../../src/github.com/supabase/auth/internal/api/oauthserver/authorize_test.go:237:19: Error return value of `ts.DB.Close` is not checked (errcheck)
	defer ts.DB.Close()
	                 ^
../../../../src/github.com/supabase/auth/internal/api/oauthserver/handlers_test.go:56:19: Error return value of `ts.DB.Close` is not checked (errcheck)
	defer ts.DB.Close()
	                 ^
../../../../src/github.com/supabase/auth/internal/api/oauthserver/service_test.go:51:19: Error return value of `ts.DB.Close` is not checked (errcheck)
	defer ts.DB.Close()
	                 ^
../../../../src/github.com/supabase/auth/internal/api/provider/custom_oauth_test.go:94:28: Error return value of `(*encoding/json.Encoder).Encode` is not checked (errcheck)
		json.NewEncoder(w).Encode(map[string]interface{}{
		                         ^
../../../../src/github.com/supabase/auth/internal/api/provider/custom_oauth_test.go:137:28: Error return value of `(*encoding/json.Encoder).Encode` is not checked (errcheck)
		json.NewEncoder(w).Encode(map[string]interface{}{
		                         ^
../../../../src/github.com/supabase/auth/internal/api/provider/custom_oauth_test.go:258:29: Error return value of `(*encoding/json.Encoder).Encode` is not checked (errcheck)
			json.NewEncoder(w).Encode(map[string]interface{}{
			                         ^
../../../../src/github.com/supabase/auth/internal/conf/confload/confload_test.go:14:11: Error return value of `os.Setenv` is not checked (errcheck)
	os.Setenv("GOTRUE_SITE_URL", "http://localhost:8080")
	         ^
../../../../src/github.com/supabase/auth/internal/conf/confload/confload_test.go:15:11: Error return value of `os.Setenv` is not checked (errcheck)
	os.Setenv("GOTRUE_DB_DRIVER", "postgres")
	         ^
../../../../src/github.com/supabase/auth/internal/conf/confload/confload_test.go:16:11: Error return value of `os.Setenv` is not checked (errcheck)
	os.Setenv("GOTRUE_DB_DATABASE_URL", "fake")
	         ^
../../../../src/github.com/supabase/auth/internal/conf/confload/loader.go:253:15: Error return value of `f.Close` is not checked (errcheck)
	defer f.Close()
	             ^
../../../../src/github.com/supabase/auth/internal/e2e/e2eapi/e2eapi.go:72:16: Error return value of `o.Close` is not checked (errcheck)
		defer o.Close()
		             ^
../../../../src/github.com/supabase/auth/internal/e2e/e2eapi/e2eapi.go:191:26: Error return value of `httpRes.Body.Close` is not checked (errcheck)
	defer httpRes.Body.Close()
	                        ^
../../../../src/github.com/supabase/auth/internal/e2e/e2eapi/e2eapi_test.go:32:20: Error return value of `inst.Close` is not checked (errcheck)
			defer inst.Close()
			                ^
../../../../src/github.com/supabase/auth/internal/e2e/e2eapi/e2eapi_test.go:49:20: Error return value of `inst.Close` is not checked (errcheck)
			defer inst.Close()
			                ^
../../../../src/github.com/supabase/auth/internal/e2e/e2eapi/e2eapi_test.go:77:20: Error return value of `inst.Close` is not checked (errcheck)
			defer inst.Close()
			                ^
../../../../src/github.com/supabase/auth/internal/hooks/hookshttp/hookshttp.go:184:23: Error return value of `rsp.Body.Close` is not checked (errcheck)
		defer rsp.Body.Close()
		                    ^
../../../../src/github.com/supabase/auth/internal/hooks/hookshttp/hookshttp_test.go:185:19: Error return value of `io.WriteString` is not checked (errcheck)
				io.WriteString(w, "12345")
				              ^
../../../../src/github.com/supabase/auth/internal/hooks/hookshttp/hookshttp_test.go:196:19: Error return value of `io.WriteString` is not checked (errcheck)
				io.WriteString(w, `{"error": {"message": "failed to verify ip addres"}}`)
				              ^
../../../../src/github.com/supabase/auth/internal/hooks/hookshttp/hookshttp_test.go:207:19: Error return value of `io.WriteString` is not checked (errcheck)
				io.WriteString(w, `{"error": {"message": "failed to verify ip addres", "http_code": 400}}`)
				              ^
../../../../src/github.com/supabase/auth/internal/indexworker/indexworker_test.go:84:17: Error return value of `ts.popDB.Close` is not checked (errcheck)
		ts.popDB.Close()
		              ^
../../../../src/github.com/supabase/auth/internal/indexworker/indexworker_test.go:89:20: Error return value of `models.TruncateAll` is not checked (errcheck)
	models.TruncateAll(ts.db)
	                  ^
../../../../src/github.com/supabase/auth/internal/indexworker/indexworker_test.go:458:27: Error return value of `manipulatorDB.Close` is not checked (errcheck)
	defer manipulatorDB.Close()
	                         ^
../../../../src/github.com/supabase/auth/internal/mailer/templatemailer/template.go:486:22: Error return value of `res.Body.Close` is not checked (errcheck)
	defer res.Body.Close()
	                    ^
../../../../src/github.com/supabase/auth/internal/mailer/validateclient/validateclient.go:309:22: Error return value of `res.Body.Close` is not checked (errcheck)
	defer res.Body.Close()
	                    ^
../../../../src/github.com/supabase/auth/internal/mailer/validateclient/validateclient_test.go:34:16: Error return value of `fmt.Fprintln` is not checked (errcheck)
			fmt.Fprintln(w, `{"error": true}`)
			            ^
../../../../src/github.com/supabase/auth/internal/mailer/validateclient/validateclient_test.go:38:15: Error return value of `fmt.Fprintln` is not checked (errcheck)
		fmt.Fprintln(w, testResVal.Load().(string))
		            ^
../../../../src/github.com/supabase/auth/internal/models/custom_oauth_provider_test.go:24:13: Error return value is not checked (errcheck)
	TruncateAll(ts.db)
	           ^
../../../../src/github.com/supabase/auth/internal/models/custom_oauth_provider_test.go:38:19: Error return value of `ts.db.Close` is not checked (errcheck)
	defer ts.db.Close()
	                 ^
../../../../src/github.com/supabase/auth/internal/models/factor_test.go:31:19: Error return value of `ts.db.Close` is not checked (errcheck)
	defer ts.db.Close()
	                 ^
../../../../src/github.com/supabase/auth/internal/models/factor_test.go:62:13: Error return value is not checked (errcheck)
	TruncateAll(ts.db)
	           ^
../../../../src/github.com/supabase/auth/internal/models/factor_test.go:134:16: Error return value of `json.Unmarshal` is not checked (errcheck)
	json.Unmarshal(encodedFactor, &decodedFactor)
	              ^
../../../../src/github.com/supabase/auth/internal/models/identity_test.go:20:13: Error return value is not checked (errcheck)
	TruncateAll(ts.db)
	           ^
../../../../src/github.com/supabase/auth/internal/models/identity_test.go:33:19: Error return value of `ts.db.Close` is not checked (errcheck)
	defer ts.db.Close()
	                 ^
../../../../src/github.com/supabase/auth/internal/models/sso_test.go:297:25: Error return value of `(*github.com/gobuffalo/pop/v6.Connection).Destroy` is not checked (errcheck)
			ts.db.Eager().Destroy(pr)
			                     ^
../../../../src/github.com/supabase/auth/internal/models/sso_test.go:304:49: Error return value of `(*github.com/gobuffalo/pop/v6.Query).First` is not checked (errcheck)
		ts.db.Eager().Q().Where("id = ?", pr.ID).First(pr)
		                                              ^
../../../../src/github.com/supabase/auth/internal/reloader/poller.go:129:15: Error return value of `f.Close` is not checked (errcheck)
	defer f.Close()
	             ^
../../../../src/github.com/supabase/auth/internal/reloader/reloader.go:219:16: Error return value of `wr.Close` is not checked (errcheck)
	defer wr.Close()
	              ^
../../../../src/github.com/supabase/auth/internal/reloader/reloader_test.go:766:35: Error return value of `os.RemoveAll` is not checked (errcheck)
	return dir, func() { os.RemoveAll(dir) }
	                                 ^
../../../../src/github.com/supabase/auth/internal/storage/dial_test.go:120:17: Error return value of `db.Close` is not checked (errcheck)
		defer db.Close()
		              ^
../../../../src/github.com/supabase/auth/internal/storage/dial_test.go:149:17: Error return value of `db.Close` is not checked (errcheck)
		defer db.Close()
		              ^
../../../../src/github.com/supabase/auth/internal/storage/dial_test.go:231:17: Error return value of `db.Close` is not checked (errcheck)
		defer db.Close()
		              ^
../../../../src/github.com/supabase/auth/internal/tokens/service_test.go:51:18: Error return value of `conn.Close` is not checked (errcheck)
	defer conn.Close()
	                ^
../../../../src/github.com/supabase/auth/internal/tokens/service_test.go:57:20: Error return value of `models.TruncateAll` is not checked (errcheck)
	models.TruncateAll(ts.Conn)
	                  ^
../../../../src/github.com/supabase/auth/internal/tokens/service_test.go:917:18: Error return value of `conn.Close` is not checked (errcheck)
	defer conn.Close()
	                ^
../../../../src/github.com/supabase/auth/internal/tokens/service_test.go:923:20: Error return value of `models.TruncateAll` is not checked (errcheck)
	models.TruncateAll(ts.Conn)
	                  ^
../../../../src/github.com/supabase/auth/internal/tokens/service_test.go:1302:18: Error return value of `conn.Close` is not checked (errcheck)
	defer conn.Close()
	                ^
../../../../src/github.com/supabase/auth/internal/utilities/oidc_discovery.go:63:23: Error return value of `resp.Body.Close` is not checked (errcheck)
	defer resp.Body.Close()
	                     ^
../../../../src/github.com/supabase/auth/internal/utilities/oidc_discovery_test.go:90:10: Error return value of `w.Write` is not checked (errcheck)
		w.Write([]byte(`{"issuer":"x","filler":"`))
		       ^
../../../../src/github.com/supabase/auth/internal/utilities/oidc_discovery_test.go:91:10: Error return value of `w.Write` is not checked (errcheck)
		w.Write([]byte(strings.Repeat("A", MaxOIDCDiscoveryResponseSize+1024)))
		       ^
../../../../src/github.com/supabase/auth/internal/utilities/oidc_discovery_test.go:92:10: Error return value of `w.Write` is not checked (errcheck)
		w.Write([]byte(`"}`))
		       ^
../../../../src/github.com/supabase/auth/internal/storage/dial.go:415:18: inline: Constant reflect.Ptr should be inlined (govet)
	if st.Kind() == reflect.Ptr {
	                ^
../../../../src/github.com/supabase/auth/internal/api/e2e_test.go:1243:5: ineffectual assignment to currentUser (ineffassign)
				currentUser := signupUser
				^
../../../../src/github.com/supabase/auth/internal/api/e2e_test.go:1468:5: ineffectual assignment to currentUser (ineffassign)
				currentUser := signupUser
				^
../../../../src/github.com/supabase/auth/internal/api/custom_oauth_admin.go:439:2: QF1003: could use tagged switch on providerType (staticcheck)
	if providerType == models.ProviderTypeOIDC {
	^
../../../../src/github.com/supabase/auth/internal/api/custom_oauth_admin.go:462:2: QF1003: could use tagged switch on providerType (staticcheck)
	if providerType == models.ProviderTypeOIDC {
	^
../../../../src/github.com/supabase/auth/internal/api/e2e_test.go:47:3: QF1012: Use fmt.Fprintf(...) instead of WriteString(fmt.Sprintf(...)) (staticcheck)
		sb.WriteString(fmt.Sprintf("%d", rand.Intn(9)))
		^
../../../../src/github.com/supabase/auth/internal/api/external.go:409:47: QF1001: could apply De Morgan's law (staticcheck)
	hasEmails := providerType != Web3Provider && !(emailOptional && decision.CandidateEmail.Email == "")
	                                             ^
../../../../src/github.com/supabase/auth/internal/api/hooks.go:107:2: QF1007: could merge conditional assignment into variable declaration (staticcheck)
	isSSOUser := false
	^
../../../../src/github.com/supabase/auth/internal/api/mail.go:258:4: QF1003: could use tagged switch on params.Type (staticcheck)
			if params.Type == "email_change_current" {
			^
../../../../src/github.com/supabase/auth/internal/api/mfa_test.go:531:4: QF1003: could use tagged switch on v.factorType (staticcheck)
			if v.factorType == models.TOTP {
			^
../../../../src/github.com/supabase/auth/internal/api/mfa_test.go:553:4: QF1003: could use tagged switch on v.factorType (staticcheck)
			if v.factorType == models.TOTP {
			^
../../../../src/github.com/supabase/auth/internal/api/provider/custom_oauth_test.go:256:3: QF1003: could use tagged switch on r.URL.Path (staticcheck)
		if r.URL.Path == "/.well-known/openid-configuration" {
		^
../../../../src/github.com/supabase/auth/internal/api/provider/custom_oauth_test.go:388:3: QF1003: could use tagged switch on r.URL.Path (staticcheck)
		if r.URL.Path == "/.well-known/openid-configuration" {
		^
../../../../src/github.com/supabase/auth/internal/api/provider/custom_oauth_test.go:490:3: QF1003: could use tagged switch on r.URL.Path (staticcheck)
		if r.URL.Path == "/.well-known/openid-configuration" {
		^
../../../../src/github.com/supabase/auth/internal/api/provider/facebook.go:82:40: QF1008: could remove embedded field "Config" from selector (staticcheck)
	hash := hmac.New(sha256.New, []byte(p.Config.ClientSecret))
	                                      ^
../../../../src/github.com/supabase/auth/internal/api/provider/google.go:90:16: QF1008: could remove embedded field "Config" from selector (staticcheck)
			ClientID: g.Config.ClientID,
			            ^
../../../../src/github.com/supabase/auth/internal/api/provider/twitch.go:97:32: QF1008: could remove embedded field "Config" from selector (staticcheck)
	req.Header.Set("Client-Id", t.Config.ClientID)
	                              ^
../../../../src/github.com/supabase/auth/internal/api/resend_test.go:269:5: QF1003: could use tagged switch on c.params["type"] (staticcheck)
				if c.params["type"] == mail.SignupVerification {
				^
../../../../src/github.com/supabase/auth/internal/api/sms_provider/twilio_verify.go:85:5: QF1001: could apply De Morgan's law (staticcheck)
	if !(res.StatusCode == http.StatusOK || res.StatusCode == http.StatusCreated) {
	   ^
../../../../src/github.com/supabase/auth/internal/api/sso_test.go:706:3: QF1003: could use tagged switch on example.Code (staticcheck)
		if example.Code == http.StatusSeeOther {
		^
../../../../src/github.com/supabase/auth/internal/api/verify.go:409:3: QF1003: could use tagged switch on params.Type (staticcheck)
		if params.Type == smsVerification {
		^
../../../../src/github.com/supabase/auth/internal/api/verify_test.go:754:4: QF1003: could use tagged switch on c.payload.Type (staticcheck)
			if c.payload.Type == "signup" {
			^
../../../../src/github.com/supabase/auth/internal/api/verify_test.go:1037:28: QF1008: could remove embedded field "expected" from selector (staticcheck)
			u.ConfirmationToken = c.expected.tokenHash
			                        ^
../../../../src/github.com/supabase/auth/internal/api/verify_test.go:1038:24: QF1008: could remove embedded field "expected" from selector (staticcheck)
			u.RecoveryToken = c.expected.tokenHash
			                    ^
../../../../src/github.com/supabase/auth/internal/api/verify_test.go:1039:30: QF1008: could remove embedded field "expected" from selector (staticcheck)
			u.EmailChangeTokenNew = c.expected.tokenHash
			                          ^
../../../../src/github.com/supabase/auth/internal/conf/configuration.go:788:46: QF1008: could remove embedded field "Time" from selector (staticcheck)
	if c.TestOTP != nil && (c.TestOTPValidUntil.Time.IsZero() || now.Before(c.TestOTPValidUntil.Time)) {
	                                            ^
../../../../src/github.com/supabase/auth/internal/conf/envparse/envparse.go:79:8: QF1004: could use bytes.ReplaceAll instead (staticcheck)
	src = bytes.Replace(src, []byte("\r\n"), []byte("\n"), -1)
	      ^
../../../../src/github.com/supabase/auth/internal/models/audit_log_entry.go:195:4: QF1012: Use fmt.Fprintf(...) instead of WriteString(fmt.Sprintf(...)) (staticcheck)
			builder.WriteString(fmt.Sprintf("payload->>'%s' ILIKE ?", col))
			^
../../../../src/github.com/supabase/auth/internal/models/custom_oauth_provider_test.go:542:2: QF1003: could use tagged switch on providerType (staticcheck)
	if providerType == ProviderTypeOAuth2 {
	^
../../../../src/github.com/supabase/auth/internal/models/oauth_authorization_test.go:371:20: QF1008: could remove embedded field "Connection" from selector (staticcheck)
	holdTx, err := db.Connection.NewTransaction()
	                  ^
80 issues:
* errcheck: 50
* govet: 1
* ineffassign: 2
* staticcheck: 27
```

## What is the new behavior?

```bash
モ golangci-lint run
../../../../src/github.com/supabase/auth/internal/api/oauthserver/authorize_test.go:237:19: Error return value of `ts.DB.Close` is not checked (errcheck)
	defer ts.DB.Close()
	                 ^
../../../../src/github.com/supabase/auth/internal/api/oauthserver/handlers_test.go:56:19: Error return value of `ts.DB.Close` is not checked (errcheck)
	defer ts.DB.Close()
	                 ^
../../../../src/github.com/supabase/auth/internal/api/oauthserver/service_test.go:51:19: Error return value of `ts.DB.Close` is not checked (errcheck)
	defer ts.DB.Close()
	                 ^
../../../../src/github.com/supabase/auth/internal/api/provider/custom_oauth_test.go:94:28: Error return value of `(*encoding/json.Encoder).Encode` is not checked (errcheck)
		json.NewEncoder(w).Encode(map[string]interface{}{
		                         ^
../../../../src/github.com/supabase/auth/internal/api/provider/custom_oauth_test.go:137:28: Error return value of `(*encoding/json.Encoder).Encode` is not checked (errcheck)
		json.NewEncoder(w).Encode(map[string]interface{}{
		                         ^
../../../../src/github.com/supabase/auth/internal/api/provider/custom_oauth_test.go:259:29: Error return value of `(*encoding/json.Encoder).Encode` is not checked (errcheck)
			json.NewEncoder(w).Encode(map[string]interface{}{
			                         ^
../../../../src/github.com/supabase/auth/internal/conf/confload/confload_test.go:14:11: Error return value of `os.Setenv` is not checked (errcheck)
	os.Setenv("GOTRUE_SITE_URL", "http://localhost:8080")
	         ^
../../../../src/github.com/supabase/auth/internal/conf/confload/confload_test.go:15:11: Error return value of `os.Setenv` is not checked (errcheck)
	os.Setenv("GOTRUE_DB_DRIVER", "postgres")
	         ^
../../../../src/github.com/supabase/auth/internal/conf/confload/confload_test.go:16:11: Error return value of `os.Setenv` is not checked (errcheck)
	os.Setenv("GOTRUE_DB_DATABASE_URL", "fake")
	         ^
../../../../src/github.com/supabase/auth/internal/conf/confload/loader.go:253:15: Error return value of `f.Close` is not checked (errcheck)
	defer f.Close()
	             ^
../../../../src/github.com/supabase/auth/internal/e2e/e2eapi/e2eapi.go:72:16: Error return value of `o.Close` is not checked (errcheck)
		defer o.Close()
		             ^
../../../../src/github.com/supabase/auth/internal/e2e/e2eapi/e2eapi.go:191:26: Error return value of `httpRes.Body.Close` is not checked (errcheck)
	defer httpRes.Body.Close()
	                        ^
../../../../src/github.com/supabase/auth/internal/e2e/e2eapi/e2eapi_test.go:32:20: Error return value of `inst.Close` is not checked (errcheck)
			defer inst.Close()
			                ^
../../../../src/github.com/supabase/auth/internal/e2e/e2eapi/e2eapi_test.go:49:20: Error return value of `inst.Close` is not checked (errcheck)
			defer inst.Close()
			                ^
../../../../src/github.com/supabase/auth/internal/e2e/e2eapi/e2eapi_test.go:77:20: Error return value of `inst.Close` is not checked (errcheck)
			defer inst.Close()
			                ^
../../../../src/github.com/supabase/auth/internal/hooks/hookshttp/hookshttp.go:184:23: Error return value of `rsp.Body.Close` is not checked (errcheck)
		defer rsp.Body.Close()
		                    ^
../../../../src/github.com/supabase/auth/internal/hooks/hookshttp/hookshttp_test.go:185:19: Error return value of `io.WriteString` is not checked (errcheck)
				io.WriteString(w, "12345")
				              ^
../../../../src/github.com/supabase/auth/internal/hooks/hookshttp/hookshttp_test.go:196:19: Error return value of `io.WriteString` is not checked (errcheck)
				io.WriteString(w, `{"error": {"message": "failed to verify ip addres"}}`)
				              ^
../../../../src/github.com/supabase/auth/internal/hooks/hookshttp/hookshttp_test.go:207:19: Error return value of `io.WriteString` is not checked (errcheck)
				io.WriteString(w, `{"error": {"message": "failed to verify ip addres", "http_code": 400}}`)
				              ^
../../../../src/github.com/supabase/auth/internal/indexworker/indexworker_test.go:84:17: Error return value of `ts.popDB.Close` is not checked (errcheck)
		ts.popDB.Close()
		              ^
../../../../src/github.com/supabase/auth/internal/indexworker/indexworker_test.go:89:20: Error return value of `models.TruncateAll` is not checked (errcheck)
	models.TruncateAll(ts.db)
	                  ^
../../../../src/github.com/supabase/auth/internal/indexworker/indexworker_test.go:458:27: Error return value of `manipulatorDB.Close` is not checked (errcheck)
	defer manipulatorDB.Close()
	                         ^
../../../../src/github.com/supabase/auth/internal/mailer/templatemailer/template.go:486:22: Error return value of `res.Body.Close` is not checked (errcheck)
	defer res.Body.Close()
	                    ^
../../../../src/github.com/supabase/auth/internal/mailer/validateclient/validateclient.go:309:22: Error return value of `res.Body.Close` is not checked (errcheck)
	defer res.Body.Close()
	                    ^
../../../../src/github.com/supabase/auth/internal/mailer/validateclient/validateclient_test.go:34:16: Error return value of `fmt.Fprintln` is not checked (errcheck)
			fmt.Fprintln(w, `{"error": true}`)
			            ^
../../../../src/github.com/supabase/auth/internal/mailer/validateclient/validateclient_test.go:38:15: Error return value of `fmt.Fprintln` is not checked (errcheck)
		fmt.Fprintln(w, testResVal.Load().(string))
		            ^
../../../../src/github.com/supabase/auth/internal/models/custom_oauth_provider_test.go:24:13: Error return value is not checked (errcheck)
	TruncateAll(ts.db)
	           ^
../../../../src/github.com/supabase/auth/internal/models/custom_oauth_provider_test.go:38:19: Error return value of `ts.db.Close` is not checked (errcheck)
	defer ts.db.Close()
	                 ^
../../../../src/github.com/supabase/auth/internal/models/factor_test.go:31:19: Error return value of `ts.db.Close` is not checked (errcheck)
	defer ts.db.Close()
	                 ^
../../../../src/github.com/supabase/auth/internal/models/factor_test.go:62:13: Error return value is not checked (errcheck)
	TruncateAll(ts.db)
	           ^
../../../../src/github.com/supabase/auth/internal/models/factor_test.go:134:16: Error return value of `json.Unmarshal` is not checked (errcheck)
	json.Unmarshal(encodedFactor, &decodedFactor)
	              ^
../../../../src/github.com/supabase/auth/internal/models/identity_test.go:20:13: Error return value is not checked (errcheck)
	TruncateAll(ts.db)
	           ^
../../../../src/github.com/supabase/auth/internal/models/identity_test.go:33:19: Error return value of `ts.db.Close` is not checked (errcheck)
	defer ts.db.Close()
	                 ^
../../../../src/github.com/supabase/auth/internal/models/sso_test.go:297:25: Error return value of `(*github.com/gobuffalo/pop/v6.Connection).Destroy` is not checked (errcheck)
			ts.db.Eager().Destroy(pr)
			                     ^
../../../../src/github.com/supabase/auth/internal/models/sso_test.go:304:49: Error return value of `(*github.com/gobuffalo/pop/v6.Query).First` is not checked (errcheck)
		ts.db.Eager().Q().Where("id = ?", pr.ID).First(pr)
		                                              ^
../../../../src/github.com/supabase/auth/internal/reloader/poller.go:129:15: Error return value of `f.Close` is not checked (errcheck)
	defer f.Close()
	             ^
../../../../src/github.com/supabase/auth/internal/reloader/reloader.go:219:16: Error return value of `wr.Close` is not checked (errcheck)
	defer wr.Close()
	              ^
../../../../src/github.com/supabase/auth/internal/reloader/reloader_test.go:766:35: Error return value of `os.RemoveAll` is not checked (errcheck)
	return dir, func() { os.RemoveAll(dir) }
	                                 ^
../../../../src/github.com/supabase/auth/internal/storage/dial_test.go:120:17: Error return value of `db.Close` is not checked (errcheck)
		defer db.Close()
		              ^
../../../../src/github.com/supabase/auth/internal/storage/dial_test.go:149:17: Error return value of `db.Close` is not checked (errcheck)
		defer db.Close()
		              ^
../../../../src/github.com/supabase/auth/internal/storage/dial_test.go:231:17: Error return value of `db.Close` is not checked (errcheck)
		defer db.Close()
		              ^
../../../../src/github.com/supabase/auth/internal/tokens/service_test.go:51:18: Error return value of `conn.Close` is not checked (errcheck)
	defer conn.Close()
	                ^
../../../../src/github.com/supabase/auth/internal/tokens/service_test.go:57:20: Error return value of `models.TruncateAll` is not checked (errcheck)
	models.TruncateAll(ts.Conn)
	                  ^
../../../../src/github.com/supabase/auth/internal/tokens/service_test.go:917:18: Error return value of `conn.Close` is not checked (errcheck)
	defer conn.Close()
	                ^
../../../../src/github.com/supabase/auth/internal/tokens/service_test.go:923:20: Error return value of `models.TruncateAll` is not checked (errcheck)
	models.TruncateAll(ts.Conn)
	                  ^
../../../../src/github.com/supabase/auth/internal/tokens/service_test.go:1302:18: Error return value of `conn.Close` is not checked (errcheck)
	defer conn.Close()
	                ^
../../../../src/github.com/supabase/auth/internal/utilities/oidc_discovery.go:63:23: Error return value of `resp.Body.Close` is not checked (errcheck)
	defer resp.Body.Close()
	                     ^
../../../../src/github.com/supabase/auth/internal/utilities/oidc_discovery_test.go:90:10: Error return value of `w.Write` is not checked (errcheck)
		w.Write([]byte(`{"issuer":"x","filler":"`))
		       ^
../../../../src/github.com/supabase/auth/internal/utilities/oidc_discovery_test.go:91:10: Error return value of `w.Write` is not checked (errcheck)
		w.Write([]byte(strings.Repeat("A", MaxOIDCDiscoveryResponseSize+1024)))
		       ^
../../../../src/github.com/supabase/auth/internal/utilities/oidc_discovery_test.go:92:10: Error return value of `w.Write` is not checked (errcheck)
		w.Write([]byte(`"}`))
		       ^
../../../../src/github.com/supabase/auth/internal/api/e2e_test.go:1243:5: ineffectual assignment to currentUser (ineffassign)
				currentUser := signupUser
				^
../../../../src/github.com/supabase/auth/internal/api/e2e_test.go:1468:5: ineffectual assignment to currentUser (ineffassign)
				currentUser := signupUser
				^
52 issues:
* errcheck: 50
* ineffassign: 2
```

## Additional context

- https://golangci-lint.run/docs/welcome/quick-start/
