### PR TITLE
chore(otp): unify the FindUserBy*Token lookups

### DIFF
--- a/internal/api/admin_test.go
+++ b/internal/api/admin_test.go
@@ -652,7 +652,7 @@ func (ts *AdminTestSuite) TestAdminUserUpdateClearsPendingTokensOnEmailChange() 
 	require.NoError(ts.T(), models.CreateOneTimeToken(ts.API.db, u.ID, u.GetEmail(), recoveryHash, models.RecoveryToken))
 
 	// sanity check: the token is redeemable before the email change
-	_, err = models.FindUserByRecoveryToken(ts.API.db, recoveryHash)
+	_, err = models.FindUserByOneTimeToken(ts.API.db, recoveryHash, models.RecoveryToken)
 	require.NoError(ts.T(), err, "recovery token should be redeemable before the email change")
 
 	var buffer bytes.Buffer
@@ -672,7 +672,7 @@ func (ts *AdminTestSuite) TestAdminUserUpdateClearsPendingTokensOnEmailChange() 
 	require.Empty(ts.T(), updated.RecoveryToken, "recovery token should be cleared after an admin email change")
 
 	// and the one-time token row must no longer resolve to a user
-	_, err = models.FindUserByRecoveryToken(ts.API.db, recoveryHash)
+	_, err = models.FindUserByOneTimeToken(ts.API.db, recoveryHash, models.RecoveryToken)
 	require.Error(ts.T(), err, "recovery token should no longer be redeemable after an admin email change")
 	require.True(ts.T(), models.IsNotFoundError(err), "expected NotFoundError")
 }

--- a/internal/api/e2e_test.go
+++ b/internal/api/e2e_test.go
@@ -215,8 +215,8 @@ func signupAndConfirmEmail(
 	require.Equal(t, expUser.Email.String(), ott.RelatesTo)
 
 	// OTP token user matches our signup user
-	hookUser, err := models.FindUserByConfirmationToken(
-		inst.Conn, hookReq.EmailData.TokenHash)
+	hookUser, err := models.FindUserByOneTimeToken(
+		inst.Conn, hookReq.EmailData.TokenHash, models.ConfirmationToken)
 	require.NoError(t, err)
 	require.Equal(t, expUser.ID, hookUser.ID)
 	require.Equal(t, expUser.Email, hookUser.Email)

--- a/internal/api/external.go
+++ b/internal/api/external.go
@@ -52,7 +52,7 @@ func (a *API) GetExternalProviderRedirectURL(w http.ResponseWriter, r *http.Requ
 
 	inviteToken := query.Get("invite_token")
 	if inviteToken != "" {
-		_, userErr := models.FindUserByConfirmationToken(db, inviteToken)
+		_, userErr := models.FindUserByOneTimeToken(db, inviteToken, models.ConfirmationToken)
 		if userErr != nil {
 			if models.IsNotFoundError(userErr) {
 				return "", apierrors.NewNotFoundError(apierrors.ErrorCodeUserNotFound, "User identified by token not found")
@@ -466,7 +466,7 @@ func (a *API) createAccountFromExternalIdentity(tx *storage.Connection, r *http.
 func (a *API) processInvite(r *http.Request, tx *storage.Connection, userData *provider.UserProvidedData, inviteToken, providerType string) (*models.User, error) {
 	config := a.config
 
-	user, err := models.FindUserByConfirmationToken(tx, inviteToken)
+	user, err := models.FindUserByOneTimeToken(tx, inviteToken, models.ConfirmationToken)
 	if err != nil {
 		if models.IsNotFoundError(err) {
 			return nil, apierrors.NewNotFoundError(apierrors.ErrorCodeInviteNotFound, "Invite not found")

--- a/internal/api/verify.go
+++ b/internal/api/verify.go
@@ -648,13 +648,13 @@ func (a *API) verifyTokenHash(conn *storage.Connection, params *VerifyParams) (*
 	switch params.Type {
 	case mail.EmailOTPVerification:
 		// need to find user by confirmation token or recovery token with the token hash
-		user, err = models.FindUserByConfirmationOrRecoveryToken(conn, params.TokenHash)
+		user, err = models.FindUserByOneTimeToken(conn, params.TokenHash, models.ConfirmationToken, models.RecoveryToken)
 	case mail.SignupVerification, mail.InviteVerification:
-		user, err = models.FindUserByConfirmationToken(conn, params.TokenHash)
+		user, err = models.FindUserByOneTimeToken(conn, params.TokenHash, models.ConfirmationToken)
 	case mail.RecoveryVerification, mail.MagicLinkVerification:
-		user, err = models.FindUserByRecoveryToken(conn, params.TokenHash)
+		user, err = models.FindUserByOneTimeToken(conn, params.TokenHash, models.RecoveryToken)
 	case mail.EmailChangeVerification:
-		user, err = models.FindUserByEmailChangeToken(conn, params.TokenHash)
+		user, err = models.FindUserByOneTimeToken(conn, params.TokenHash, models.EmailChangeTokenCurrent, models.EmailChangeTokenNew)
 	default:
 		return nil, apierrors.NewBadRequestError(apierrors.ErrorCodeValidationFailed, "Invalid email verification type")
 	}

--- a/internal/models/one_time_token.go
+++ b/internal/models/one_time_token.go
@@ -179,39 +179,10 @@ func FindOneTimeToken(tx *storage.Connection, tokenHash string, tokenTypes ...On
 	return oneTimeToken, nil
 }
 
-// FindUserByConfirmationToken finds users with the matching confirmation token.
-func FindUserByConfirmationOrRecoveryToken(tx *storage.Connection, token string) (*User, error) {
-	ott, err := FindOneTimeToken(tx, token, ConfirmationToken, RecoveryToken)
-	if err != nil {
-		return nil, err
-	}
-
-	return FindUserByID(tx, ott.UserID)
-}
-
-// FindUserByConfirmationToken finds users with the matching confirmation token.
-func FindUserByConfirmationToken(tx *storage.Connection, token string) (*User, error) {
-	ott, err := FindOneTimeToken(tx, token, ConfirmationToken)
-	if err != nil {
-		return nil, err
-	}
-
-	return FindUserByID(tx, ott.UserID)
-}
-
-// FindUserByRecoveryToken finds a user with the matching recovery token.
-func FindUserByRecoveryToken(tx *storage.Connection, token string) (*User, error) {
-	ott, err := FindOneTimeToken(tx, token, RecoveryToken)
-	if err != nil {
-		return nil, err
-	}
-
-	return FindUserByID(tx, ott.UserID)
-}
-
-// FindUserByEmailChangeToken finds a user with the matching email change token.
-func FindUserByEmailChangeToken(tx *storage.Connection, token string) (*User, error) {
-	ott, err := FindOneTimeToken(tx, token, EmailChangeTokenCurrent, EmailChangeTokenNew)
+// FindUserByOneTimeToken finds the user holding the one-time token matching
+// tokenHash for any of the given token types.
+func FindUserByOneTimeToken(tx *storage.Connection, tokenHash string, tokenTypes ...OneTimeTokenType) (*User, error) {
+	ott, err := FindOneTimeToken(tx, tokenHash, tokenTypes...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/models/user_test.go
+++ b/internal/models/user_test.go
@@ -92,9 +92,14 @@ func (ts *UserTestSuite) TestFindUserByConfirmationToken() {
 	tokenHash := "test_confirmation_token"
 	require.NoError(ts.T(), CreateOneTimeToken(ts.db, u.ID, "relates_to not used", tokenHash, ConfirmationToken))
 
-	n, err := FindUserByConfirmationToken(ts.db, tokenHash)
+	n, err := FindUserByOneTimeToken(ts.db, tokenHash, ConfirmationToken)
 	require.NoError(ts.T(), err)
 	require.Equal(ts.T(), u.ID, n.ID)
+
+	// the token type filters the lookup
+	_, err = FindUserByOneTimeToken(ts.db, tokenHash, RecoveryToken)
+	require.Error(ts.T(), err)
+	require.True(ts.T(), IsNotFoundError(err))
 }
 
 func (ts *UserTestSuite) TestFindUserByEmailAndAudience() {
@@ -272,7 +277,7 @@ func (ts *UserTestSuite) TestFindUserByRecoveryToken() {
 	tokenHash := "test_recovery_token"
 	require.NoError(ts.T(), CreateOneTimeToken(ts.db, u.ID, "relates_to not used", tokenHash, RecoveryToken))
 
-	n, err := FindUserByRecoveryToken(ts.db, tokenHash)
+	n, err := FindUserByOneTimeToken(ts.db, tokenHash, RecoveryToken)
 	require.NoError(ts.T(), err)
 	require.Equal(ts.T(), u.ID, n.ID)
 }
@@ -702,7 +707,7 @@ func (ts *UserTestSuite) TestUpdateUserEmailClearsStaleTokens() {
 	require.Nil(ts.T(), userA.ReauthenticationSentAt)
 
 	// the one-time token must no longer be redeemable
-	_, err = FindUserByConfirmationToken(ts.db, "confirmation-token-hash")
+	_, err = FindUserByOneTimeToken(ts.db, "confirmation-token-hash", ConfirmationToken)
 	require.Error(ts.T(), err)
 }
 

--- a/internal/models/user_test.go
+++ b/internal/models/user_test.go
@@ -282,6 +282,20 @@ func (ts *UserTestSuite) TestFindUserByRecoveryToken() {
 	require.Equal(ts.T(), u.ID, n.ID)
 }
 
+func (ts *UserTestSuite) TestFindUserByOneTimeTokenMultipleTypes() {
+	u := ts.createUser()
+	tokenHash := "test_confirmation_or_recovery_token"
+	require.NoError(ts.T(), CreateOneTimeToken(ts.db, u.ID, "relates_to not used", tokenHash, RecoveryToken))
+
+	n, err := FindUserByOneTimeToken(ts.db, tokenHash, ConfirmationToken, RecoveryToken)
+	require.NoError(ts.T(), err)
+	require.Equal(ts.T(), u.ID, n.ID)
+
+	_, err = FindUserByOneTimeToken(ts.db, tokenHash, EmailChangeTokenCurrent, EmailChangeTokenNew)
+	require.Error(ts.T(), err)
+	require.True(ts.T(), IsNotFoundError(err))
+}
+
 func (ts *UserTestSuite) TestFindUserWithRefreshToken() {
 	u := ts.createUser()
 	r, err := GrantAuthenticatedUser(ts.db, u, GrantParams{})


### PR DESCRIPTION
Cleaning house  🧹 

## What kind of change does this PR introduce?
Chore

## What is the current behavior?
We had four functions with the same find-token-then-load-user logic:
- `FindUserByConfirmationOrRecoveryToken`
- `FindUserByConfirmationToken`
- `FindUserByRecoveryToken`
- `FindUserByEmailChangeToken`

## What is the new behavior?
Generalized the logic + collapsed them into `FindUserByOneTimeToken`, which takes the token types as arguments. No behavior change.

## Additional context
Contributes to AUTH-1553 but does not close
