### PR TITLE
fix(api): guard against nil session pointer dereference in user update and recovery codes

### DIFF
--- a/internal/api/recovery_codes.go
+++ b/internal/api/recovery_codes.go
@@ -116,7 +116,7 @@ func (a *API) RecoveryCodesGenerate(w http.ResponseWriter, r *http.Request) erro
 		}
 	}
 
-	if !session.IsAAL2() {
+	if session == nil || !session.IsAAL2() {
 		return apierrors.NewForbiddenError(apierrors.ErrorCodeInsufficientAAL, "AAL2 required to generate recovery codes")
 	}
 
@@ -201,7 +201,7 @@ func (a *API) RecoveryCodesRegenerate(w http.ResponseWriter, r *http.Request) er
 		return apierrors.NewUnprocessableEntityError(apierrors.ErrorCodeMFARecoveryCodesEnrollDisabled, "MFA enroll is disabled for recovery codes")
 	}
 
-	if !session.IsAAL2() {
+	if session == nil || !session.IsAAL2() {
 		return apierrors.NewForbiddenError(apierrors.ErrorCodeInsufficientAAL, "AAL2 required to regenerate recovery codes")
 	}
 

--- a/internal/api/user.go
+++ b/internal/api/user.go
@@ -103,7 +103,7 @@ func (a *API) UserUpdate(w http.ResponseWriter, r *http.Request) error {
 		}
 	}
 
-	if user.HasMFAEnabled() && !session.IsAAL2() {
+	if user.HasMFAEnabled() && (session == nil || !session.IsAAL2()) {
 		if (params.Password != nil && *params.Password != "") || (params.Email != "" && user.GetEmail() != params.Email) || (params.Phone != "" && user.GetPhone() != params.Phone) {
 			return apierrors.NewHTTPError(http.StatusUnauthorized, apierrors.ErrorCodeInsufficientAAL, "AAL2 session is required to update email or password when MFA is enabled.")
 		}
@@ -172,7 +172,7 @@ func (a *API) UserUpdate(w http.ResponseWriter, r *http.Request) error {
 				// current password required when updating password
 				if config.Security.UpdatePasswordRequireCurrentPassword {
 					// ensure user is not in a password recovery flow
-					if !session.IsRecovery() {
+					if session == nil || !session.IsRecovery() {
 						if params.CurrentPassword == nil || *params.CurrentPassword == "" {
 							return apierrors.NewBadRequestError(apierrors.ErrorCodeCurrentPasswordRequired, "Current password required when setting new password.")
 						}


### PR DESCRIPTION
## Problem

When handling tokens where `session` is nil (e.g. customized access tokens with blank or nil session IDs where `maybeLoadUserOrSession` does not load a session), requests to `PUT /user` and recovery codes endpoints crash with a nil pointer dereference panic, resulting in an unhandled HTTP 500 error.

## Root Cause

In `internal/api/user.go`:
- Line 106: `user.HasMFAEnabled() && !session.IsAAL2()` dereferences `session` when MFA is enabled and `session` is nil.
- Line 175: `!session.IsRecovery()` dereferences `session` when updating passwords without checking if `session` is nil.

In `internal/api/recovery_codes.go`:
- Lines 119 and 204: calls `!session.IsAAL2()` without ensuring `session` is non-nil.

## Fix

Add nil guards that fail closed consistently with the rest of the API:
- `user.HasMFAEnabled() && (session == nil || !session.IsAAL2())`
- `if session == nil || !session.IsRecovery()`
- `if session == nil || !session.IsAAL2()` in recovery codes generate and regenerate handlers.

## Verification

- `go vet ./internal/api` ran cleanly.
- `go test -c ./internal/api` compiled successfully.

Fixes #2665