### PR TITLE
fix(provider): don't pin expected issuer for the Azure consumers endpoint

### DIFF
--- a/internal/api/provider/azure.go
+++ b/internal/api/provider/azure.go
@@ -16,6 +16,11 @@ import (
 const IssuerAzureCommon = "https://login.microsoftonline.com/common/v2.0"
 const IssuerAzureOrganizations = "https://login.microsoftonline.com/organizations/v2.0"
 
+// IssuerAzureConsumers is the alias endpoint for personal Microsoft accounts.
+// Like common/organizations, Microsoft never issues ID tokens from it directly:
+// personal-account tokens carry IssuerAzureMicrosoft (the 9188040d-... tenant).
+const IssuerAzureConsumers = "https://login.microsoftonline.com/consumers/v2.0"
+
 // IssuerAzureMicrosoft is the OIDC issuer for microsoft.com accounts:
 // https://learn.microsoft.com/en-us/azure/active-directory/develop/id-token-claims-reference#payload-claims
 const IssuerAzureMicrosoft = "https://login.microsoftonline.com/9188040d-6c67-4c5b-b112-36a304b66dad/v2.0"
@@ -69,11 +74,11 @@ func NewAzureProvider(ext conf.OAuthProviderConfiguration, scopes string, cache 
 	if ext.URL != "" {
 		expectedIssuer = authHost + "/v2.0"
 
-		if (!IsAzureIssuer(expectedIssuer) && !IsAzureCIAMIssuer(expectedIssuer)) || expectedIssuer == IssuerAzureCommon || expectedIssuer == IssuerAzureOrganizations {
+		if (!IsAzureIssuer(expectedIssuer) && !IsAzureCIAMIssuer(expectedIssuer)) || expectedIssuer == IssuerAzureCommon || expectedIssuer == IssuerAzureOrganizations || expectedIssuer == IssuerAzureConsumers {
 			// in tests, the URL is a local server which should not
 			// be the expected issuer
-			// also, IssuerAzure (common) never actually issues any
-			// ID tokens so it needs to be ignored
+			// also, IssuerAzure (common/organizations/consumers) never
+			// actually issues any ID tokens so it needs to be ignored
 			expectedIssuer = ""
 		}
 	}

--- a/internal/api/provider/azure_test.go
+++ b/internal/api/provider/azure_test.go
@@ -74,6 +74,11 @@ func TestNewAzureProviderExpectedIssuer(t *testing.T) {
 			expectedIssuer: "",
 		},
 		{
+			name:           "consumers endpoint is not pinned",
+			url:            "https://login.microsoftonline.com/consumers",
+			expectedIssuer: "",
+		},
+		{
 			name:           "non-Azure URL is not pinned",
 			url:            "http://localhost:3000",
 			expectedIssuer: "",


### PR DESCRIPTION
Fixes #2795.

Setting the Azure provider URL to the documented `https://login.microsoftonline.com/consumers` (the only correct value for personal Microsoft accounts) made `NewAzureProvider` pin `ExpectedIssuer` to the `/consumers/v2.0` alias - but Microsoft never issues ID tokens from the alias: personal-account tokens carry `iss = https://login.microsoftonline.com/9188040d-6c67-4c5b-b112-36a304b66dad/v2.0` (the well-known consumers tenant GUID). The issuer check then rejected every personal-account login with "Error getting user profile from external provider".

`common` and `organizations` were already exempted from pinning for exactly this reason; `consumers` was the missed third alias. This PR adds it to the same condition.

Security note: unpinning the alias is safe. A consumers-only app registration only receives tokens minted for that app's client ID, and `ParseIDToken` still validates the signature and audience through OIDC discovery - the issuer pin was only ever belt-and-braces for the alias case, and it was the wrong value anyway.

Credit: @iohinted-prog did the legwork in #2795 - manifest-level `signInAudience` confirmation and ruling out `/common` before the issuer comparison fell out. #1549 and #1274 look like the same symptom family; maintainers may want to link them.

Verification: new table case is red against pre-patch code (`ExpectedIssuer` pinned to consumers/v2.0), green with the fix; the 7 existing cases unaffected; full provider package suite green; go vet clean (go 1.27.0).

> Built by breken, your AI support engineer - breken.ai - this one's on us.