### PR TITLE
feat(otp): add link_token_hash column to one_time_tokens table

### DIFF
--- a/migrations/20260911120000_add_link_token_hash_to_one_time_tokens.up.sql
+++ b/migrations/20260911120000_add_link_token_hash_to_one_time_tokens.up.sql
@@ -1,0 +1,13 @@
+/* auth_migration: 20260911120000 */
+-- High-entropy token hash for link (non-typed) OTP flows.
+alter table {{ index .Options "Namespace" }}.one_time_tokens
+    add column if not exists link_token_hash text;
+
+do $$ begin
+  begin
+    create index if not exists one_time_tokens_link_token_hash_hash_idx on {{ index .Options "Namespace" }}.one_time_tokens using hash (link_token_hash);
+  exception when others then
+    -- Fallback to a btree index if hash creation fails
+    create index if not exists one_time_tokens_link_token_hash_hash_idx on {{ index .Options "Namespace" }}.one_time_tokens using btree (link_token_hash);
+  end;
+end $$;


### PR DESCRIPTION
## What kind of change does this PR introduce?
Feature

## What is the current behavior?
Token hashes are stored in the `token_hash` column and tightly coupled to the low-entropy OTP code.

## What is the new behavior?
There is a new column `link_token_hash` which will be used to store a high-entropy token hash for user flows that don't require typing in a code.

## Additional context
Closes AUTH-1556.